### PR TITLE
fix: keyphrase reload

### DIFF
--- a/circles-app/src/lib/stores/wallet.ts
+++ b/circles-app/src/lib/stores/wallet.ts
@@ -30,7 +30,7 @@ export async function initializeWallet(type: string, address?: `0x${string}`) {
   if (type === 'metamask') {
     const runner = new BrowserProviderContractRunner();
     await runner.init();
-    localStorage.setItem('wallet', JSON.stringify(runner.address!));
+    localStorage.setItem('wallet', runner.address || '');
     return runner;
   } else if (type === 'safe' && address) {
     localStorage.setItem('wallet', address);
@@ -109,12 +109,12 @@ export async function restoreWallet() {
 }
 
 export async function clearSession() {
-  localStorage.clear();
+  // localStorage.clear();
   avatar.set(undefined);
   wallet.set(undefined);
   circles.set(undefined);
-  localStorage.removeItem('wallet');
-  localStorage.removeItem('avatar');
+  // localStorage.removeItem('wallet');
+  // localStorage.removeItem('avatar');
   await goto('/connect-wallet');
   console.log('User session cleared');
 }


### PR DESCRIPTION
- don't clear localstorage on `clearSession`