### PR TITLE
fix(vite): remove adapter-node polyfill externalization that breaks client bundle

### DIFF
--- a/circles-app/vite.config.ts
+++ b/circles-app/vite.config.ts
@@ -22,26 +22,11 @@ export default defineConfig({
       },
     },
   },
-  resolve: {
-    alias: {
-      // Fix SDK runner import of vite polyfill shims
-      'vite-plugin-node-polyfills/shims/global': 'vite-plugin-node-polyfills/shims/global',
-    },
-  },
   ssr: {
     // @safe-global/protocol-kit is CJS and its internal require('abitype')
     // gets converted to a default import that ESM-only abitype doesn't export.
     // Externalizing lets Node handle the interop at runtime.
     // The app is SSR-disabled (ssr:false) so these aren't needed server-side.
     external: ['@safe-global/protocol-kit', '@safe-global/safe-core-sdk-types', 'abitype'],
-  },
-  build: {
-    rollupOptions: {
-      // With adapter-node, polyfill shims can be externalized (Node resolves at runtime).
-      // With adapter-static, they MUST be bundled — browsers can't resolve bare specifiers.
-      ...(process.env.ADAPTER === 'node'
-        ? { external: (id: string) => id.includes('vite-plugin-node-polyfills/shims') }
-        : {}),
-    },
   },
 });


### PR DESCRIPTION
## Summary
Backport of the vite.config.ts fix landed on `main` via #176, so dev doesn't regress the same bug on its next sync.

## Details
`build.rollupOptions.external` applies to **both** the client and the server bundles in vite. The conditional externalization of `vite-plugin-node-polyfills/shims/*` when `ADAPTER=node` was leaking a bare `import 'vite-plugin-node-polyfills/shims/global'` into the client bundle (chunk `BJT4BECd.js` in the failed deploy). Browser can't resolve bare module specifiers — TypeError on hydration. The fix removes the block.

Also drops the inert `resolve.alias` self-mapping (`vite-plugin-node-polyfills/shims/global` → itself), which was a no-op.

## Impact
- **dev / Netlify (adapter-static):** no behavior change — bug doesn't manifest with adapter-static.
- **prod / DigitalOcean (adapter-node):** would have regressed on any future dev→main merge without this fix.

## Verification
Reproduced and verified on #176's local ADAPTER=node build: 285 client chunks, zero containing a bare polyfill import.

## Test plan
- [ ] Netlify deploy-preview goes green
- [ ] app.circlesubi.network continues to work after merge