### PR TITLE
fix(market): unstick settings tabs, unify popup state, rename marketplace tab to offers

### DIFF
--- a/circles-app/src/lib/shared/state/popup/popUp.svelte.ts
+++ b/circles-app/src/lib/shared/state/popup/popUp.svelte.ts
@@ -1,107 +1,11 @@
-import type { Component } from 'svelte';
-
-export type PopupContentDefinition<T extends Record<string, any> = any> = {
-  title?: string;
-  /**
-   * If true, the popup shell will not render the title text
-   * (useful when the inner component already has its own header).
-   */
-  hideTitle?: boolean;
-  component: Component<T>;
-  props?: Record<string, any>;
-  key?: string | number;
-  id?: string | number;
-  onClose?: () => void;
-  kind?: 'flow' | 'confirm' | 'inspect' | 'edit';
-  dismiss?: 'backdrop' | 'explicit' | 'confirmIfDirty';
-  isDirty?: boolean;
-  /**
-   * Groups popup entries that belong to the same flow instance.
-   * Used for flow-scoped dirty-state handling across stack navigation.
-   */
-  flowId?: string;
-  confirmDiscardMessage?: string;
-};
-
-export const popupState = $state({
-  content: null as PopupContentDefinition | null,
-  stack: [] as PopupContentDefinition[],
-});
-
-/**
- * Convenience wrapper: opens a popup pre-configured as a flow popup
- * (kind='flow', dismiss='explicit').
- */
-export function openFlowPopup(def: PopupContentDefinition): void {
-  popupControls.open({
-    kind: 'flow',
-    dismiss: 'explicit',
-    props: {},
-    ...def,
-  });
-}
-
-export const popupControls = {
-  open(content: PopupContentDefinition) {
-    if (popupState.content) {
-      popupState.stack.push(popupState.content);
-    }
-    popupState.content = content;
-  },
-
-  close() {
-    try {
-      popupState.content?.onClose?.();
-    } catch (e) {
-      console.error('Popup onClose handler threw', e);
-    }
-    // Fire onClose for all stacked entries (e.g. flow popup underneath a success popup)
-    for (const entry of popupState.stack) {
-      try {
-        entry.onClose?.();
-      } catch (e) {
-        console.error('Stacked popup onClose handler threw', e);
-      }
-    }
-    popupState.content = null;
-    popupState.stack = [];
-  },
-
-  back() {
-    if (popupState.stack.length === 0) return;
-    popupState.content = popupState.stack.pop() ?? null;
-  },
-
-  /**
-   * Replace the current popup content without modifying the stack.
-   */
-  replace(content: PopupContentDefinition) {
-    popupState.content = content;
-  },
-
-  /**
-   * Walk the stack backwards looking for an entry that matches `predicate`.
-   * If found, pop back to it (discarding entries above) and return true.
-   * If not found, return false and leave the stack unchanged.
-   */
-  popTo(predicate: (entry: PopupContentDefinition) => boolean): boolean {
-    // Build the full ordered list: [...stack, content]
-    const entries: PopupContentDefinition[] = popupState.content
-      ? [...popupState.stack, popupState.content]
-      : [...popupState.stack];
-
-    let foundIndex = -1;
-    for (let i = entries.length - 1; i >= 0; i--) {
-      if (predicate(entries[i])) {
-        foundIndex = i;
-        break;
-      }
-    }
-
-    if (foundIndex === -1) return false;
-
-    popupState.content = entries[foundIndex];
-    popupState.stack = entries.slice(0, foundIndex);
-    return true;
-  },
-};
+// Single source of truth for popup state lives in `./index.ts` (a Svelte
+// writable store), which is what `PopupHost.svelte` (the only mounted popup
+// host) reads via `$popupState`. Some legacy callsites still import directly
+// from this path, so we re-export to keep both import paths writing to the
+// same state.
+export {
+  popupControls,
+  popupState,
+  openFlowPopup,
+  type PopupContentDefinition,
+} from './index';

--- a/circles-app/src/lib/shared/ui/flow/PopUp.svelte
+++ b/circles-app/src/lib/shared/ui/flow/PopUp.svelte
@@ -5,12 +5,9 @@
   import PopUpPage from './PopUpPage.svelte';
   import { ArrowLeft as LArrowLeft, X as LX, type IconNode } from 'lucide';
 
