### PR TITLE
fix(scaffold): hide empty collapsed dropdown when no actions snippet

### DIFF
--- a/circles-app/src/lib/shared/ui/shell/PageScaffold.svelte
+++ b/circles-app/src/lib/shared/ui/shell/PageScaffold.svelte
@@ -264,7 +264,7 @@ import SettingProfile from '$lib/areas/settings/ui/pages/SettingProfile.svelte';
                         </div>
                     {/if}
                 </div>
-            {:else}
+            {:else if headerActionsCollapsed}
                 <div class="mt-3 md:mt-4 mb-3 flex justify-center">
                     <div class="dropdown">
                         <button type="button" class="btn btn-primary btn-md rounded-full shadow-md pointer-events-auto">
@@ -274,7 +274,7 @@ import SettingProfile from '$lib/areas/settings/ui/pages/SettingProfile.svelte';
                             </svg>
                         </button>
                         <ul class="dropdown-content menu menu-sm bg-base-100 rounded-box shadow z-30 w-56 p-2 pointer-events-auto">
-                            {@render headerActionsCollapsed?.()}
+                            {@render headerActionsCollapsed()}
                         </ul>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary

Forward-port of #166 (merged on main today) so the same fix lands on `dev`. `PageScaffold` rendered the collapsed-mode `<div class="dropdown">` unconditionally; when no `headerActionsCollapsed` snippet was supplied, the dropdown menu was empty but a purple chevron button still appeared at the top of every popup that fell into the non-`bar` collapsed mode.

## Change

- `circles-app/src/lib/shared/ui/shell/PageScaffold.svelte` — gate the entire `{:else}` branch on `headerActionsCollapsed` being defined (`{:else if headerActionsCollapsed}`). When the snippet isn't supplied, the collapsed-control host renders nothing instead of an empty chevron.

## Test plan

- [ ] Open a popup that does NOT pass a `headerActionsCollapsed` snippet → no empty chevron at top.
- [ ] Open a popup that DOES pass `headerActionsCollapsed` → chevron + dropdown items render as before.
- [ ] Resize across the collapsed/expanded breakpoint → both modes still toggle correctly.
- [ ] `bar` mode collapsed UI (the `{#if collapsedMode === 'bar'}` branch) is unchanged.