### PR TITLE
feat(send): favorites in recipient picker with optional public-profile sync

### DIFF
--- a/circles-app/src/lib/shared/ui/avatar-search/AvatarSearchList.svelte
+++ b/circles-app/src/lib/shared/ui/avatar-search/AvatarSearchList.svelte
@@ -1,12 +1,18 @@
 <script lang="ts">
   import { setContext } from 'svelte';
   import { ethers } from 'ethers';
+  import { avatarState } from '$lib/shared/state/avatar.svelte';
   import { get, writable } from 'svelte/store';
   import type { Address } from '@aboutcircles/sdk-types';
   import type { SearchProfileResult } from '$lib/shared/model/profile';
   import { circles } from '$lib/shared/state/circles';
   import { contacts } from '$lib/shared/state/contacts';
-  import { profileBookmarksStore } from '$lib/areas/settings/state/profileBookmarks';
+  import {
+    profileBookmarksService,
+    profileBookmarksStore,
+    profileBookmarksUnpublishedChangesStore,
+  } from '$lib/areas/settings/state/profileBookmarks';
+  import { openConfirmPopup, openInfoPopup } from '$lib/shared/ui/shell/confirmDialogs';
   import { SEARCH_POLICY } from '$lib/shared/ui/lists/utils/searchPolicies';
   import { createPaginatedList } from '$lib/shared/state/paginatedList';
   import GenericList from '$lib/shared/ui/lists/GenericList.svelte';
@@ -106,6 +112,127 @@
 
   const showEmpty = $derived(!remoteLoading && queryTrimmed.length > 0 && mergedRows.length === 0);
   const canInviteTrust = $derived(ethers.isAddress(queryTrimmed) && searchType === 'contact');
