### PR TITLE
feat(profile): public marketplace inspection in profile popup

### DIFF
--- a/circles-app/src/lib/areas/profile/ui/components/GatewaysPanel.svelte
+++ b/circles-app/src/lib/areas/profile/ui/components/GatewaysPanel.svelte
@@ -1,0 +1,142 @@
+<script lang="ts">
+  import type {
+    GatewayListRow,
+    GatewayTrustRow,
+  } from '$lib/shared/data/circles/paymentGateways';
+  import { fetchActiveTrustRowsByGateway } from '$lib/shared/data/circles/paymentGateways';
+  import { circles } from '$lib/shared/state/circles';
+  import { get } from 'svelte/store';
+  import RowFrame from '$lib/shared/ui/primitives/RowFrame.svelte';
+  import AddressComponent from '$lib/shared/ui/primitives/Address.svelte';
+  import Avatar from '$lib/shared/ui/avatar/Avatar.svelte';
+  import { openProfilePopup } from '$lib/shared/ui/profile/openProfilePopup';
+  import type { Address } from '@aboutcircles/sdk-types';
+
+  interface Props {
+    gateways: GatewayListRow[];
+    loading?: boolean;
+    error?: string;
+    onRetry?: () => void;
+  }
+
+  let { gateways, loading = false, error = '', onRetry }: Props = $props();
+
+  // Per-gateway expanded state and trust rows.
+  let expanded: Record<string, boolean> = $state({});
+  let trustsByGateway: Record<string, GatewayTrustRow[] | 'loading' | 'error'> = $state({});
+
+  function explorerUrl(tx?: string): string | null {
+    if (!tx) return null;
+    return `https://gnosisscan.io/tx/${tx}`;
+  }
+
+  function formatTimestamp(ts?: number): string {
+    if (!ts) return '';
+    return new Date(ts * 1000).toLocaleString();
+  }
+
+  async function toggleExpand(gateway: string): Promise<void> {
+    expanded[gateway] = !expanded[gateway];
+    if (!expanded[gateway]) return;
+    if (trustsByGateway[gateway] && trustsByGateway[gateway] !== 'error') return;
+    trustsByGateway[gateway] = 'loading';
+    try {
+      const sdk = get(circles);
+      if (!sdk) {
+        trustsByGateway[gateway] = 'error';
+        return;
+      }
+      const rows = await fetchActiveTrustRowsByGateway(sdk, gateway);
+      trustsByGateway[gateway] = rows;
+    } catch (e) {
+      console.warn('[GatewaysPanel] trust fetch failed', e);
+      trustsByGateway[gateway] = 'error';
+    }
+  }
+</script>
+
+{#if loading}
+  <div class="flex items-center gap-2 text-base-content/70 py-2">
+    <span class="loading loading-spinner loading-sm"></span>
+    <span>Loading gateways…</span>
+  </div>
+{:else if error}
+  <div class="alert alert-warning">
+    <span>{error}</span>
+    {#if onRetry}
+      <button class="btn btn-xs ml-2" onclick={onRetry}>Retry</button>
+    {/if}
+  </div>
+{:else if gateways.length === 0}
+  <div class="text-sm opacity-70">No gateways</div>
+{:else}
+  <div class="space-y-1.5">
+    {#each gateways as gw (gw.gateway)}
+      <RowFrame dense={true} noLeading={true}>
+        <button
+          type="button"
+          class="min-w-0 text-left w-full"
+          onclick={() => toggleExpand(gw.gateway)}
+          aria-expanded={!!expanded[gw.gateway]}
+          aria-label={`Toggle gateway ${gw.gateway}`}
+        >
+          <div class="flex items-center gap-2 min-w-0">
+            <span class="text-xs opacity-60">{expanded[gw.gateway] ? '▾' : '▸'}</span>
+            <AddressComponent address={gw.gateway as Address} />
+          </div>
+          <div class="text-xs opacity-60 mt-0.5">
+            Created {formatTimestamp(gw.timestamp)} · block {gw.blockNumber}
+          </div>
+        </button>
+        {#snippet trailing()}
+          {#if explorerUrl(gw.tx)}
+            <a
+              class="text-[10px] opacity-50 hover:underline"
+              href={explorerUrl(gw.tx)}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              tx ↗
+            </a>
+          {/if}
+        {/snippet}
+      </RowFrame>
+      {#if expanded[gw.gateway]}
+        <div class="ml-6 pl-3 border-l border-base-300 my-2">
+          {#if trustsByGateway[gw.gateway] === 'loading'}
+            <div class="flex items-center gap-2 text-xs text-base-content/70 py-1">
+              <span class="loading loading-spinner loading-xs"></span>
+              <span>Loading active trusts…</span>
+            </div>
+          {:else if trustsByGateway[gw.gateway] === 'error'}
+            <div class="text-xs text-error">Failed to load trusts</div>
+          {:else if Array.isArray(trustsByGateway[gw.gateway])}
+            {@const rows = trustsByGateway[gw.gateway] as GatewayTrustRow[]}
+            {#if rows.length === 0}
+              <div class="text-xs opacity-60 py-1">No active trusts</div>
+            {:else}
+              <div class="text-[10px] opacity-50 mb-1">{rows.length} active trust{rows.length === 1 ? '' : 's'}</div>
+              <div class="space-y-1">
+                {#each rows as t (t.trustReceiver)}
+                  <button
+                    type="button"
+                    class="w-full text-left"
+                    onclick={() => openProfilePopup(t.trustReceiver as Address)}
+                    aria-label={`Open avatar ${t.trustReceiver}`}
+                  >
+                    <Avatar
+                      address={t.trustReceiver as Address}
+                      clickable={true}
+                      view="horizontal"
+                      showTypeInfo={true}
+                    />
+                  </button>
+                {/each}
+              </div>
+            {/if}
+          {/if}
+        </div>
+      {/if}
+    {/each}
+  </div>
+{/if}

--- a/circles-app/src/lib/areas/profile/ui/components/PriceHistoryPanel.svelte
+++ b/circles-app/src/lib/areas/profile/ui/components/PriceHistoryPanel.svelte
@@ -1,0 +1,107 @@
+<script lang="ts">
+  import type { PaymentRow } from '$lib/shared/data/circles/paymentReceived';
+  import { formatCrcAmount } from '$lib/shared/data/circles/paymentReceived';
+  import ModernHistoryChart from '$lib/areas/groups/ui/components/ModernHistoryChart.svelte';
+
+  interface Props {
+    payments: PaymentRow[];
+    loading?: boolean;
+    error?: string;
+  }
+
+  let { payments, loading = false, error = '' }: Props = $props();
+
+  type SkuPoint = { timestamp: Date; price: number };
+  type SkuBucket = { key: string; label: string; series: SkuPoint[] };
+
+  /**
+   * Extract a SKU/reference key from a payment's data field.
+   * Returns the JSON `sku` or `productSku` if present, else the trimmed decoded string,
+   * else "(unknown)" when nothing is decodable.
+   */
+  function extractSkuKey(decoded: string): { key: string; label: string } {
+    if (!decoded) return { key: '__unknown__', label: '(unknown)' };
+    const trimmed = decoded.trim();
+    if (!trimmed) return { key: '__unknown__', label: '(unknown)' };
+    try {
+      const parsed = JSON.parse(trimmed);
+      const candidate = parsed?.sku ?? parsed?.productSku ?? parsed?.productCid ?? parsed?.ref;
+      if (typeof candidate === 'string' && candidate.length) {
+        return { key: candidate, label: candidate };
+      }
+    } catch {
+      // not JSON — fall through
+    }
+    // Use the raw decoded string but cap label length for display.
+    const safe = trimmed.replace(/[\x00-\x1f\x7f]/g, '').slice(0, 80);
+    if (!safe) return { key: '__unknown__', label: '(unknown)' };
+    return { key: safe, label: safe };
+  }
+
+  const MAX_BUCKETS = 20;
+
+  const allBuckets = $derived.by<SkuBucket[]>(() => {
+    const map = new Map<string, SkuBucket>();
+    for (const p of payments) {
+      const { key, label } = extractSkuKey(p.dataDecoded);
+      const ts = p.timestamp > 0 ? new Date(p.timestamp * 1000) : null;
+      if (!ts) continue;
+      const price = parseFloat(formatCrcAmount(p.amount));
+      if (!isFinite(price) || price <= 0) continue;
+      let bucket = map.get(key);
+      if (!bucket) {
+        bucket = { key, label, series: [] };
+        map.set(key, bucket);
+      }
+      bucket.series.push({ timestamp: ts, price });
+    }
+    return Array.from(map.values())
+      .map((b) => ({ ...b, series: b.series.slice().sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime()) }))
+      .sort((a, b) => b.series.length - a.series.length);
+  });
+
+  const buckets = $derived(allBuckets.slice(0, MAX_BUCKETS));
+  const hiddenBucketCount = $derived(Math.max(0, allBuckets.length - MAX_BUCKETS));
+</script>
+
+{#if loading}
+  <div class="flex items-center gap-2 text-base-content/70 py-2">
+    <span class="loading loading-spinner loading-sm"></span>
+    <span>Loading price history…</span>
+  </div>
+{:else if error}
+  <div class="alert alert-warning">
+    <span>{error}</span>
+  </div>
+{:else if buckets.length === 0}
+  <div class="text-sm opacity-70">No price history</div>
+{:else}
+  <div class="text-xs opacity-60 mb-2">
+    Realised prices from completed sales. Listing price changes that happened without a sale are not shown.
+  </div>
+  <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+    {#each buckets as b (b.key)}
+      <div class="bg-base-100 border border-base-300 p-3 rounded-xl shadow-sm">
+        <div class="text-xs opacity-70 truncate" title={b.label}>{b.label}</div>
+        <div class="text-[10px] opacity-50 mb-1">{b.series.length} sale{b.series.length === 1 ? '' : 's'}</div>
+        {#if b.series.length >= 2}
+          <ModernHistoryChart
+            dataSet1={b.series}
+            dataSet2={[]}
+            title=""
+            label="CRC"
+          />
+        {:else}
+          <div class="text-sm tabular-nums">
+            {b.series[0].price.toFixed(2)} CRC · {b.series[0].timestamp.toLocaleDateString()}
+          </div>
+        {/if}
+      </div>
+    {/each}
+  </div>
+  {#if hiddenBucketCount > 0}
+    <div class="text-xs opacity-60 mt-3 text-center">
+      +{hiddenBucketCount} more SKU{hiddenBucketCount === 1 ? '' : 's'} with fewer sales not shown
+    </div>
+  {/if}
+{/if}

--- a/circles-app/src/lib/areas/profile/ui/components/SalesPanel.svelte
+++ b/circles-app/src/lib/areas/profile/ui/components/SalesPanel.svelte
@@ -1,0 +1,178 @@
+<script lang="ts">
+  import type { PaymentRow } from '$lib/shared/data/circles/paymentReceived';
+  import { formatCrcAmount } from '$lib/shared/data/circles/paymentReceived';
+  import { getCrcPrice, applyCrcRate, type CrcPrice } from '$lib/shared/data/market/crcPricing';
+  import RowFrame from '$lib/shared/ui/primitives/RowFrame.svelte';
+  import Avatar from '$lib/shared/ui/avatar/Avatar.svelte';
+  import { openProfilePopup } from '$lib/shared/ui/profile/openProfilePopup';
+  import type { Address } from '@aboutcircles/sdk-types';
+
+  interface Props {
+    payments: PaymentRow[];
+    loading?: boolean;
+    error?: string;
+    onRetry?: () => void;
+  }
+
+  let { payments, loading = false, error = '', onRetry }: Props = $props();
+
+  // Stats: synchronous (count, CRC volume, unique buyers).
+  const totalPaymentsCount = $derived(payments.length);
+  const totalCrc = $derived(
+    payments.reduce((sum, p) => sum + parseFloat(formatCrcAmount(p.amount)), 0)
+  );
+  const uniqueBuyers = $derived(new Set(payments.map((p) => p.payer.toLowerCase())).size);
+
+  // Stats: async EUR volume — bucket by date, fetch one rate per date.
+  let eurVolume: number | null = $state(null);
+  let eurUsedFallback: boolean = $state(false);
+  let eurAvailable: boolean = $state(false);
+  let eurComputing: boolean = $state(false);
+  let computedFor: string = $state('');
+
+  $effect(() => {
+    const fingerprint = payments.length
+      ? `${payments[0].tx}:${payments[payments.length - 1].tx}:${payments.length}`
+      : 'empty';
+    if (computedFor === fingerprint) return;
+    computedFor = fingerprint;
+    void computeEurVolume();
+  });
+
+  async function computeEurVolume(): Promise<void> {
+    eurAvailable = false;
+    eurUsedFallback = false;
+    eurVolume = null;
+    if (payments.length === 0) return;
+    eurComputing = true;
+    try {
+      // bucket: dateStr -> sum of CRC for that day
+      const buckets: Record<string, { crc: number; ts: number }> = {};
+      for (const p of payments) {
+        if (!isFinite(p.timestamp) || p.timestamp <= 0) continue;
+        const dateStr = new Date(p.timestamp * 1000).toISOString().slice(0, 10);
+        if (!buckets[dateStr]) buckets[dateStr] = { crc: 0, ts: p.timestamp };
+        buckets[dateStr].crc += parseFloat(formatCrcAmount(p.amount));
+      }
+      let total = 0;
+      let hasAny = false;
+      let usedFallback = false;
+      for (const dateStr of Object.keys(buckets)) {
+        const bucket = buckets[dateStr];
+        const price: CrcPrice | null = await getCrcPrice(bucket.ts);
+        const conv = applyCrcRate(bucket.crc, price);
+        if (conv) {
+          total += conv.eur;
+          hasAny = true;
+          if (conv.usedFallback) usedFallback = true;
+        }
+      }
+      eurAvailable = hasAny;
+      eurUsedFallback = usedFallback;
+      eurVolume = hasAny ? total : null;
+    } catch (e) {
+      console.warn('[SalesPanel] EUR volume computation failed', e);
+      eurAvailable = false;
+      eurVolume = null;
+    } finally {
+      eurComputing = false;
+    }
+  }
+
+  function formatTimestamp(ts: number): string {
+    if (!ts) return '';
+    return new Date(ts * 1000).toLocaleString();
+  }
+
+  function formatCrcDisplay(amount: bigint): string {
+    const v = parseFloat(formatCrcAmount(amount));
+    return v.toFixed(2);
+  }
+
+  function explorerUrl(tx: string): string {
+    return `https://gnosisscan.io/tx/${tx}`;
+  }
+
+  function openPayer(address: Address): void {
+    openProfilePopup(address);
+  }
+</script>
+
+{#if loading}
+  <div class="flex items-center gap-2 text-base-content/70 py-2">
+    <span class="loading loading-spinner loading-sm"></span>
+    <span>Loading sales…</span>
+  </div>
+{:else if error}
+  <div class="alert alert-warning">
+    <span>{error}</span>
+    {#if onRetry}
+      <button class="btn btn-xs ml-2" onclick={onRetry}>Retry</button>
+    {/if}
+  </div>
+{:else if payments.length === 0}
+  <div class="text-sm opacity-70">No sales</div>
+{:else}
+  <!-- Stats -->
+  <div class="flex flex-wrap gap-2 mb-3">
+    <div class="bg-base-200 rounded-lg px-3 py-2 min-w-[100px]">
+      <div class="text-xs opacity-60">Sales</div>
+      <div class="text-lg font-bold tabular-nums">{totalPaymentsCount}</div>
+    </div>
+    <div class="bg-base-200 rounded-lg px-3 py-2 min-w-[120px]">
+      <div class="text-xs opacity-60">Volume</div>
+      <div class="text-lg font-bold tabular-nums">{totalCrc.toFixed(2)} CRC</div>
+    </div>
+    <div class="bg-base-200 rounded-lg px-3 py-2 min-w-[120px]">
+      <div class="text-xs opacity-60">EUR volume</div>
+      <div class="text-lg font-bold tabular-nums">
+        {#if eurComputing}
+          …
+        {:else if eurAvailable && eurVolume !== null}
+          {eurUsedFallback ? '~' : ''}€{eurVolume.toFixed(2)}
+        {:else}
+          —
+        {/if}
+      </div>
+      {#if eurUsedFallback}
+        <div class="text-[10px] opacity-50 mt-0.5">partial xDAI fallback</div>
+      {/if}
+    </div>
+    <div class="bg-base-200 rounded-lg px-3 py-2 min-w-[100px]">
+      <div class="text-xs opacity-60">Buyers</div>
+      <div class="text-lg font-bold tabular-nums">{uniqueBuyers}</div>
+    </div>
+  </div>
+
+  <!-- Payment list -->
+  <div class="space-y-1.5">
+    {#each payments as p (p.tx)}
+      <RowFrame dense={true} noLeading={true}>
+        <button
+          type="button"
+          class="min-w-0 text-left w-full"
+          onclick={() => openPayer(p.payer)}
+          aria-label={`Open buyer ${p.payer}`}
+        >
+          <Avatar address={p.payer} clickable={true} view="horizontal" showTypeInfo={true} />
+        </button>
+        {#snippet trailing()}
+          <div class="text-right tabular-nums whitespace-nowrap">
+            <div class="font-medium">{formatCrcDisplay(p.amount)} CRC</div>
+            <div class="text-xs opacity-60">{formatTimestamp(p.timestamp)}</div>
+            {#if p.tx}
+              <a
+                class="text-[10px] opacity-50 hover:underline"
+                href={explorerUrl(p.tx)}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                tx ↗
+              </a>
+            {/if}
+          </div>
+        {/snippet}
+      </RowFrame>
+    {/each}
+  </div>
+{/if}

--- a/circles-app/src/lib/areas/profile/ui/pages/Profile.svelte
+++ b/circles-app/src/lib/areas/profile/ui/pages/Profile.svelte
@@ -42,6 +42,15 @@
     import { normalizeEvmAddress as normalizeAddress } from '@circles-market/sdk';
     import type { AggregatedCatalogItem } from '$lib/areas/market/model';
     import { getMarketClient } from '$lib/shared/data/market/marketClientProxy';
+    // Sales / Price history / Gateways tabs
+    import SalesPanel from '$lib/areas/profile/ui/components/SalesPanel.svelte';
+    import PriceHistoryPanel from '$lib/areas/profile/ui/components/PriceHistoryPanel.svelte';
+    import GatewaysPanel from '$lib/areas/profile/ui/components/GatewaysPanel.svelte';
+    import { fetchPaymentsByPayee, type PaymentRow } from '$lib/shared/data/circles/paymentReceived';
+    import {
+        fetchGatewayRowsByOwner,
+        type GatewayListRow,
+    } from '$lib/shared/data/circles/paymentGateways';
     // Namespaces explorer (read-only) for other profiles
     import { ProfileNamespaces } from '$lib/shared/ui/profile';
     import { loadProfileOrInit } from '@circles-market/sdk';
@@ -127,6 +136,18 @@
     // Track which seller address the current `offers` belong to (lowercased)
     let offersFor: string | null = $state(null);
 
+    // Sales tab state (PaymentReceived events filtered by payee)
+    let paymentsLoading: boolean = $state(false);
+    let paymentsError: string = $state('');
+    let payments: PaymentRow[] = $state([]);
+    let paymentsFor: string | null = $state(null);
+
+    // Gateways tab state (CrcV2_PaymentGateway.GatewayCreated rows owned by avatar)
+    let gatewaysLoading: boolean = $state(false);
+    let gatewaysError: string = $state('');
+    let gateways: GatewayListRow[] = $state([]);
+    let gatewaysFor: string | null = $state(null);
+
     async function loadOffers(): Promise<void> {
         if (!address) return;
         const seller = normalizeAddress(String(address));
@@ -176,6 +197,69 @@
         if (!offersLoading && offersFor !== want) {
             void loadOffers();
         }
+    });
+
+    async function loadPayments(): Promise<void> {
+        if (!address) return;
+        const seller = normalizeAddress(String(address));
+        if (!seller) {
+            paymentsError = 'Invalid address';
+            payments = [];
+            paymentsFor = null;
+            return;
+        }
+        // Atomic swap: keep stale data in `payments` while fetching so `availableTabIds`
+        // doesn't drop the Sales tab mid-fetch and reset `selectedTab` away from it.
+        // If the address has changed, drop the old data first.
+        if (paymentsFor !== seller) payments = [];
+        paymentsLoading = true;
+        paymentsError = '';
+        try {
+            const sdk = get(circles);
+            if (!sdk) throw new Error('Circles SDK not initialized');
+            const fresh = await fetchPaymentsByPayee(sdk, seller);
+            payments = fresh;
+            paymentsFor = seller;
+        } catch (e: any) {
+            paymentsError = e?.message || 'Failed to load sales';
+            paymentsFor = seller;
+        } finally {
+            paymentsLoading = false;
+        }
+    }
+
+    async function loadGateways(): Promise<void> {
+        if (!address) return;
+        const owner = normalizeAddress(String(address));
+        if (!owner) {
+            gatewaysError = 'Invalid address';
+            gateways = [];
+            gatewaysFor = null;
+            return;
+        }
+        if (gatewaysFor !== owner) gateways = [];
+        gatewaysLoading = true;
+        gatewaysError = '';
+        try {
+            const sdk = get(circles);
+            if (!sdk) throw new Error('Circles SDK not initialized');
+            const fresh = await fetchGatewayRowsByOwner(sdk, owner);
+            gateways = fresh;
+            gatewaysFor = owner;
+        } catch (e: any) {
+            gatewaysError = e?.message || 'Failed to load gateways';
+            gatewaysFor = owner;
+        } finally {
+            gatewaysLoading = false;
+        }
+    }
+
+    // Eagerly load payments + gateways when address changes — both gate tab visibility.
+    $effect(() => {
+        if (!address) return;
+        const want = normalizeAddress(String(address));
+        if (!paymentsLoading && paymentsFor !== want) void loadPayments();
+        if (!gatewaysLoading && gatewaysFor !== want) void loadGateways();
     });
 
     // ─────────────────────────────────────────────────────────────
@@ -383,6 +467,9 @@
         'holders',
         'holdings',
         'offers',
+        'sales',
+        'price_history',
+        'gateways',
         'explore_namespaces',
     ] as const;
     type TabId = TabIdOf<typeof TAB_IDS>;
@@ -507,6 +594,11 @@
             ids.push('holdings');
         }
         ids.push('offers');
+        if (payments.length > 0) {
+            ids.push('sales');
+            ids.push('price_history');
+        }
+        if (gateways.length > 0) ids.push('gateways');
         ids.push('explore_namespaces');
         return ids;
     })());
@@ -954,6 +1046,50 @@
             {/if}
         {/if}
     </Tab>
+
+    {#if payments.length > 0}
+        <Tab
+                id="sales"
+                title="Sales"
+                badge={payments.length}
+                panelClass={tabPanelClass}
+        >
+            <SalesPanel
+                {payments}
+                loading={paymentsLoading}
+                error={paymentsError}
+                onRetry={loadPayments}
+            />
+        </Tab>
+
+        <Tab
+                id="price_history"
+                title="Price history"
+                panelClass={tabPanelClass}
+        >
+            <PriceHistoryPanel
+                {payments}
+                loading={paymentsLoading}
+                error={paymentsError}
+            />
+        </Tab>
+    {/if}
+
+    {#if gateways.length > 0}
+        <Tab
+                id="gateways"
+                title="Gateways"
+                badge={gateways.length}
+                panelClass={tabPanelClass}
+        >
+            <GatewaysPanel
+                {gateways}
+                loading={gatewaysLoading}
+                error={gatewaysError}
+                onRetry={loadGateways}
+            />
+        </Tab>
+    {/if}
 
     <!-- Explore namespaces tab: auto-load the viewed profile's namespaces (read-only) -->
     <Tab

--- a/circles-app/src/lib/shared/config/circles.ts
+++ b/circles-app/src/lib/shared/config/circles.ts
@@ -17,6 +17,9 @@ export type CirclesConfig = BaseCirclesConfig & {
   marketChainIdHex?: string;
   /** IPFS gateway base URL */
   ipfsGatewayBase?: string;
+  // The metrics-exporter currently only serves from the staging subdomain even in prod use.
+  /** CRC→EUR/xDAI pricing endpoint (metrics-exporter) */
+  crcPricingApi?: string;
 };
 
 export const chiadoConfig: { production: CirclesConfig; rings: CirclesConfig } =
@@ -45,6 +48,9 @@ export const chiadoConfig: { production: CirclesConfig; rings: CirclesConfig } =
       marketOperator: '0x20ced4ed3b1651b832a77e13e54ea5cb14c8b95b',
       marketChainId: 100,
       marketChainIdHex: '0x64',
+      crcPricingApi:
+        import.meta.env.VITE_CRC_PRICING_API ||
+        'https://rpc.staging.aboutcircles.com/metrics-api/pricing',
     },
     // rings are not deployed on chiado yet
     rings: {
@@ -71,6 +77,9 @@ export const chiadoConfig: { production: CirclesConfig; rings: CirclesConfig } =
       marketOperator: '0x20ced4ed3b1651b832a77e13e54ea5cb14c8b95b',
       marketChainId: 100,
       marketChainIdHex: '0x64',
+      crcPricingApi:
+        import.meta.env.VITE_CRC_PRICING_API ||
+        'https://rpc.staging.aboutcircles.com/metrics-api/pricing',
     },
   };
 
@@ -104,6 +113,9 @@ export const gnosisConfig: { production: CirclesConfig; rings: CirclesConfig } =
       marketOperator: '0x20ced4ed3b1651b832a77e13e54ea5cb14c8b95b',
       marketChainId: 100,
       marketChainIdHex: '0x64',
+      crcPricingApi:
+        import.meta.env.VITE_CRC_PRICING_API ||
+        'https://rpc.staging.aboutcircles.com/metrics-api/pricing',
     },
     rings: {
       circlesRpcUrl:
@@ -133,6 +145,9 @@ export const gnosisConfig: { production: CirclesConfig; rings: CirclesConfig } =
       marketOperator: '0x20ced4ed3b1651b832a77e13e54ea5cb14c8b95b',
       marketChainId: 100,
       marketChainIdHex: '0x64',
+      crcPricingApi:
+        import.meta.env.VITE_CRC_PRICING_API ||
+        'https://rpc.staging.aboutcircles.com/metrics-api/pricing',
     },
   };
 

--- a/circles-app/src/lib/shared/data/circles/paymentReceived.ts
+++ b/circles-app/src/lib/shared/data/circles/paymentReceived.ts
@@ -1,0 +1,136 @@
+import type { Sdk } from '@aboutcircles/sdk';
+import type { Address } from '@aboutcircles/sdk-types';
+import { ethers } from 'ethers';
+
+export type PaymentRow = {
+  payer: Address;
+  payee: Address;
+  gateway: Address;
+  amount: bigint;
+  /** Raw 0x-prefixed hex string from the indexer */
+  data: string;
+  /** Best-effort UTF-8 decode of `data`; empty string if undecodable */
+  dataDecoded: string;
+  /** Unix seconds */
+  timestamp: number;
+  tx: string;
+  blockNumber: number;
+};
+
+type RpcQueryResult = {
+  columns?: string[];
+  rows?: any[][];
+};
+
+/** Hex (0x...) → UTF-8 string. Returns the input on failure. Mirrors marketplaceExplorer.html:1109. */
+export function hexToUtf8(hex: string): string {
+  if (!hex || !hex.startsWith('0x')) return hex || '';
+  try {
+    const bytes: number[] = [];
+    for (let i = 2; i < hex.length; i += 2) {
+      bytes.push(parseInt(hex.substring(i, i + 2), 16));
+    }
+    return new TextDecoder().decode(new Uint8Array(bytes));
+  } catch {
+    return hex;
+  }
+}
+
+/**
+ * Format a wei-like amount (18 decimals) to a CRC string with trailing zeros trimmed.
+ * Accepts bigint or numeric string. Mirrors marketplaceExplorer.html:1119.
+ *
+ * Manual implementation rather than ethers.formatUnits to handle raw circles_query
+ * string columns without precision drift.
+ */
+export function formatCrcAmount(amountWei: bigint | string): string {
+  if (amountWei === undefined || amountWei === null) return '0';
+  const s = typeof amountWei === 'bigint' ? amountWei.toString() : String(amountWei);
+  if (!s || s === '0') return '0';
+  if (s.length <= 18) {
+    const f = s.replace(/0+$/, '');
+    return f ? '0.' + '0'.repeat(18 - s.length) + f : '0';
+  }
+  const whole = s.slice(0, s.length - 18);
+  const frac = s.slice(s.length - 18).replace(/0+$/, '');
+  return frac ? whole + '.' + frac : whole;
+}
+
+/**
+ * Fetch all PaymentReceived events for a given payee address.
+ * Public, no auth required. Mirrors marketplaceExplorer.html:1151-1154.
+ */
+export async function fetchPaymentsByPayee(
+  sdk: Sdk,
+  payee: string,
+  limit: number = 200
+): Promise<PaymentRow[]> {
+  if (!sdk?.rpc || !payee) return [];
+  if (!ethers.isAddress(payee)) return [];
+
+  const resp: RpcQueryResult = await sdk.rpc.client.call('circles_query', [
+    {
+      Namespace: 'CrcV2_PaymentGateway',
+      Table: 'PaymentReceived',
+      Columns: ['payer', 'payee', 'gateway', 'amount', 'data', 'timestamp', 'transactionHash', 'blockNumber'],
+      Filter: [
+        {
+          Type: 'FilterPredicate',
+          FilterType: 'Equals',
+          Column: 'payee',
+          Value: payee.toLowerCase(),
+        },
+      ],
+      Order: [{ Column: 'blockNumber', SortOrder: 'DESC' }],
+      Limit: limit,
+    },
+  ]);
+
+  const cols = resp?.columns ?? [];
+  const rows = resp?.rows ?? [];
+
+  const idxPayer = cols.indexOf('payer');
+  const idxPayee = cols.indexOf('payee');
+  const idxGw = cols.indexOf('gateway');
+  const idxAmount = cols.indexOf('amount');
+  const idxData = cols.indexOf('data');
+  const idxTs = cols.indexOf('timestamp');
+  const idxTx = cols.indexOf('transactionHash');
+  const idxBn = cols.indexOf('blockNumber');
+
+  const out: PaymentRow[] = [];
+  for (const r of rows) {
+    // Skip rows where the indexer returned malformed addresses or unparseable amounts
+    // — one bad row should not blank the whole panel.
+    try {
+      const payerRaw = r[idxPayer];
+      const payeeRaw = r[idxPayee];
+      const gwRaw = r[idxGw];
+      if (!payerRaw || !payeeRaw || !gwRaw) continue;
+
+      const data = String(r[idxData] ?? '');
+      let amount: bigint = 0n;
+      try {
+        amount = BigInt(String(r[idxAmount] ?? '0'));
+      } catch {
+        amount = 0n;
+      }
+
+      out.push({
+        payer: ethers.getAddress(payerRaw) as Address,
+        payee: ethers.getAddress(payeeRaw) as Address,
+        gateway: ethers.getAddress(gwRaw) as Address,
+        amount,
+        data,
+        dataDecoded: hexToUtf8(data),
+        timestamp: Number(r[idxTs] ?? 0),
+        tx: String(r[idxTx] ?? ''),
+        blockNumber: Number(r[idxBn] ?? 0),
+      });
+    } catch (e) {
+      console.warn('[paymentReceived] skipped malformed row', e);
+    }
+  }
+
+  return out;
+}

--- a/circles-app/src/lib/shared/data/market/crcPricing.ts
+++ b/circles-app/src/lib/shared/data/market/crcPricing.ts
@@ -1,0 +1,87 @@
+import { gnosisConfig } from '$lib/shared/config/circles';
+
+export type CrcPrice = {
+  dcrc_eur: number;
+  dcrc_xdai: number;
+  date: string;
+  source: string;
+};
+
+/**
+ * Per-date in-memory cache + inflight-promise dedup so concurrent rows for the
+ * same day share one fetch. Mirrors marketplaceExplorer.html:1067-1087.
+ */
+const priceCache = new Map<string, CrcPrice | null>();
+const inflight = new Map<string, Promise<CrcPrice | null>>();
+
+function dateKey(unixTimestamp: number): string {
+  return new Date(unixTimestamp * 1000).toISOString().slice(0, 10);
+}
+
+function endpoint(): string | undefined {
+  // ring vs production share the same metrics endpoint; production is a safe default here.
+  return gnosisConfig.production.crcPricingApi;
+}
+
+const MAX_PLAUSIBLE_RATE = 100;
+function sanitizeRate(v: unknown): number | null {
+  if (typeof v !== 'number' || !isFinite(v)) return null;
+  if (v <= 0 || v > MAX_PLAUSIBLE_RATE) return null;
+  return v;
+}
+
+export async function getCrcPrice(unixTimestamp: number): Promise<CrcPrice | null> {
+  if (!isFinite(unixTimestamp) || unixTimestamp <= 0) return null;
+  const base = endpoint();
+  if (!base) return null;
+
+  const date = dateKey(unixTimestamp);
+  if (priceCache.has(date)) return priceCache.get(date)!;
+  const pending = inflight.get(date);
+  if (pending) return pending;
+
+  const p = (async (): Promise<CrcPrice | null> => {
+    try {
+      const url = `${base}?date=${date}`;
+      const resp = await fetch(url);
+      if (!resp.ok) {
+        priceCache.set(date, null);
+        return null;
+      }
+      const data = (await resp.json()) as Partial<CrcPrice> | null;
+      // Clamp upper bound: if the metrics endpoint is hijacked or returns garbage,
+      // a multiplier > 100 EUR/CRC is implausible and would produce nonsense totals.
+      const eur = sanitizeRate(data?.dcrc_eur);
+      const xdai = sanitizeRate(data?.dcrc_xdai);
+      if (eur === null && xdai === null) {
+        priceCache.set(date, null);
+        return null;
+      }
+      const out: CrcPrice = {
+        dcrc_eur: eur ?? 0,
+        dcrc_xdai: xdai ?? 0,
+        date: String(data!.date ?? date),
+        source: String(data!.source ?? ''),
+      };
+      priceCache.set(date, out);
+      return out;
+    } catch (e) {
+      console.warn('[crcPricing] fetch failed for', date, e);
+      priceCache.set(date, null);
+      return null;
+    } finally {
+      inflight.delete(date);
+    }
+  })();
+
+  inflight.set(date, p);
+  return p;
+}
+
+/** Convert CRC amount to EUR using the dcrc_eur rate, falling back to dcrc_xdai. */
+export function applyCrcRate(crc: number, price: CrcPrice | null): { eur: number; usedFallback: boolean } | null {
+  if (!price) return null;
+  if (price.dcrc_eur > 0) return { eur: crc * price.dcrc_eur, usedFallback: false };
+  if (price.dcrc_xdai > 0) return { eur: crc * price.dcrc_xdai, usedFallback: true };
+  return null;
+}


### PR DESCRIPTION
## Summary

Adds public, no-auth marketplace inspection of any avatar (human, organization, or group) directly inside the existing ProfilePopup. Three new tabs:

- **Sales** — paginated list of incoming on-chain `PaymentReceived` events filtered by payee. Stats cards show count, CRC volume, async EUR volume (one rate fetch per unique payment date), and unique buyer count.
- **Price history** — per-SKU realised CRC price chart, derived by hex-decoding the `data` column of `PaymentReceived` events to extract a SKU/reference. Capped at 20 buckets with an overflow indicator. Surfaces a caveat that listing-price changes without sales are not visible (no offer-publication event source today).
- **Gateways** — `CrcV2_PaymentGateway.GatewayCreated` rows owned by the avatar, with expandable active trust receivers per gateway.

Tab visibility is data-gated: tabs only appear when the avatar has at least one row in the corresponding dataset. Payments and gateways are loaded eagerly on address change so chips settle before the user clicks. Arrays are swapped atomically (kept stale during refetch) so the corrective `selectedTab` effect does not drop the active tab mid-load.

## Implementation notes

- New data layer: `fetchPaymentsByPayee` (circles_query → `CrcV2_PaymentGateway.PaymentReceived`, validates payee shape, skips malformed rows), `getCrcPrice` (date-keyed cache + inflight dedup, clamps rates ≤ 100, caches null on network errors).
- Reuses existing `fetchGatewayRowsByOwner` / `fetchActiveTrustRowsByGateway`.
- Catalog-side reuses the already-wired `getMarketClient().catalog.fetchSellerCatalog(...)` for the existing Offers tab — no duplication.
- Adds `CirclesConfig.crcPricingApi` with `VITE_CRC_PRICING_API` override; default points at the staging-subdomain metrics-exporter (the only host currently serving the endpoint, kept consistent with the standalone explorer tool).

## Test plan

- [x] \`npm run check\` — 0 errors (14 pre-existing warnings in admin files untouched here).
- [x] \`npm run test:e2e\` — 12/12 pass (13s).
- [x] Full workspace build — passes (~49s).
- [ ] Manual: open ProfilePopup on a known marketplace seller, confirm Sales / Price history / Gateways tabs appear, EUR volume fills in async, and clicking a buyer opens their popup. Inspect a non-seller and confirm the three tabs are hidden.
- [ ] Manual: confirm circles_query traffic hits \`rpc.aboutcircles.com\` and pricing calls hit \`rpc.staging.aboutcircles.com/metrics-api/pricing?date=YYYY-MM-DD\`.