-  // Use $effect to manage ESC listener - always add/remove, check condition in handler
-  // Note: Early return in $effect breaks cleanup pattern in Svelte 5
-  // Uses capture phase to intercept before child components can stopPropagation
   $effect(() => {
     function handleKeydown(e: KeyboardEvent) {
-      if (e.key === 'Escape' && popupState.content) {
+      if (e.key === 'Escape' && $popupState.content) {
         e.preventDefault();
         e.stopPropagation();
         popupControls.close();
@@ -25,16 +22,15 @@
   }
 
   function onClose() {
-    if (popupState.stack.length > 0) popupControls.back();
+    if ($popupState.stack.length > 0) popupControls.back();
     else popupControls.close();
   }
 
-  let icon: IconNode = $derived(popupState.stack.length > 0 ? LArrowLeft : LX);
+  let icon: IconNode = $derived($popupState.stack.length > 0 ? LArrowLeft : LX);
 
-  // Keep *all* pages mounted: stack + current
   let pages = $derived([
-    ...(popupState.stack ?? []),
-    ...(popupState.content ? [popupState.content] : []),
+    ...($popupState.stack ?? []),
+    ...($popupState.content ? [$popupState.content] : []),
   ]);
 
   let top = $derived(Math.max(0, pages.length - 1));
@@ -54,7 +50,7 @@
 </script>
 
 <!-- Backdrop overlay - click to close -->
-{#if popupState.content}
+{#if $popupState.content}
   <button
     class="popup-backdrop"
     onclick={handleBackdropClick}
@@ -65,7 +61,7 @@
 
 <div
   class="popup rounded-t-lg overflow-y-auto"
-  class:open={popupState.content !== null}
+  class:open={$popupState.content !== null}
   role="dialog"
   aria-modal="true"
   aria-labelledby="popup-title"
@@ -76,8 +72,8 @@
       <button
         class="btn btn-ghost btn-circle btn-sm"
         onclick={onClose}
-        aria-label={popupState.stack.length > 0 ? 'Back' : 'Close'}
-        title={popupState.stack.length > 0 ? 'Back' : 'Close'}
+        aria-label={$popupState.stack.length > 0 ? 'Back' : 'Close'}
+        title={$popupState.stack.length > 0 ? 'Back' : 'Close'}
       >
         <Lucide
           icon={icon}
@@ -87,9 +83,9 @@
         />
       </button>
 
-      {#if popupState.content?.title}
+      {#if $popupState.content?.title}
         <h2 id="popup-title" class="text-xl font-bold">
-          {popupState.content.title}
+          {$popupState.content.title}
         </h2>
       {/if}
     </div>

--- a/circles-app/src/lib/shared/ui/primitives/tabs/Tabs.svelte
+++ b/circles-app/src/lib/shared/ui/primitives/tabs/Tabs.svelte
@@ -61,16 +61,17 @@
 
     if (!hasExternal) return;
 
-    // Parent acknowledged our last request.
-    if (pendingExternalAck !== null && external === pendingExternalAck) {
+    if (pendingExternalAck !== null) {
+      // Parent acknowledged our last request — clear ack and follow.
+      if (external === pendingExternalAck) {
+        pendingExternalAck = null;
+        if (differs) active = external;
+        return;
+      }
+      // Parent moved to a value other than our pending ack (URL change,
+      // popstate, programmatic select). Treat as authoritative override
+      // so we never get stuck waiting for an ack that won't arrive.
       pendingExternalAck = null;
-      if (differs) active = external;
-      return;
-    }
-
-    // While waiting for parent to reflect the requested value, don't snap back.
-    if (pendingExternalAck !== null && active === pendingExternalAck) {
-      return;
     }
 
     if (differs) {

--- a/circles-app/src/routes/DefaultHeader.svelte
+++ b/circles-app/src/routes/DefaultHeader.svelte
@@ -185,7 +185,7 @@
           <li><a class="link link-hover" href="/settings?tab=bookmarks">Bookmarks</a></li>
           <li><a class="link link-hover" href="/settings?tab=orders">Orders</a></li>
           <li><a class="link link-hover" href="/settings?tab=sales">Sales</a></li>
-          <li><a class="link link-hover" href="/settings?tab=marketplace">Offers</a></li>
+          <li><a class="link link-hover" href="/settings?tab=offers">Offers</a></li>
           <li><a class="link link-hover" href="/settings?tab=payment">Payment gateways</a></li>
           <li><a class="link link-hover" href="/settings?tab=namespaces">Namespaces</a></li>
           <li><a class="link link-hover" href="/settings?tab=keys">Signing keys</a></li>

--- a/circles-app/src/routes/market/+page.svelte
+++ b/circles-app/src/routes/market/+page.svelte
@@ -285,7 +285,7 @@
     });
 
     const actions: Action[] = [
-      { id: 'my-offers', label: 'Offers', variant: 'primary', onClick: () => goto('/settings?tab=marketplace') },
+      { id: 'my-offers', label: 'Offers', variant: 'primary', onClick: () => goto('/settings?tab=offers') },
       { id: 'my-orders', label: 'Orders', variant: 'ghost', onClick: () => goto('/settings?tab=orders') },
       { id: 'my-sales', label: 'Sales', variant: 'ghost', onClick: () => goto('/settings?tab=sales') },
     ];

--- a/circles-app/src/routes/settings/+layout.svelte
+++ b/circles-app/src/routes/settings/+layout.svelte
@@ -70,11 +70,12 @@
   import CreateGatewayProfile from '$lib/areas/settings/flows/gateway/CreateGatewayProfile.svelte';
   import { coerceTabId, type TabIdOf } from '$lib/shared/ui/primitives/tabs/tabId';
 
-  const TAB_IDS = ['personal', 'bookmarks', 'orders', 'sales', 'keys', 'namespaces', 'marketplace', 'payment'] as const;
+  const TAB_IDS = ['personal', 'bookmarks', 'orders', 'sales', 'keys', 'namespaces', 'offers', 'payment'] as const;
   type TabId = TabIdOf<typeof TAB_IDS>;
 
-  // Friendly aliases for URL ?tab= values (e.g. ?tab=offers → marketplace)
-  const TAB_ALIASES: Record<string, TabId> = { offers: 'marketplace', profile: 'personal' };
+  // Friendly aliases for URL ?tab= values. `marketplace` kept as a back-compat
+  // read alias so existing links/bookmarks still resolve; canonical id is `offers`.
+  const TAB_ALIASES: Record<string, TabId> = { marketplace: 'offers', profile: 'personal' };
 
   let selectedTab = $state<TabId>('personal');
 
@@ -88,6 +89,7 @@
   // Tab → URL: keep ?tab= in sync when the user clicks a tab
   $effect(() => {
     if (!browser) return;
+    if (!$page.url.pathname.startsWith('/settings')) return;
     const current = selectedTab;
     const urlTab = $page.url.searchParams.get('tab');
     if (current && current !== urlTab) {
@@ -364,8 +366,8 @@
   }
 
   $effect(() => {
-    // only load when the Marketplace tab is visible
-    if (selectedTab !== 'marketplace') return;
+    // only load when the Offers tab is visible
+    if (selectedTab !== 'offers') return;
     void loadSellerCatalog();
   });
 
@@ -467,7 +469,7 @@
   const currentActions = $derived(
     !avatarAddress
       ? []
-      : selectedTab === 'marketplace'
+      : selectedTab === 'offers'
         ? actionsMarketplace
         : selectedTab === 'orders'
           ? actionsOrders
@@ -598,7 +600,7 @@
         <Tab id="bookmarks" title="Bookmarks" />
         <Tab id="orders" title="Orders" />
         <Tab id="sales" title="Sales" />
-        <Tab id="marketplace" title="Offers" />
+        <Tab id="offers" title="Offers" />
         <Tab id="payment" title="Payment gateways" />
         <Tab id="namespaces" title="Applications" />
         <Tab id="keys" title="Signing keys" />
@@ -645,7 +647,7 @@
           {nsIsOwner}
           {onNamespacesChanged}
         />
-      {:else if selectedTab === 'marketplace'}
+      {:else if selectedTab === 'offers'}
         <MarketplaceSection
           {avatarAddress}
           {marketLoading}


### PR DESCRIPTION
## Summary

Three coupled fixes for the bug Daisy reported (German): *"There's a bug on app.circlesubi.network when you go to the market — it leaves you unable to navigate away from the page."* The screenshots showed `URL=?tab=bookmarks` rendering Offers, and a second screenshot showed `URL=?tab=marketplace` rendering Orders — opposite-direction desyncs that fingerprinted a state-machine lockout.

### Bug A — Tabs `pendingExternalAck` lockout (`Tabs.svelte`)

The controlled-mode sync effect short-circuited when `pendingExternalAck` was set and `active === pendingExternalAck`, even if the parent moved `selected` to a totally different value. Result: a fast popstate or programmatic URL change during a click round-trip permanently froze `active` on the clicked id while the URL drifted elsewhere. Now: if the parent diverges from the ack, the ack is cleared and the parent wins. The "no second click needed" UX guarantee is preserved (the ack still suppresses snap-back during the normal round-trip).

### Bug B — Popup state duality (`popup/popUp.svelte.ts`, `PopUp.svelte`)

Two parallel `popupState` modules coexisted: a runes-based `popUp.svelte.ts` and a writable-store-based `index.ts`. The barrel import path resolved to one, the direct path to the other. ~30 callsites wrote to the store; 9 callsites wrote to the rune; **the only mounted popup host (`PopupHost.svelte`) reads the store**, so the 9 direct-importers' writes were silently no-op. `popUp.svelte.ts` is now a thin re-export from `index.ts` so all callers write to the canonical state. `PopUp.svelte` (orphaned, no importers — left in tree) updated to `\$popupState` store syntax for type-correctness.

### Bug C — Tab id rename + URL pollution guard (`+layout.svelte` and friends)

- Internal tab id renamed `marketplace` → `offers`.
- `TAB_ALIASES` inverted: `marketplace` is now a back-compat read alias so existing bookmarks/links keep resolving; canonical id is `offers`.
- Updated callsites: `market/+page.svelte` (`goto('/settings?tab=offers')`), `DefaultHeader.svelte` menu link.
- Added pathname guard to the tab→URL effect: it no longer fires `replaceState` once `\$page.url.pathname` has left `/settings`, preventing `?tab=personal` from leaking onto `/wallet`/`/market`/etc. during cross-route navigation teardown.

## Verification

Live, logged-in session on local dev (`http://localhost:5173`):

- **Bug A**: synthesized the exact popstate-during-click race — clicked `Offers` tab and immediately fired `popstate` with URL `?tab=sales`; result `active='sales'`, `url='?tab=sales'` (in sync). Pre-fix this would lock `active='offers'` while URL says `sales`.
- **Bug B**: Profile popup → Edit profile (stack push) → Back (stack pop) → Close (full close); `popup-shell.open` toggles `false→true→true→true→false` and bottom nav `translate-y-0/8 opacity-0/100 pointer-events-*` round-trips cleanly.
- **Bug C**: `/market` → `Offers` action button → `/settings?tab=offers` (active=`offers`). `?tab=marketplace` back-compat alias resolves to active=`offers`. Tab clicks update URL to canonical id.

### Test suite
- `npm run check` → 0 errors, 14 pre-existing warnings (admin components, unrelated).
- `npm run test:run` → **103/103** unit tests pass.
- `npm run test:e2e` → **12/12** Playwright tests pass.

## Known follow-up (out of scope)

URL auto-canonicalization from `?tab=marketplace` to `?tab=offers` doesn't take visible effect: `popup/index.ts` uses raw `window.history.pushState/replaceState` for popup-depth markers, which conflicts with SvelteKit's router (visible as a console warning) and overrides the canonical URL written by `replaceState` from `\$app/navigation`. Migrating to SvelteKit's history APIs requires reworking `readPopupHistoryMarker` for the nested page-state shape — bigger blast radius, separate PR. Pre-existing on `dev`; not introduced by this PR.

`circles-app/CLAUDE.md` "Popup System — Single Source of Truth (2026-02-20)" note now reflects the opposite of reality and should be updated post-merge.

## Test plan

- [x] Repro Tabs lockout pre-fix (synthesized race)
- [x] Confirm Tabs lockout fixed post-fix
- [x] Popup open/stack-push/back/close round-trip
- [x] Bottom nav hide/show in sync with popup state
- [x] Tab id rename consistent across layout, market action button, header menu link
- [x] Back-compat alias `?tab=marketplace` resolves to canonical `offers`
- [x] `npm run check` 0 errors
- [x] `npm run test:run` 103/103 pass
- [x] `npm run test:e2e` 12/12 pass
- [ ] Netlify preview/dev deploy lands at app.circlesubi.network and clears the original repro