### PR TITLE
fix(admin): delete odoo stock record when local stock is toggled off

### DIFF
--- a/circles-app/src/lib/areas/admin/services/gateway/adminClient.ts
+++ b/circles-app/src/lib/areas/admin/services/gateway/adminClient.ts
@@ -279,6 +279,11 @@ export async function getOdooStock(chainId: number, seller: string, sku: string)
   return adminFetch<OdooStockItem>(path);
 }
 
+export async function deleteOdooStock(chainId: number, seller: string, sku: string): Promise<{ ok: true }> {
+  const path = `/admin/odoo-stock/${chainId}/${encodeURIComponent(seller)}/${encodeURIComponent(sku)}`;
+  return adminFetch<{ ok: true }>(path, { method: 'DELETE' });
+}
+
 export async function listOdooProductCatalog(params: {
   chainId: number;
   seller: string;

--- a/circles-app/src/routes/admin/+page.svelte
+++ b/circles-app/src/routes/admin/+page.svelte
@@ -23,6 +23,7 @@
     listOdooProducts,
     upsertOdooProduct,
     upsertOdooStock,
+    deleteOdooStock,
     disableOdooProduct,
     listCodeProducts,
     upsertCodeProduct,
@@ -378,6 +379,16 @@
         await runTask({
           name: 'Saving local stock…',
           promise: upsertOdooStock(payload.odooStock),
+        });
+      } else if (product?.odoo?.localAvailableQty != null) {
+        // Stock was previously set but now being turned off — delete the record
+        await runTask({
+          name: 'Removing local stock…',
+          promise: deleteOdooStock(
+            payload.odoo.chainId,
+            payload.odoo.seller,
+            payload.odoo.sku,
+          ),
         });
       }
     } else if (payload.type === 'codedispenser' && payload.code) {

--- a/circles-app/src/routes/admin/+page.svelte
+++ b/circles-app/src/routes/admin/+page.svelte
@@ -385,9 +385,9 @@
         await runTask({
           name: 'Removing local stock…',
           promise: deleteOdooStock(
-            payload.odoo.chainId,
-            payload.odoo.seller,
-            payload.odoo.sku,
+            product.odoo.chainId,
+            product.odoo.seller,
+            product.odoo.sku,
           ),
         });
       }


### PR DESCRIPTION
## Summary

Adds proper toggle-off semantics for local stock in the Odoo product editor — the missing inverse of `upsertOdooStock`. When a user toggles `Use local stock` OFF on an existing product, the editor now calls `DELETE /admin/odoo-stock/{chainId}/{seller}/{sku}` to remove the `seller_inventory_stock` override, allowing inventory queries to fall back to Odoo's native stock. Without this change, toggling off had no backend effect.

## Changes

- `circles-app/src/lib/areas/admin/services/gateway/adminClient.ts` — added `deleteOdooStock(chainId, seller, sku)` adapter calling the new `DELETE /admin/odoo-stock/{chainId}/{seller}/{sku}` endpoint.
- `circles-app/src/routes/admin/+page.svelte` — added an `else if (product?.odoo?.localAvailableQty != null)` branch in `saveProduct()` that fires the DELETE when local stock was previously set but is now toggled off.
- DELETE targets `product.odoo.{chainId,seller,sku}` (saved state), not `payload.odoo.*` (form state). SKU is editable in `AdminOdooProductEditor.svelte`, so simultaneous SKU edit + toggle-off would otherwise orphan the original `seller_inventory_stock` row.

## Backend dependency

Backend endpoint `MapDelete /admin/odoo-stock/{chainId}/{seller}/{sku}` is live in prod (`marketplace-api#38`, deployed 2026-05-06). Verified `HTTP 401 Bearer` (was `405` pre-deploy).

## Why hard-DELETE instead of `PUT qty=0`

The Odoo adapter short-circuits inventory queries on any present `seller_inventory_stock` row regardless of qty value — only row absence falls through to Odoo's native stock. `PUT qty=0` would persist a "use local, but it's 0" override, which is the wrong semantic.

## Verification

Verified end-to-end on the deploy preview against prod backend (`market-api.aboutcircles.com`) using `test-odoo-03-vpo1r` (seller `0x9C07...876834`):

1. Starting state: `Local stock: 10`
2. Toggle off + save → `DELETE /admin/odoo-stock/100/0x9C07.../test-odoo-03-vpo1r` → `200`
3. Product card shows `Local stock: fallback` (Odoo native takes over)
4. Toggle on + qty=10 + save → `PUT /admin/odoo-stock` → `200`
5. Card back to `Local stock: 10` — fully reversible, no data loss

## Test plan

- [x] Toggle ON → save creates `seller_inventory_stock` row (PUT)
- [x] Toggle OFF → save deletes the row (DELETE)
- [x] Product correctly falls through to Odoo native stock after delete
- [x] Re-toggle ON re-creates the row
- [x] Original SKU used as DELETE path (verified via `product.odoo.sku` field in code; SKU-edit + toggle-off combo not exercised live to avoid prod product mutation)