### PR TITLE
fix(admin): delete odoo stock record when local stock is toggled off

### DIFF
--- a/circles-app/src/lib/areas/admin/services/gateway/adminClient.ts
+++ b/circles-app/src/lib/areas/admin/services/gateway/adminClient.ts
@@ -279,6 +279,11 @@ export async function getOdooStock(chainId: number, seller: string, sku: string)
   return adminFetch<OdooStockItem>(path);
 }
 
+export async function deleteOdooStock(chainId: number, seller: string, sku: string): Promise<{ ok: true }> {
+  const path = `/admin/odoo-stock/${chainId}/${encodeURIComponent(seller)}/${encodeURIComponent(sku)}`;
+  return adminFetch<{ ok: true }>(path, { method: 'DELETE' });
+}
+
 export async function listOdooProductCatalog(params: {
   chainId: number;
   seller: string;

--- a/circles-app/src/routes/admin/+page.svelte
+++ b/circles-app/src/routes/admin/+page.svelte
@@ -23,6 +23,7 @@
     listOdooProducts,
     upsertOdooProduct,
     upsertOdooStock,
+    deleteOdooStock,
     disableOdooProduct,
     listCodeProducts,
     upsertCodeProduct,
@@ -378,6 +379,15 @@
         await runTask({
           name: 'Saving local stock…',
           promise: upsertOdooStock(payload.odooStock),
+        });
+      } else if (product?.odoo?.localAvailableQty != null) {
+        await runTask({
+          name: 'Removing local stock…',
+          promise: deleteOdooStock(
+            product.odoo.chainId,
+            product.odoo.seller,
+            product.odoo.sku,
+          ),
         });
       }
     } else if (payload.type === 'codedispenser' && payload.code) {


### PR DESCRIPTION
## Summary

Forward-port of #165 (merged on main today) so the admin editor on `dev` also calls `DELETE /admin/odoo-stock` when a user toggles `Use local stock` OFF on a product that previously had it set. Without this, toggling off has no backend effect — the `seller_inventory_stock` override stays in place and Odoo native stock fallback never engages.

## Changes

- `circles-app/src/lib/areas/admin/services/gateway/adminClient.ts` — add `deleteOdooStock(chainId, seller, sku)` adapter calling `DELETE /admin/odoo-stock/{chainId}/{seller}/{sku}`.
- `circles-app/src/routes/admin/+page.svelte` — add `else if (product?.odoo?.localAvailableQty != null)` branch in `saveProduct()` that fires the DELETE when local stock was previously set but is now toggled off. DELETE targets `product.odoo.{chainId,seller,sku}` (saved state), not `payload.odoo.*` (form state) — SKU is editable in the editor, so simultaneous SKU edit + toggle-off would otherwise orphan the original row.

## Backend dependency

`MapDelete /admin/odoo-stock/{chainId}/{seller}/{sku}` is live in prod (`marketplace-api#38`, deployed 2026-05-06).

## Why hard-DELETE instead of `PUT qty=0`

The Odoo adapter short-circuits inventory queries on any present `seller_inventory_stock` row regardless of qty value — only row absence falls through to Odoo native stock. `PUT qty=0` would persist a "use local, but it's 0" override (wrong semantic).

## Verification

The same diff is already verified end-to-end on `main` against the prod backend — toggle-off → DELETE 200 → product falls through to Odoo native stock → re-toggle-on PUT restores the row, no data loss.

## Test plan

- [ ] Toggle ON → save creates `seller_inventory_stock` row (PUT)
- [ ] Toggle OFF → save deletes the row (DELETE)
- [ ] Product correctly falls through to Odoo native stock after delete
- [ ] Re-toggle ON re-creates the row