### PR TITLE
fix(groups): list group members via getGroupMembers RPC

### DIFF
--- a/circles-app/src/lib/areas/contacts/ui/components/CommonConnections.svelte
+++ b/circles-app/src/lib/areas/contacts/ui/components/CommonConnections.svelte
@@ -7,6 +7,8 @@
   import { circles } from '$lib/shared/state/circles';
   import type { Address } from '@aboutcircles/sdk-types';
   import { getAggregatedTrustRelationsEnriched, type TrustRelationInfo } from '$lib/shared/utils/sdkHelpers';
+  import { createGroupDataSource } from '$lib/shared/data/circles/groupDataSource';
+  import { isGroupType } from '$lib/shared/utils/avatarHelpers';
 
   interface Props {
     otherAvatarAddress?: Address;
@@ -32,47 +34,55 @@
         return;
       }
 
-      // Use enriched trust relations - includes avatar info in single call
-      const [mine, theirs] = await Promise.all([
-        getAggregatedTrustRelationsEnriched($circles, me),
-        getAggregatedTrustRelationsEnriched($circles, other),
-      ]);
+      // For groups the "trusts" set IS the member list, sourced from
+      // V_CrcV2.GroupMemberships. The trust-relations view doesn't include
+      // group→member edges under the new SDK.
+      const groupDataSource = createGroupDataSource($circles);
 
