### PR TITLE
fix(send): cancel button for nickname editor must not commit on blur

### DIFF
--- a/circles-app/src/lib/shared/ui/avatar-search/AvatarSearchRow.svelte
+++ b/circles-app/src/lib/shared/ui/avatar-search/AvatarSearchRow.svelte
@@ -80,9 +80,14 @@
   function startEditNote(event: MouseEvent | KeyboardEvent): void {
     event.preventDefault();
     event.stopPropagation();
+    cancellingEdit = false;
     noteDraft = note;
     editingNote = true;
     queueMicrotask(() => noteInputEl?.focus());
+  }
+
+  function markCancelOnMousedown(): void {
+    cancellingEdit = true;
   }
 
   function commitNote(): void {
@@ -150,13 +155,26 @@
       </div>
       {#snippet trailing()}
         <div class="flex items-center gap-1" onclick={(e) => e.stopPropagation()} role="presentation">
-          {#if isFavorite}
+          {#if isFavorite && editingNote}
             <button
               type="button"
               class="btn btn-ghost btn-xs btn-square text-base-content/60 hover:text-base-content"
-              aria-label={editingNote ? 'Cancel editing nickname' : 'Edit nickname'}
-              title={editingNote ? 'Cancel editing nickname' : 'Edit nickname'}
-              onclick={(e) => (editingNote ? cancelEditNote() : startEditNote(e))}
+              aria-label="Cancel editing nickname"
+              title="Cancel editing nickname"
+              onmousedown={markCancelOnMousedown}
+              onclick={cancelEditNote}
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" class="h-4 w-4" aria-hidden="true">
+                <path d="M5 5l10 10M15 5L5 15" />
+              </svg>
+            </button>
+          {:else if isFavorite}
+            <button
+              type="button"
+              class="btn btn-ghost btn-xs btn-square text-base-content/60 hover:text-base-content"
+              aria-label="Edit nickname"
+              title="Edit nickname"
+              onclick={startEditNote}
             >
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-4 w-4" aria-hidden="true">
                 <path d="M2.695 14.762l-1.262 3.155a.5.5 0 00.65.65l3.155-1.262a4 4 0 001.343-.886L17.5 5.501a2.121 2.121 0 00-3-3L3.58 13.42a4 4 0 00-.885 1.343z" />


### PR DESCRIPTION
## Summary

- Splits the toggle pencil button on each favorite recipient row into two dedicated buttons (Edit / Cancel) so its onclick cannot be misrouted by mid-flight state changes.
- Sets the `cancellingEdit` guard flag in the Cancel button's `onmousedown` so it precedes the input's `blur` → `commitNote` path. Previously the toggle's onclick read `editingNote` after `commit` had already flipped it, so Cancel re-opened the editor with the just-saved draft.
- `startEditNote` resets `cancellingEdit` to keep subsequent commits valid after a cancel.

## Touched files

- `circles-app/src/lib/shared/ui/avatar-search/AvatarSearchRow.svelte`

## Test plan

- [ ] Star a contact → pencil icon appears next to the gold star
- [ ] Click pencil → input opens, dedicated 'Cancel editing nickname' (×) button replaces the pencil
- [ ] Type into the input, click Cancel → draft discarded, input closes, no note persisted to `Circles.Bookmarks`
- [ ] Press Escape inside the input → same behavior (already worked before this fix)
- [ ] Press Enter inside the input → note saved and renders under the contact name
- [ ] Click pencil after a cancel → fresh empty input (no stale draft)