### PR TITLE
Sequentialize admin data load; typed AdminApiError for auth short-circuit

### DIFF
--- a/circles-app/src/lib/areas/admin/services/gateway/adminClient.ts
+++ b/circles-app/src/lib/areas/admin/services/gateway/adminClient.ts
@@ -168,6 +168,31 @@ export interface UnlockProductListItem {
 // ============= API Functions =============
 
 /**
+ * Typed error for admin API responses. Carries the HTTP status so callers can
+ * distinguish 401 (re-auth required) from 403 (authenticated but not allowlisted)
+ * from other failures, and short-circuit batched loads on auth failure.
+ */
+export class AdminApiError extends Error {
+  readonly status: number;
+  readonly body: string;
+  readonly method: string;
+  readonly path: string;
+
+  constructor(method: string, path: string, status: number, body: string) {
+    super(`${method} ${path} failed (${status}): ${body}`);
+    this.name = 'AdminApiError';
+    this.status = status;
+    this.body = body;
+    this.method = method;
+    this.path = path;
+  }
+
+  isAuthFailure(): boolean {
+    return this.status === 401 || this.status === 403;
+  }
+}
+
+/**
  * Get the admin API base URL - re-exported for convenience
  */
 function getBaseUrl(): string {
@@ -182,7 +207,8 @@ async function adminFetch<T>(
   options: RequestInit = {}
 ): Promise<T> {
   const baseUrl = getBaseUrl();
-  
+  const method = options.method ?? 'GET';
+
   const res = await fetch(`${baseUrl}${path}`, {
     ...options,
     headers: {
@@ -194,7 +220,7 @@ async function adminFetch<T>(
 
   if (!res.ok) {
     const text = await res.text().catch(() => '');
-    throw new Error(`${options.method ?? 'GET'} ${path} failed (${res.status}): ${text}`);
+    throw new AdminApiError(method, path, res.status, text);
   }
 
   return res.json() as Promise<T>;
@@ -308,7 +334,7 @@ export async function listOdooProductCatalog(params: {
 
   if (!res.ok) {
     const text = await res.text().catch(() => '');
-    throw new Error(`GET /admin/odoo-product-catalog failed (${res.status}): ${text}`);
+    throw new AdminApiError('GET', '/admin/odoo-product-catalog', res.status, text);
   }
 
   return res.json() as Promise<OdooProductCatalogResponse>;

--- a/circles-app/src/routes/admin/+page.svelte
+++ b/circles-app/src/routes/admin/+page.svelte
@@ -41,6 +41,7 @@
     type OdooProductListItem,
     type CodeProductListItem,
     type UnlockProductListItem,
+    AdminApiError,
   } from '$lib/areas/admin/services/gateway/adminClient';
   import { gnosisConfig } from '$lib/shared/config/circles';
   import type { Address } from '@aboutcircles/sdk-types';
@@ -152,6 +153,11 @@
     unlockProducts = [];
   }
 
+  // Each loader stores its own error state for the UI. On auth failure (401/403)
+  // it re-throws so `loadAdminData` can short-circuit the remaining loaders —
+  // a parallel volley of admin GETs against an unauthorised user trips the
+  // CrowdSec http-admin-interface-probing scenario (capacity=2 on 403/404 of
+  // admin paths) and bans the IP for 168h. One sequential request = one event.
   async function loadRoutes(): Promise<void> {
     routesLoading = true;
     routesError = null;
@@ -163,6 +169,7 @@
       });
     } catch (e) {
       routesError = e instanceof Error ? e.message : String(e);
+      if (e instanceof AdminApiError && e.isAuthFailure()) throw e;
     } finally {
       routesLoading = false;
     }
@@ -179,6 +186,7 @@
       });
     } catch (e) {
       connectionsError = e instanceof Error ? e.message : String(e);
+      if (e instanceof AdminApiError && e.isAuthFailure()) throw e;
     } finally {
       connectionsLoading = false;
     }
@@ -189,26 +197,49 @@
     productsError = null;
 
     try {
-      const [odoo, code, unlock] = await runTask({
-        name: 'Loading products…',
-        promise: Promise.all([
-          listOdooProducts(),
-          listCodeProducts(),
-          listUnlockProducts(),
-        ]),
+      // Stage into locals; assign all three atomically on full success.
+      // Avoids mixing fresh + stale arrays in `unifiedProducts` ($derived),
+      // which feeds the new-product wizard's duplicate-detection list.
+      const odoo = await runTask({
+        name: 'Loading Odoo products…',
+        promise: listOdooProducts(),
+      });
+      const code = await runTask({
+        name: 'Loading code products…',
+        promise: listCodeProducts(),
+      });
+      const unlock = await runTask({
+        name: 'Loading Unlock products…',
+        promise: listUnlockProducts(),
       });
       odooProducts = odoo;
       codeProducts = code;
       unlockProducts = unlock;
     } catch (e) {
       productsError = e instanceof Error ? e.message : String(e);
+      if (e instanceof AdminApiError && e.isAuthFailure()) throw e;
     } finally {
       productsLoading = false;
     }
   }
 
   async function loadAdminData(): Promise<void> {
-    await Promise.all([loadRoutes(), loadConnections(), loadProducts()]);
+    try {
+      await loadRoutes();
+      await loadConnections();
+      await loadProducts();
+    } catch (e) {
+      // A loader re-threw an auth failure to short-circuit the chain.
+      // Per-loader error state is already populated for the UI.
+      // For 401 (token unusable: stale, expired, or invalidated) drop back to
+      // the login card so the user has a clear re-auth path. For 403 we keep
+      // the session — the token is valid, the addr is just not on the admin
+      // allowlist, and re-auth would mint the same unprivileged token.
+      if (e instanceof AdminApiError && e.status === 401) {
+        clearAdminToken();
+        adminUser = null;
+      }
+    }
   }
 
   function openProductEditor(


### PR DESCRIPTION
## Summary
- Replace two parallel `Promise.all` fetches on the admin page with sequential `await` chains. The page used to fire 5 admin GETs on mount; non-allowlisted users would generate 5 simultaneous 403s, tripping CrowdSec's `http-admin-interface-probing` scenario (capacity=2 on 404/403 of admin paths) and triggering a 168h firewall ban at the network layer.
- Introduce `AdminApiError extends Error` carrying `.status`, `.body`, `.method`, `.path` and `.isAuthFailure()`. Loaders re-throw on 401/403 so `loadAdminData` short-circuits — one admin request reaches the server instead of five.
- On 401, clear the admin token and drop back to the login card. On 403, preserve the session (the token is valid; the addr is just not on the allowlist, and re-auth mints the same unprivileged token).
- `loadProducts` stages the three sequential fetches into locals and assigns all three reactive arrays atomically on success. Prevents mid-failure leaving `odooProducts` fresh while `codeProducts`/`unlockProducts` retain stale values, which would feed mixed-vintage data into the `$derived` `unifiedProducts` consumed by the new-product wizard's duplicate-detection list.

## Details
market-api correctly returns 401 for missing/invalid auth and 403 for "authenticated but not in admin allowlist" (verified by probe). The root cause was purely client-side load shaping: the admin SPA fanning out 5 parallel requests before the user's authorisation status was known, so a single page load could generate enough admin-path 403s to cross the CrowdSec scenario threshold across multiple DNS-pool members at once.

Happy-path cost: one extra sequential round-trip compared to parallel; finer per-stage progress feedback in the UI. Auth-failure cost: 4 admin requests avoided per failed page load.

## Test plan
- [x] \`npm run check\` — no new errors/warnings in the edited files
- [x] Confirm \`instanceof AdminApiError\` works under the project's ES2020/esnext target
- [x] Verify \`productsLoading\` / \`routesLoading\` / \`connectionsLoading\` cleared on every code path
- [x] Verify each loader's per-section error state is populated before re-throwing — outer catch never masks an unsurfaced failure
- [ ] Manual smoke on Netlify preview: log in as a non-admin address, confirm the page surfaces a 403 in section error state and no parallel volley fires (DevTools Network: at most one admin request before the chain stops)
- [ ] Manual smoke with a valid admin address: all three sections load sequentially, no regression vs prior behaviour