+
+  const isQueryEmpty = $derived(queryTrimmed.length === 0);
+  const vipRows = $derived(isQueryEmpty ? preferredRows.filter((r) => r.isVipBookmarked) : []);
+  const favoriteRows = $derived(
+    isQueryEmpty ? preferredRows.filter((r) => r.isBookmarked && !r.isVipBookmarked) : []
+  );
+  const contactRows = $derived(
+    isQueryEmpty
+      ? preferredRows.filter((r) => r.isContact && !r.isBookmarked && !r.isVipBookmarked)
+      : []
+  );
+
+  const queryAddressLower = $derived(
+    ethers.isAddress(queryTrimmed) ? queryTrimmed.toLowerCase() : null
+  );
+  const queryAddressIsBookmarked = $derived.by((): boolean => {
+    if (!queryAddressLower) return false;
+    const list = $profileBookmarksStore ?? [];
+    return list.some((b) => b.address === queryAddressLower);
+  });
+  const queryAddressInMergedRows = $derived.by((): boolean => {
+    if (!queryAddressLower) return false;
+    return mergedRows.some((r) => String(r.address).toLowerCase() === queryAddressLower);
+  });
+  const showAddToFavoritesCta = $derived(
+    !!queryAddressLower && !queryAddressIsBookmarked && !queryAddressInMergedRows
+  );
+
+  const hasUnpublishedChanges = $derived($profileBookmarksUnpublishedChangesStore);
+  const totalLocalBookmarks = $derived(($profileBookmarksStore ?? []).length);
+  const currentOwnerKey = $derived(
+    (avatarState.avatar?.address ?? '').toLowerCase() || null
+  );
+  let pulledForOwner: string | null = $state(null);
+  let pulling = $state(false);
+  let pullError: string | null = $state(null);
+  let syncing = $state(false);
+  const baselineKnown = $derived(
+    !!currentOwnerKey && pulledForOwner === currentOwnerKey && !pullError
+  );
+  const showSyncFooter = $derived(
+    isQueryEmpty && hasUnpublishedChanges && totalLocalBookmarks > 0 && !pulling
+  );
+  const canPublish = $derived(baselineKnown);
+
+  $effect(() => {
+    const owner = currentOwnerKey;
+    if (!owner) return;
+    if (pulledForOwner === owner || pulling) return;
+    void pullFromProfile({ silent: true });
+  });
+
+  async function pullFromProfile(opts: { silent: boolean }): Promise<void> {
+    if (pulling) return;
+    const ownerAtStart = currentOwnerKey;
+    if (!ownerAtStart) return;
+    pulling = true;
+    pullError = null;
+    try {
+      await profileBookmarksService.syncFromProfile();
+      if (currentOwnerKey === ownerAtStart) {
+        pulledForOwner = ownerAtStart;
+      }
+    } catch (e) {
+      pullError = e instanceof Error ? e.message : 'Unknown error';
+      if (!opts.silent) {
+        await openInfoPopup({
+          title: 'Could not load favorites from profile',
+          message: pullError,
+          tone: 'error',
+        });
+      }
+    } finally {
+      pulling = false;
+    }
+  }
+
+  function addQueryAddressToFavorites(): void {
+    if (!queryAddressLower) return;
+    profileBookmarksService.upsertProfile(queryAddressLower);
+  }
+
+  async function onSyncToProfileClick(): Promise<void> {
+    if (syncing) return;
+    if (!canPublish) {
+      await openInfoPopup({
+        title: 'Cannot save favorites yet',
+        message:
+          'We could not check your profile for existing favorites. Saving now might overwrite a list saved from another device. Please retry the load first.',
+        tone: 'warning',
+      });
+      return;
+    }
+    const confirmed = await openConfirmPopup({
+      title: 'Sync favorites to your profile',
+      message:
+        "Your favorites will be saved to your public Circles profile on IPFS. Anyone who looks up your address can read this list. Continue?",
+      confirmLabel: 'Sync now',
+      cancelLabel: 'Keep local',
+    });
+    if (!confirmed) return;
+
+    syncing = true;
+    try {
+      await profileBookmarksService.publishToProfile();
+      await openInfoPopup({
+        title: 'Favorites synced',
+        message: 'Your favorites are now saved to your Circles profile.',
+        tone: 'success',
+      });
+    } catch (e) {
+      const detail = e instanceof Error ? e.message : 'Unknown error';
+      await openInfoPopup({
+        title: 'Sync failed',
+        message: `Could not sync favorites: ${detail}`,
+        tone: 'error',
+      });
+    } finally {
+      syncing = false;
+    }
+  }
 
   $effect(() => {
     if (queryTrimmed.length === 0 && Object.keys(resultByAddress).length > 0) {
@@ -232,9 +359,6 @@
   >
     <div class="-mt-1 mb-3 text-xs text-base-content/60 flex items-center gap-2">
       <span>{preferredRows.length} result(s)</span>
-      {#if queryTrimmed.length === 0}
-        <span>• Showing bookmarks and contacts first</span>
-      {/if}
       {#if queryTrimmed.length > 0 && queryTrimmed.length < minRemoteLength}
         <span>• Type at least {minRemoteLength} chars for remote search</span>
       {/if}
@@ -246,7 +370,40 @@
       {/if}
     </div>
 
-    {#if preferredRows.length > 0}
+    {#if isQueryEmpty && preferredRows.length > 0}
+      {#if vipRows.length > 0}
+        <p class="menu-title pl-0 text-xs uppercase tracking-wider text-warning mt-1 mb-1">
+          ★ VIPs
+        </p>
+        <div class="mb-2">
+          {#each vipRows as row (row.key)}
+            <AvatarSearchRow item={row} />
+          {/each}
+        </div>
+      {/if}
+
+      {#if favoriteRows.length > 0}
+        <p class="menu-title pl-0 text-xs uppercase tracking-wider text-warning mt-1 mb-1">
+          ★ Favorites
+        </p>
+        <div class="mb-2">
+          {#each favoriteRows as row (row.key)}
+            <AvatarSearchRow item={row} />
+          {/each}
+        </div>
+      {/if}
+
+      {#if contactRows.length > 0}
+        <p class="menu-title pl-0 text-xs uppercase tracking-wider text-base-content/60 mt-1 mb-1">
+          Contacts
+        </p>
+        <div>
+          {#each contactRows as row (row.key)}
+            <AvatarSearchRow item={row} />
+          {/each}
+        </div>
+      {/if}
+    {:else if preferredRows.length > 0}
       <GenericList
         store={paginatedRows}
         row={AvatarSearchRow}
@@ -256,6 +413,13 @@
         expectedPageSize={PAGE_SIZE}
         placeholderRow={AvatarRowPlaceholder}
       />
+      {#if showAddToFavoritesCta}
+        <div class="mt-2 text-center">
+          <button class="btn btn-sm btn-outline btn-warning" onclick={addQueryAddressToFavorites}>
+            ☆ Add {queryTrimmed.slice(0, 6)}…{queryTrimmed.slice(-4)} to favorites
+          </button>
+        </div>
+      {/if}
     {:else if showEmpty}
       <div class="text-center py-4">
         {#if canInviteTrust}
@@ -267,6 +431,71 @@
         {:else}
           <p>No accounts found.</p>
         {/if}
+        {#if showAddToFavoritesCta}
+          <div class="mt-3">
+            <button class="btn btn-sm btn-outline btn-warning" onclick={addQueryAddressToFavorites}>
+              ☆ Add {queryTrimmed.slice(0, 6)}…{queryTrimmed.slice(-4)} to favorites
+            </button>
+          </div>
+        {/if}
+      </div>
+    {:else if isQueryEmpty}
+      <div class="text-center py-4 text-sm text-base-content/60">
+        <p>No favorites or contacts yet.</p>
+        <p class="mt-1">Paste an address above or search by name to send Circles.</p>
+      </div>
+    {/if}
+
+    {#if pulling && isQueryEmpty}
+      <div class="mt-4 border-t border-base-300 pt-3 text-xs text-base-content/60 flex items-center gap-2">
+        <span class="loading loading-spinner loading-xs" aria-hidden="true"></span>
+        <span>Loading favorites from your profile…</span>
+      </div>
+    {:else if showSyncFooter}
+      <div class="mt-4 border-t border-base-300 pt-3 text-xs text-base-content/70 space-y-2">
+        <div class="flex items-start justify-between gap-3">
+          <div class="space-y-0.5">
+            <p class="font-medium text-base-content/80">
+              {baselineKnown
+                ? 'Local changes not yet saved to your public profile.'
+                : pullError
+                  ? 'Cannot check your profile for existing favorites.'
+                  : 'Favorites are saved on this device only.'}
+            </p>
+            <p class="text-base-content/60">
+              Saving copies the list to your <span class="font-medium">public Circles profile</span> on IPFS — anyone who looks up your address can read it.
+            </p>
+          </div>
+          <button
+            type="button"
+            class="btn btn-ghost btn-xs whitespace-nowrap"
+            disabled={syncing || !canPublish}
+            title={!canPublish && pullError ? 'Retry loading from profile first to avoid overwriting' : undefined}
+            onclick={onSyncToProfileClick}
+          >
+            {#if syncing}
+              <span class="loading loading-spinner loading-xs" aria-hidden="true"></span>
+              Saving…
+            {:else}
+              {baselineKnown ? 'Update public profile' : 'Save to public profile'}
+            {/if}
+          </button>
+        </div>
+        {#if pullError}
+          <p class="text-error/80">
+            Could not check your profile for existing favorites ({pullError}).
+            <button type="button" class="link link-hover ml-1" onclick={() => pullFromProfile({ silent: false })}>
+              Retry
+            </button>
+          </p>
+        {/if}
+      </div>
+    {:else if isQueryEmpty && pullError && totalLocalBookmarks === 0}
+      <div class="mt-4 border-t border-base-300 pt-3 text-xs text-error/80">
+        Could not load favorites from your profile ({pullError}).
+        <button type="button" class="link link-hover ml-1" onclick={() => pullFromProfile({ silent: false })}>
+          Retry
+        </button>
       </div>
     {/if}
   </ListShell>

--- a/circles-app/src/lib/shared/ui/avatar-search/AvatarSearchRow.svelte
+++ b/circles-app/src/lib/shared/ui/avatar-search/AvatarSearchRow.svelte
@@ -4,6 +4,11 @@
   import RowFrame from '$lib/shared/ui/primitives/RowFrame.svelte';
   import { formatTrustRelation } from '$lib/shared/utils/helpers';
   import { createKeyboardListNavigator } from '$lib/shared/ui/lists/utils/keyboardListNavigator';
+  import {
+    profileBookmarksService,
+    profileBookmarksStore,
+    type ProfileBookmark,
+  } from '$lib/areas/settings/state/profileBookmarks';
   import type { AvatarSearchItem } from './avatarSearch.types';
 
   const ACTIVATE_CTX_KEY = 'avatar-search-row-activate';
@@ -48,39 +53,152 @@
     runActivate();
   }
 
-  const bottomInfo = $derived(item.trustRelation ? formatTrustRelation(item.trustRelation) : '');
-
-  /** Pre-computed avatar info shape for potential future use (Avatar component doesn't consume it yet) */
-  const avatarInfo = $derived.by((): { avatar: string; type: string } | undefined => {
-    if (!item.avatarType) return undefined;
-    return {
-      avatar: item.address,
-      type: item.avatarType,
-    };
+  const bookmarkEntry = $derived.by((): ProfileBookmark | undefined => {
+    const list = $profileBookmarksStore ?? [];
+    const target = String(item.address).toLowerCase();
+    return list.find((b) => b.address === target);
   });
+  const isFavorite = $derived(!!bookmarkEntry);
+  const note = $derived(bookmarkEntry?.note ?? '');
+
+  let editingNote = $state(false);
+  let noteDraft = $state('');
+  let noteInputEl: HTMLInputElement | null = $state(null);
+  let cancellingEdit = $state(false);
+
+  function toggleFavorite(event: MouseEvent | KeyboardEvent): void {
+    event.preventDefault();
+    event.stopPropagation();
+    if (isFavorite) {
+      profileBookmarksService.removeProfile(item.address);
+      if (editingNote) editingNote = false;
+    } else {
+      profileBookmarksService.upsertProfile(item.address);
+    }
+  }
+
+  function startEditNote(event: MouseEvent | KeyboardEvent): void {
+    event.preventDefault();
+    event.stopPropagation();
+    noteDraft = note;
+    editingNote = true;
+    queueMicrotask(() => noteInputEl?.focus());
+  }
+
+  function commitNote(): void {
+    if (cancellingEdit) {
+      cancellingEdit = false;
+      editingNote = false;
+      noteDraft = '';
+      return;
+    }
+    if (!isFavorite) {
+      editingNote = false;
+      noteDraft = '';
+      return;
+    }
+    const next = noteDraft.trim();
+    profileBookmarksService.upsertProfile(item.address, { note: next.length ? next : undefined });
+    editingNote = false;
+  }
+
+  function cancelEditNote(): void {
+    cancellingEdit = true;
+    editingNote = false;
+    noteDraft = '';
+  }
+
+  function onNoteKeydown(event: KeyboardEvent): void {
+    event.stopPropagation();
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      commitNote();
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      cancelEditNote();
+    }
+  }
+
+  const bottomInfo = $derived(
+    note.length > 0
+      ? note
+      : item.trustRelation
+        ? formatTrustRelation(item.trustRelation)
+        : ''
+  );
 </script>
 
-<div
-  data-avatar-search-row
-  tabindex={0}
-  role="button"
-  aria-label={`Open profile for ${item.address}`}
-  class="rounded-[var(--row-radius)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
-  onkeydown={onRowKeydown}
-  onclick={onRowClick}
->
-  <RowFrame clickable={true} dense={true} noLeading={true}>
-    <div class="min-w-0">
-      <Avatar
-        address={item.address}
-        view="horizontal"
-        bottomInfo={bottomInfo}
-        showTypeInfo={true}
-        clickable={true}
+<div>
+  <div
+    data-avatar-search-row
+    tabindex={0}
+    role="button"
+    aria-label={`Open profile for ${item.address}`}
+    class="rounded-[var(--row-radius)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+    onkeydown={onRowKeydown}
+    onclick={onRowClick}
+  >
+    <RowFrame clickable={true} dense={true} noLeading={true}>
+      <div class="min-w-0">
+        <Avatar
+          address={item.address}
+          view="horizontal"
+          bottomInfo={bottomInfo}
+          showTypeInfo={true}
+          clickable={true}
+        />
+      </div>
+      {#snippet trailing()}
+        <div class="flex items-center gap-1" onclick={(e) => e.stopPropagation()} role="presentation">
+          {#if isFavorite}
+            <button
+              type="button"
+              class="btn btn-ghost btn-xs btn-square text-base-content/60 hover:text-base-content"
+              aria-label={editingNote ? 'Cancel editing nickname' : 'Edit nickname'}
+              title={editingNote ? 'Cancel editing nickname' : 'Edit nickname'}
+              onclick={(e) => (editingNote ? cancelEditNote() : startEditNote(e))}
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-4 w-4" aria-hidden="true">
+                <path d="M2.695 14.762l-1.262 3.155a.5.5 0 00.65.65l3.155-1.262a4 4 0 001.343-.886L17.5 5.501a2.121 2.121 0 00-3-3L3.58 13.42a4 4 0 00-.885 1.343z" />
+              </svg>
+            </button>
+          {/if}
+          <button
+            type="button"
+            class="btn btn-ghost btn-xs btn-square {isFavorite ? 'text-warning' : 'text-base-content/40 hover:text-warning'}"
+            aria-label={isFavorite ? 'Remove from favorites' : 'Add to favorites'}
+            aria-pressed={isFavorite}
+            title={isFavorite ? 'Remove from favorites' : 'Add to favorites'}
+            onclick={toggleFavorite}
+          >
+            {#if isFavorite}
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-4 w-4" aria-hidden="true">
+                <path d="M10 1.5l2.6 5.27 5.82.85-4.21 4.1.99 5.8L10 14.77l-5.2 2.74.99-5.8L1.58 7.62l5.82-.85L10 1.5z" />
+              </svg>
+            {:else}
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" class="h-4 w-4" aria-hidden="true">
+                <path d="M10 2.5l2.39 4.85 5.35.78-3.87 3.77.91 5.33L10 14.7l-4.78 2.53.91-5.33L2.26 8.13l5.35-.78L10 2.5z" />
+              </svg>
+            {/if}
+          </button>
+        </div>
+      {/snippet}
+    </RowFrame>
+  </div>
+
+  {#if isFavorite && editingNote}
+    <div class="px-2 pb-3 -mt-1" onclick={(e) => e.stopPropagation()} role="presentation">
+      <input
+        bind:this={noteInputEl}
+        bind:value={noteDraft}
+        type="text"
+        placeholder="Nickname (e.g. Mom's wallet)"
+        maxlength={64}
+        class="input input-sm input-bordered w-full"
+        onkeydown={onNoteKeydown}
+        onblur={commitNote}
+        aria-label="Nickname for this favorite"
       />
     </div>
-    {#snippet trailing()}<div aria-hidden="true">
-      <img src="/chevron-right.svg" alt="" class="h-4 w-4 opacity-70" aria-hidden="true" />
-    </div>{/snippet}
-  </RowFrame>
+  {/if}
 </div>


### PR DESCRIPTION
## Summary

- Adds a star toggle, sectioned recipient list (`★ FAVORITES` / `CONTACTS`), inline nickname editor, and a raw-address bookmarking CTA to the Send recipient picker. Surfaces the existing `profileBookmarksService` data layer.
- Auto-pulls the connected avatar's remote favorites from their Circles profile on IPFS at mount and on owner change. Tracks the pulled owner so a stale baseline cannot overwrite a remote list.
- Sync-to-profile footer is state-aware: distinguishes "never pulled" / "pull failed" / "diverged from remote" / "in flight". The publish CTA is disabled until a successful pull has set a baseline for the connected owner. A second-layer confirm dialog reinforces the public-IPFS visibility before signing.

## Touched files

- `circles-app/src/lib/shared/ui/avatar-search/AvatarSearchRow.svelte`
- `circles-app/src/lib/shared/ui/avatar-search/AvatarSearchList.svelte`

## Test plan

- [ ] Open the Send flow on the Dashboard; empty query shows `★ FAVORITES` (if any) and `CONTACTS` section headers
- [ ] Tap a row's star → row moves into the FAVORITES section; reload → favorite persists in localStorage
- [ ] Tap pencil → inline nickname input renders; type a nickname and press Enter → renders as the row subtitle
- [ ] Press Escape while editing a nickname → draft discarded, no upsert fires
- [ ] Click the pencil's "Cancel editing nickname" toggle → draft discarded
- [ ] Paste an arbitrary `0x…` address not in contacts → synthetic row renders; `☆ Add 0x…… to favorites` CTA appears below
- [ ] Paste an address that matches an already-rendered row → CTA is suppressed (no duplicate path)
- [ ] When connected: footer copy says "Local changes not yet saved to your public profile" after a successful auto-pull; publish CTA is enabled
- [ ] When the auto-pull fails: publish CTA is disabled with a Retry link; clicking the disabled button surfaces a warning popup rather than silently overwriting remote
- [ ] Confirm dialog before publish states "saved to your public Circles profile on IPFS — anyone who looks up your address can read this list"