### PR TITLE
chore: add build:packages script to root

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,6 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.58.2",
-        "@safe-global/protocol-kit": "^6.1.2",
         "@sveltejs/adapter-auto": "^7.0.0",
         "@sveltejs/adapter-netlify": "^5.2.4",
         "@sveltejs/adapter-node": "^5.5.2",
@@ -1780,25 +1779,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "circles-app/node_modules/@safe-global/protocol-kit": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@safe-global/protocol-kit/-/protocol-kit-6.1.2.tgz",
-      "integrity": "sha512-cTpPdUAS2AMfGCkD1T601rQNjT0rtMQLA2TH7L/C+iFPAC6WrrDFop2B9lzeHjczlnVzrRpfFe4cL1bLrJ9NZw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@safe-global/safe-deployments": "^1.37.49",
-        "@safe-global/safe-modules-deployments": "^2.2.21",
-        "@safe-global/types-kit": "^3.0.0",
-        "abitype": "^1.0.2",
-        "semver": "^7.7.2",
-        "viem": "^2.21.8"
-      },
-      "optionalDependencies": {
-        "@noble/curves": "^1.6.0",
-        "@peculiar/asn1-schema": "^2.3.13"
       }
     },
     "circles-app/node_modules/@safe-global/safe-apps-provider": {
@@ -6297,27 +6277,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@peculiar/asn1-schema": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.6.0.tgz",
-      "integrity": "sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "asn1js": "^3.0.6",
-        "pvtsutils": "^1.3.6",
-        "tslib": "^2.8.1"
-      }
-    },
-    "node_modules/@peculiar/asn1-schema/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
-    },
     "node_modules/@playwright/test": {
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
@@ -6894,16 +6853,6 @@
       "integrity": "sha512-HxVSX2F3yHvtwm85KlRpM4QXnnq1LDXZZKs5X2+Ip9DeQX+xXSRm9MjHED7ZdCdxXT/Sfga/2vmKsnoSU1t/lA==",
       "license": "MIT"
     },
-    "node_modules/@safe-global/types-kit": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@safe-global/types-kit/-/types-kit-3.0.0.tgz",
-      "integrity": "sha512-AZWIlR5MguDPdGiOj7BB4JQPY2afqmWQww1mu8m8Oi16HHBW99G01kFOu4NEHBwEU1cgwWOMY19hsI5KyL4W2w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "abitype": "^1.0.2"
-      }
-    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -7434,30 +7383,6 @@
       "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/asn1js": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.7.tgz",
-      "integrity": "sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "dependencies": {
-        "pvtsutils": "^1.3.6",
-        "pvutils": "^1.1.3",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/asn1js/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
     },
     "node_modules/assert": {
       "version": "2.1.0",
@@ -10731,36 +10656,6 @@
       "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/pvtsutils": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
-      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.8.1"
-      }
-    },
-    "node_modules/pvtsutils/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
-    },
-    "node_modules/pvutils": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
-      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=16.0.0"
-      }
     },
     "node_modules/qs": {
       "version": "6.14.1",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
     "packages/*",
     "circles-app"
   ],
+  "scripts": {
+    "build:packages": "npm --workspaces --if-present run build"
+  },
   "engines": {
     "node": ">=18"
   }


### PR DESCRIPTION
## Summary
- Adds `build:packages` script to root `package.json` so the workspace packages can be built from the repo root with a single npm command. Mirrors the existing pattern on `dev`.
- Prunes stale `@safe-global/protocol-kit` v6 entries from `package-lock.json` (residual from the v6 → v5 dependency cleanup; `npm install` regenerated the lockfile).

## Details
The current DO build_command (`npm run build`, run inside `circles-app/`) is **unchanged and unaffected** by this PR. The new script enables a future workspace-aware deploy command (`cd .. && npm install && npm run build:packages && cd circles-app && npm run build`) without breaking the existing setup. Landing this first lets the next deploy-config change happen with zero failure window.

## Test plan
- [x] `npm install` regenerates lockfile cleanly (only pruning, no new packages)
- [ ] Auto-deploy on merge succeeds with the unchanged build_command
- [ ] `npm run build:packages` succeeds from repo root in a DO-equivalent env (verified separately when the next deploy spec change lands)