### PR TITLE
fix: remove conflicting protocol-kit v6 dependency

### DIFF
--- a/circles-app/package-lock.json
+++ b/circles-app/package-lock.json
@@ -3540,25 +3540,6 @@
         "win32"
       ]
     },
-    "node_modules/@safe-global/protocol-kit": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@safe-global/protocol-kit/-/protocol-kit-6.1.2.tgz",
-      "integrity": "sha512-cTpPdUAS2AMfGCkD1T601rQNjT0rtMQLA2TH7L/C+iFPAC6WrrDFop2B9lzeHjczlnVzrRpfFe4cL1bLrJ9NZw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@safe-global/safe-deployments": "^1.37.49",
-        "@safe-global/safe-modules-deployments": "^2.2.21",
-        "@safe-global/types-kit": "^3.0.0",
-        "abitype": "^1.0.2",
-        "semver": "^7.7.2",
-        "viem": "^2.21.8"
-      },
-      "optionalDependencies": {
-        "@noble/curves": "^1.6.0",
-        "@peculiar/asn1-schema": "^2.3.13"
-      }
-    },
     "node_modules/@safe-global/safe-apps-provider": {
       "version": "0.18.6",
       "resolved": "https://registry.npmjs.org/@safe-global/safe-apps-provider/-/safe-apps-provider-0.18.6.tgz",

--- a/circles-app/package.json
+++ b/circles-app/package.json
@@ -17,8 +17,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",
-    "@safe-global/protocol-kit": "^6.1.2",
-    "@sveltejs/adapter-auto": "^7.0.0",
+"@sveltejs/adapter-auto": "^7.0.0",
     "@sveltejs/adapter-netlify": "^5.2.4",
     "@sveltejs/adapter-node": "^5.5.2",
     "@sveltejs/adapter-static": "^3.0.10",


### PR DESCRIPTION
## Summary
- Remove `@safe-global/protocol-kit: ^6.1.2` direct devDependency that conflicts with `@circles-sdk/adapter-safe`'s `^4.1.0` requirement
- Clean phantom v6 entry from lock file

## Problem
`adapter-safe` was built for protocol-kit v4. Having v6 as a direct dep caused npm to hoist v6, which Vite bundled for the browser. Safe transaction simulation failed with `Error("Unknown")` before the signing modal could open — breaking `personalMint` and likely all Safe transactions on the DO deployment.

## Test plan
- [ ] Deploy to DO, verify `personalMint` opens signing modal
- [ ] Verify Safe transactions work end-to-end