### PR TITLE
fix: pin endpoint to rpc.aboutcircles.com/profiles, drop /api/ prefix

### DIFF
--- a/circles-app/src/lib/shared/config/circles.ts
+++ b/circles-app/src/lib/shared/config/circles.ts
@@ -16,7 +16,7 @@ export const chiadoConfig: { production: AppConfig, rings: AppConfig } = {
   production: {
     ipfsGatewayBase: 'https://da08cae2-8b50-45dc-80b9-48925be78ec8.myfilebase.com',
     marketApiBase: 'https://market-api.aboutcircles.com/market/',
-    profilePinningServiceUrl: 'https://staging.circlesubi.network/profiles',
+    profilePinningServiceUrl: 'https://rpc.aboutcircles.com/profiles',
     marketOperator: '0x20ced4ed3b1651b832a77e13e54ea5cb14c8b95b',
     marketChainId: 100,
     marketChainIdHex: "0x64",
@@ -33,7 +33,7 @@ export const chiadoConfig: { production: AppConfig, rings: AppConfig } = {
   rings: {
     ipfsGatewayBase: 'https://da08cae2-8b50-45dc-80b9-48925be78ec8.myfilebase.com',
     marketApiBase: 'https://market-api.aboutcircles.com/market/',
-    profilePinningServiceUrl: 'https://staging.circlesubi.network/profiles',
+    profilePinningServiceUrl: 'https://rpc.aboutcircles.com/profiles',
     marketOperator: '0x20ced4ed3b1651b832a77e13e54ea5cb14c8b95b',
     marketChainId: 100,
     marketChainIdHex: "0x64",
@@ -52,7 +52,7 @@ export const gnosisConfig: { production: AppConfig, rings: AppConfig } = {
   production: {
     ipfsGatewayBase: 'https://da08cae2-8b50-45dc-80b9-48925be78ec8.myfilebase.com',
     marketApiBase: 'https://market-api.aboutcircles.com/market/',
-    profilePinningServiceUrl: 'https://staging.circlesubi.network/profiles',
+    profilePinningServiceUrl: 'https://rpc.aboutcircles.com/profiles',
     marketOperator: '0x20ced4ed3b1651b832a77e13e54ea5cb14c8b95b',
     marketChainId: 100,
     marketChainIdHex: "0x64",
@@ -71,7 +71,7 @@ export const gnosisConfig: { production: AppConfig, rings: AppConfig } = {
   rings: {
     ipfsGatewayBase: 'https://da08cae2-8b50-45dc-80b9-48925be78ec8.myfilebase.com',
     marketApiBase: 'https://market-api.aboutcircles.com/market/',
-    profilePinningServiceUrl: 'https://staging.circlesubi.network/profiles',
+    profilePinningServiceUrl: 'https://rpc.aboutcircles.com/profiles',
     marketOperator: '0x20ced4ed3b1651b832a77e13e54ea5cb14c8b95b',
     marketChainId: 100,
     marketChainIdHex: "0x64",

--- a/packages/circles-profile-core/src/bindings/circlesSdk.ts
+++ b/packages/circles-profile-core/src/bindings/circlesSdk.ts
@@ -35,12 +35,7 @@ export function createCirclesSdkProfilesBindings(opts: {
   const base = (opts.pinApiBase ?? '').replace(/\/$/, '');
   function endpointCandidates(path: 'pin' | 'pin-media'): string[] {
     if (!base) return [];
-    // Legacy services expose /api/* while the dedicated profile pinning service
-    // exposes routes at root (behind /profiles reverse-proxy prefix).
-    if (/\/api$/i.test(base)) {
-      return [`${base}/${path}`];
-    }
-    return [`${base}/api/${path}`, `${base}/${path}`];
+    return [`${base}/${path}`];
   }
 
   const pinUrls = endpointCandidates('pin');


### PR DESCRIPTION
## Summary
- All 4 `profilePinningServiceUrl` configs changed from `staging.circlesubi.network/profiles` to `rpc.aboutcircles.com/profiles`
- Removed `/api/` prefix fallback in `endpointCandidates()` — pin requests now go directly to `/profiles/pin` and `/profiles/pin-media`

Fixes offer publishing 404 on `staging.circlesubi.network/profiles/api/pin`.

## Test plan
- [ ] Verify `POST rpc.aboutcircles.com/profiles/pin` returns `{ cid: "Qm..." }` 
- [ ] Create test offer with image on staging — confirm pin succeeds
- [ ] Save profile on staging — confirm no 404 in console