-      // Combine mutual + trusts (outgoing trust) for "good" relations
-      // SDK may return undefined instead of empty arrays
-      let myTrusted = (mine.results || []).filter((r: any) => r.relationType === 'mutual' || r.relationType === 'trusts');
-      let theirTrusted = (theirs.results || []).filter((r: any) => r.relationType === 'mutual' || r.relationType === 'trusts');
-
-      // Fallback: If enriched returns empty but user has trust relations (known backend bug)
-      if (myTrusted.length === 0 && avatarState.avatar?.trust?.getAll) {
-        try {
-          const myFallback = await avatarState.avatar.trust.getAll();
-          if (myFallback && myFallback.length > 0) {
-            myTrusted = myFallback
-              .filter((r: any) => r.relation === 'mutuallyTrusts' || r.relation === 'trusts')
-              .map((r: any) => ({ address: r.objectAvatar as Address, relationType: r.relation === 'mutuallyTrusts' ? 'mutual' as const : 'trusts' as const }));
-          }
-        } catch {
-          // Fallback failed — continue with empty list
+      const trustedAddressesFor = async (
+        addr: Address,
+        isSelf: boolean
+      ): Promise<TrustRelationInfo[]> => {
+        const info = await $circles.data.getAvatar(addr).catch(() => null);
+        if (isGroupType(info?.type)) {
+          const members = await groupDataSource.getGroupMembers(addr);
+          return members.map((row) => ({
+            address: row.member as Address,
+            relationType: 'trusts' as const,
+          }));
         }
-      }
 
-      if (theirTrusted.length === 0) {
-        try {
-          // Get an avatar instance for the other address to access trust.getAll()
-          const otherAvatar = await $circles.getAvatar(other);
-          if (otherAvatar?.trust?.getAll) {
-            const theirFallback = await otherAvatar.trust.getAll();
-            if (theirFallback && theirFallback.length > 0) {
-              theirTrusted = theirFallback
+        const enriched = await getAggregatedTrustRelationsEnriched($circles, addr);
+        let trusted = (enriched.results || []).filter(
+          (r: any) => r.relationType === 'mutual' || r.relationType === 'trusts'
+        );
+
+        // Fallback: If enriched returns empty but the avatar has trust relations (known backend bug)
+        if (trusted.length === 0) {
+          try {
+            const avatarInstance = isSelf
+              ? avatarState.avatar
+              : await $circles.getAvatar(addr);
+            const fallback = await avatarInstance?.trust?.getAll?.();
+            if (fallback && fallback.length > 0) {
+              trusted = fallback
                 .filter((r: any) => r.relation === 'mutuallyTrusts' || r.relation === 'trusts')
-                .map((r: any) => ({ address: r.objectAvatar as Address, relationType: r.relation === 'mutuallyTrusts' ? 'mutual' as const : 'trusts' as const }));
+                .map((r: any) => ({
+                  address: r.objectAvatar as Address,
+                  relationType: r.relation === 'mutuallyTrusts' ? 'mutual' as const : 'trusts' as const,
+                }));
             }
+          } catch {
+            // Fallback failed — continue with empty list
           }
-        } catch {
-          // Fallback failed — continue with empty list
         }
-      }
+        return trusted;
+      };
+
+      const [myTrusted, theirTrusted] = await Promise.all([
+        trustedAddressesFor(me, true),
+        trustedAddressesFor(other, false),
+      ]);
 
       // SDK may return `objectAvatar` instead of `address` in some cases
       // CRITICAL: Normalize to lowercase for comparison - addresses can have different checksums

--- a/circles-app/src/lib/areas/contacts/ui/components/CommonConnections.svelte
+++ b/circles-app/src/lib/areas/contacts/ui/components/CommonConnections.svelte
@@ -43,7 +43,10 @@
         addr: Address,
         isSelf: boolean
       ): Promise<TrustRelationInfo[]> => {
-        const info = await $circles.data.getAvatar(addr).catch(() => null);
+        const info = await $circles.data.getAvatar(addr).catch((e) => {
+          console.warn('[CommonConnections] getAvatar failed; defaulting to trust path', e);
+          return null;
+        });
         if (isGroupType(info?.type)) {
           const members = await groupDataSource.getGroupMembers(addr);
           return members.map((row) => ({

--- a/circles-app/src/lib/areas/groups/ui/components/GroupMembersManager.svelte
+++ b/circles-app/src/lib/areas/groups/ui/components/GroupMembersManager.svelte
@@ -12,8 +12,8 @@
   import { createSearchablePaginatedList } from '$lib/shared/state/searchablePaginatedList';
   import { createKeyboardListNavigator } from '$lib/shared/ui/lists/utils/keyboardListNavigator';
   import { openAddTrustFlow } from '$lib/areas/trust/flows/addTrust/openAddTrustFlow';
-  import { createTrustDataSource } from '$lib/shared/data/circles/trustDataSource';
   import { createAvatarDataSource } from '$lib/shared/data/circles/avatarDataSource';
+  import { createGroupDataSource } from '$lib/shared/data/circles/groupDataSource';
 
   interface Props {
     group: Address;
@@ -90,14 +90,13 @@
     loading = true;
     error = null;
     try {
-      const trustDataSource = createTrustDataSource(sdk);
+      const groupDataSource = createGroupDataSource(sdk);
       const avatarDataSource = createAvatarDataSource(sdk);
-      const relations = await trustDataSource.getAggregatedTrustRelations(group);
+      const memberRows = await groupDataSource.getGroupMembers(group);
       const trustedAddresses = Array.from(
         new Set(
-          relations
-            .filter((row) => row.relation === 'trusts' || row.relation === 'mutuallyTrusts')
-            .map((row) => row.objectAvatar as Address)
+          memberRows
+            .map((row) => row.member as Address)
             .filter((addr) => addr.toLowerCase() !== group.toLowerCase())
         )
       ).sort((a, b) => a.localeCompare(b));

--- a/circles-app/src/lib/shared/data/circles/groupDataSource.ts
+++ b/circles-app/src/lib/shared/data/circles/groupDataSource.ts
@@ -4,6 +4,7 @@ import { PagedQuery } from '@aboutcircles/sdk-rpc';
 
 export interface GroupDataSource {
   getGroupMemberships(member: Address, limit: number): PagedQuery<GroupMembershipRow>;
+  getGroupMembers(group: Address, pageSize?: number): Promise<GroupMembershipRow[]>;
 }
 
 export function createGroupDataSource(sdk: Sdk): GroupDataSource {
@@ -25,6 +26,17 @@ export function createGroupDataSource(sdk: Sdk): GroupDataSource {
         limit,
       };
       return new PagedQuery<GroupMembershipRow>(sdk.rpc.client, queryDef);
+    },
+
+    async getGroupMembers(group: Address, pageSize = 100): Promise<GroupMembershipRow[]> {
+      const all: GroupMembershipRow[] = [];
+      let cursor: string | null = null;
+      do {
+        const page = await sdk.rpc.group.getGroupMembers(group, pageSize, cursor);
+        all.push(...page.results);
+        cursor = page.hasMore ? page.nextCursor ?? null : null;
+      } while (cursor);
+      return all;
     },
   };
 }

--- a/circles-app/src/lib/shared/state/circlesBalances.ts
+++ b/circles-app/src/lib/shared/state/circlesBalances.ts
@@ -1,4 +1,3 @@
-import { avatarState } from '$lib/shared/state/avatar.svelte';
 import type { CirclesEvent, CirclesEventType } from '@aboutcircles/sdk-rpc';
 import type { TokenBalance } from '@aboutcircles/sdk-types';
 import { createEventStore } from '$lib/shared/state/eventStores/eventStoreFactory.svelte';
@@ -7,18 +6,14 @@ import { writable } from 'svelte/store';
 import { writeBalances, makeScopeId } from '$lib/shared/cache';
 
 const refreshOnEvents: Set<CirclesEventType> = new Set<CirclesEventType>([
-  'CrcV1_HubTransfer',
-  'CrcV1_Transfer',
+  'CrcV2_Transfer',
   'CrcV2_TransferBatch',
   'CrcV2_TransferSingle',
-  'CrcV2_Erc20WrapperTransfer',
   'CrcV2_PersonalMint',
-  'CrcV2_GroupMintSingle',
-  'CrcV2_GroupMintBatch',
-  'CrcV2_GroupRedeem',
+  'CrcV2_GroupMint',
   'CrcV2_GroupRedeemCollateralReturn',
   'CrcV2_GroupRedeemCollateralBurn',
-] as CirclesEventType[]);
+]);
 
 let currentStoreUnsubscribe: (() => void) | undefined;
 let currentAvatarAddress: string = '';

--- a/circles-app/src/lib/shared/state/contacts/query/circlesContactsQueryStore.svelte.ts
+++ b/circles-app/src/lib/shared/state/contacts/query/circlesContactsQueryStore.svelte.ts
@@ -31,11 +31,23 @@ export async function createContactsQueryStore(
   if (!sdk) throw new Error('SDK not initialized');
   const trustDataSource = createTrustDataSource(sdk);
   const groupDataSource = createGroupDataSource(sdk);
-  const subjectIsGroup = isGroupType(avatar.avatarInfo?.type);
 
   const createContactsQuery = async (): Promise<
     CirclesQuery<ContactEventRow>
   > => {
+    // Resolve the avatar type lazily so a race during init (avatarInfo not yet
+    // attached) doesn't lock the store onto the wrong path for the lifetime of
+    // the subscription. If avatarInfo is missing, fetch it from the SDK.
+    let avatarType: string | undefined = avatar.avatarInfo?.type;
+    if (!avatarType) {
+      const info = await sdk.data.getAvatar(address).catch((e) => {
+        console.warn('[Contacts] getAvatar lookup failed; defaulting to trust path', e);
+        return null;
+      });
+      avatarType = info?.type;
+    }
+    const subjectIsGroup = isGroupType(avatarType);
+
     // Group members live in V_CrcV2.GroupMemberships, not the trust-relations view.
     // For human/org avatars the trust path is correct; for groups it returns the
     // inverse (counterparties trusting the group) and misses actual members.

--- a/circles-app/src/lib/shared/state/contacts/query/circlesContactsQueryStore.svelte.ts
+++ b/circles-app/src/lib/shared/state/contacts/query/circlesContactsQueryStore.svelte.ts
@@ -15,6 +15,8 @@ import type { Address } from '@aboutcircles/sdk-types';
 import type { Avatar, Sdk } from '@aboutcircles/sdk';
 import { createTrustDataSource } from '$lib/shared/data/circles/trustDataSource';
 import { createAvatarDataSource } from '$lib/shared/data/circles/avatarDataSource';
+import { createGroupDataSource } from '$lib/shared/data/circles/groupDataSource';
+import { isGroupType } from '$lib/shared/utils/avatarHelpers';
 
 interface ContactEventRow extends EventRow {
   data: ContactList;
@@ -28,12 +30,18 @@ export async function createContactsQueryStore(
   const sdk = get(circles);
   if (!sdk) throw new Error('SDK not initialized');
   const trustDataSource = createTrustDataSource(sdk);
+  const groupDataSource = createGroupDataSource(sdk);
+  const subjectIsGroup = isGroupType(avatar.avatarInfo?.type);
 
   const createContactsQuery = async (): Promise<
     CirclesQuery<ContactEventRow>
   > => {
-    // Fetch contacts eagerly so the CirclesQuery has data on .rows immediately
-    const contacts = await trustDataSource.getAggregatedTrustRelations(address);
+    // Group members live in V_CrcV2.GroupMemberships, not the trust-relations view.
+    // For human/org avatars the trust path is correct; for groups it returns the
+    // inverse (counterparties trusting the group) and misses actual members.
+    const contacts = subjectIsGroup
+      ? await fetchGroupMembersAsRelations(groupDataSource, address)
+      : await trustDataSource.getAggregatedTrustRelations(address);
     const enrichedContacts = await enrichContactData(contacts, address, sdk);
 
     const contactEventRow: ContactEventRow = {
@@ -141,4 +149,17 @@ async function enrichContactData(
   });
 
   return profileRecord;
+}
+
+async function fetchGroupMembersAsRelations(
+  groupDataSource: ReturnType<typeof createGroupDataSource>,
+  group: Address
+): Promise<AggregatedTrustRelation[]> {
+  const members = await groupDataSource.getGroupMembers(group);
+  return members.map((row) => ({
+    subjectAvatar: row.group as Address,
+    relation: 'trusts' as const,
+    objectAvatar: row.member as Address,
+    timestamp: row.timestamp,
+  }));
 }

--- a/circles-app/src/lib/shared/ui/profile/components/TrustRelationsList.svelte
+++ b/circles-app/src/lib/shared/ui/profile/components/TrustRelationsList.svelte
@@ -4,6 +4,8 @@
     import { get, writable } from 'svelte/store';
     import type { Address } from '@aboutcircles/sdk-types';
     import { createTrustDataSource } from '$lib/shared/data/circles/trustDataSource';
+    import { createGroupDataSource } from '$lib/shared/data/circles/groupDataSource';
+    import { isGroupType } from '$lib/shared/utils/avatarHelpers';
 
     type RelationFilter = 'trusts' | 'trustedBy';
 
@@ -31,25 +33,40 @@
                 count = 0;
                 return;
             }
-            const trustDataSource = createTrustDataSource(sdk);
 
             const list: Address[] = [];
 
-            const relations = await trustDataSource.getAggregatedTrustRelations(avatarAddress);
-            if (relation === 'trusts') {
+            // For groups the "Trusts" tab is the member list, sourced from V_CrcV2.GroupMemberships.
+            // The trust-relations view doesn't include the group→member edges under the new SDK.
+            const avatarInfo = await sdk.data.getAvatar(avatarAddress).catch(() => null);
+            const subjectIsGroup = isGroupType(avatarInfo?.type);
+
+            if (relation === 'trusts' && subjectIsGroup) {
+                const groupDataSource = createGroupDataSource(sdk);
+                const members = await groupDataSource.getGroupMembers(avatarAddress);
                 list.push(
-                    ...relations
-                        .filter((row) => row.relation === 'trusts' || row.relation === 'mutuallyTrusts')
-                        .filter((row) => row.objectAvatar !== avatarAddress)
-                        .map((row) => row.objectAvatar as Address)
+                    ...members
+                        .map((row) => row.member as Address)
+                        .filter((addr) => addr !== avatarAddress)
                 );
             } else {
-                list.push(
-                    ...relations
-                        .filter((row) => row.relation === 'trustedBy' || row.relation === 'mutuallyTrusts')
-                        .filter((row) => row.objectAvatar !== avatarAddress)
-                        .map((row) => row.objectAvatar as Address)
-                );
+                const trustDataSource = createTrustDataSource(sdk);
+                const relations = await trustDataSource.getAggregatedTrustRelations(avatarAddress);
+                if (relation === 'trusts') {
+                    list.push(
+                        ...relations
+                            .filter((row) => row.relation === 'trusts' || row.relation === 'mutuallyTrusts')
+                            .filter((row) => row.objectAvatar !== avatarAddress)
+                            .map((row) => row.objectAvatar as Address)
+                    );
+                } else {
+                    list.push(
+                        ...relations
+                            .filter((row) => row.relation === 'trustedBy' || row.relation === 'mutuallyTrusts')
+                            .filter((row) => row.objectAvatar !== avatarAddress)
+                            .map((row) => row.objectAvatar as Address)
+                    );
+                }
             }
 
             const unique = Array.from(new Set(list))

--- a/circles-app/src/lib/shared/ui/profile/components/TrustRelationsList.svelte
+++ b/circles-app/src/lib/shared/ui/profile/components/TrustRelationsList.svelte
@@ -38,7 +38,10 @@
 
             // For groups the "Trusts" tab is the member list, sourced from V_CrcV2.GroupMemberships.
             // The trust-relations view doesn't include the group→member edges under the new SDK.
-            const avatarInfo = await sdk.data.getAvatar(avatarAddress).catch(() => null);
+            const avatarInfo = await sdk.data.getAvatar(avatarAddress).catch((e) => {
+                console.warn('[TrustRelationsList] getAvatar failed; defaulting to trust path', e);
+                return null;
+            });
             const subjectIsGroup = isGroupType(avatarInfo?.type);
 
             if (relation === 'trusts' && subjectIsGroup) {


### PR DESCRIPTION
## Summary

- The contacts/members surfaces for group avatars were reading from `sdk.data.getTrustRelations(groupAddress)`. Under the new SDK that RPC returns only inverse edges (counterparties trusting the group). Group->member edges live in `V_CrcV2.GroupMemberships` and are exposed via `sdk.rpc.group.getGroupMembers`.
- This PR routes all group-side member reads through `getGroupMembers` and removes dead `refreshOnEvents` strings in `circlesBalances`.

## Files

- `groupDataSource.ts`: add paginated `getGroupMembers(group, pageSize?)` helper that wraps `sdk.rpc.group.getGroupMembers` and exhausts the cursor.
- `circlesContactsQueryStore.svelte.ts`: branch on `avatar.avatarInfo.type`. Group avatars load members via `getGroupMembers` and synthesize rows in `AggregatedTrustRelation` shape so downstream UI/filter code is untouched.
- `GroupMembersManager.svelte`: replace trust-relations fetch with `getGroupMembers` for `/groups/members/[group]`.
- `TrustRelationsList.svelte`: when the viewed avatar is a group, source the 'Trusts' tab from `getGroupMembers`. 'Trusted by' continues to use the trust-relations view.
- `CommonConnections.svelte`: when either side is a group, derive that side's trusted-address set from `getGroupMembers` before intersection.
- `circlesBalances.ts`: remove dead `refreshOnEvents` entries (`CrcV1_HubTransfer`, `CrcV1_Transfer`, `CrcV2_Erc20WrapperTransfer`, `CrcV2_GroupMintSingle`, `CrcV2_GroupMintBatch`, `CrcV2_GroupRedeem`); replace with the actual emitted event names (`CrcV2_GroupMint`, `CrcV2_Transfer`). Drop the `as CirclesEventType[]` cast so future dead strings fail typecheck.

## Test plan

- [x] `npm run check` — 0 errors
- [x] Live: human-mode `/contacts` renders trust relations unchanged
- [x] Live: `/groups/members/<group>` renders the full member list (1903 for the test group)
- [x] Live: viewing a group's profile, 'Trusts' tab renders members (1989 for the test group)
- [x] Live: group-mode `/contacts` shows the full member list with 'Members' title and 'Add Member' button
- [ ] Live (post-merge on staging): adding a new member via 'Add Member' refreshes the list without manual reload
- [ ] Live (post-merge on staging): observing a group mint refreshes the balance display