### PR TITLE
fix: remove empty DB env placeholders from netlify.toml

### DIFF
--- a/circles-app/netlify.toml
+++ b/circles-app/netlify.toml
@@ -26,12 +26,8 @@
     PUBLIC_ENVIRONMENT = "production"
     PUBLIC_CIRCLES_RPC_URL = "https://rpc.aboutcircles.com"
     PUBLIC_PLAUSIBLE_DOMAIN = "app.aboutcircles.com"
-    DB_PW = ""
-    DB_USER = ""
-    DB_DATABASE = ""
-    DB_HOST = ""
-    DB_PORT = ""
-    DB_SSL_MODE = ""
+    # DB_* and THE_GRAPH_API_KEY set in Netlify dashboard only
+    # (empty toml values override dashboard — do not add placeholders here)
 
 # Deploy Preview settings (for PRs)
 [context.deploy-preview]
@@ -45,12 +41,6 @@
     PUBLIC_CIRCLES_RPC_URL = "https://rpc.circlesubi.network"
     # Disable analytics for preview
     PUBLIC_PLAUSIBLE_DOMAIN = ""
-    DB_PW = ""
-    DB_USER = ""
-    DB_DATABASE = ""
-    DB_HOST = ""
-    DB_PORT = ""
-    DB_SSL_MODE = ""
 
 # Branch deploy settings
 [context.branch-deploy]
@@ -63,12 +53,6 @@
     PUBLIC_ENVIRONMENT = "staging"
     PUBLIC_CIRCLES_RPC_URL = "https://rpc.circlesubi.network"
     PUBLIC_PLAUSIBLE_DOMAIN = ""
-    DB_PW = ""
-    DB_USER = ""
-    DB_DATABASE = ""
-    DB_HOST = ""
-    DB_PORT = ""
-    DB_SSL_MODE = ""
 
 # Headers for security
 [[headers]]

--- a/circles-app/netlify.toml
+++ b/circles-app/netlify.toml
@@ -73,3 +73,4 @@
   for = "/assets/*"
   [headers.values]
     Cache-Control = "public, max-age=31536000, immutable"
+

--- a/circles-app/src/routes/api/price/+server.ts
+++ b/circles-app/src/routes/api/price/+server.ts
@@ -5,7 +5,27 @@ import {
   DB_DATABASE
 } from '$env/static/private';
 import { CirclesConverter } from '@circles-sdk/utils';
-const { Client } = pkg;
+const { Pool } = pkg;
+
+// Module-level pool — reused across warm invocations in serverless (Netlify Functions)
+let pool: InstanceType<typeof Pool> | null = null;
+
+function getPool() {
+  if (!pool) {
+    pool = new Pool({
+      user: DB_USER,
+      password: DB_PW,
+      host: DB_HOST,
+      port: Number(DB_PORT),
+      database: DB_DATABASE,
+      ssl: { rejectUnauthorized: false },
+      max: 3,
+      idleTimeoutMillis: 30_000,
+      connectionTimeoutMillis: 5_000
+    });
+  }
+  return pool;
+}
 
 export const GET: RequestHandler = async ({ url }) => {
   const groupToken = url.searchParams.get('group')?.toLowerCase();
@@ -43,19 +63,8 @@ export const GET: RequestHandler = async ({ url }) => {
   ORDER BY bucket
 `;
 
-  const client = new Client({
-    user: DB_USER,
-    password: DB_PW,
-    host: DB_HOST,
-    port: Number(DB_PORT),
-    database: DB_DATABASE,
-    ssl: { rejectUnauthorized: false },
-    connectionTimeoutMillis: 5_000
-  });
-
   try {
-    await client.connect();
-    const { rows } = await client.query<{ bucket: Date; price: string }>(
+    const { rows } = await getPool().query<{ bucket: Date; price: string }>(
       sql,
       [groupToken, xdai]
     );
@@ -75,7 +84,5 @@ export const GET: RequestHandler = async ({ url }) => {
       status: 500,
       headers: { 'Content-Type': 'application/json' }
     });
-  } finally {
-    client.end();
   }
 };


### PR DESCRIPTION
## Summary
- Remove empty `DB_*` placeholder vars from `netlify.toml` context environments — they override Netlify dashboard values, causing `/api/price` to fail with 500
- Switch `pg.Client` to `pg.Pool` in the price endpoint for serverless compatibility (Netlify Functions reuse execution contexts)

## Context
The `[context.production.environment]` section had `DB_PW = ""`, `DB_USER = ""`, etc. Netlify's context-specific toml values override site-level dashboard values, so even though DB credentials were set in the dashboard, the empty toml values took precedence.

## Test plan
- [ ] After merge to main: verify `/api/price` returns JSON (not 500)
- [ ] Verify `/api/prices/wrapped-static` still works (unchanged)
- [ ] Verify dashboard env vars are set for production context