### PR TITLE
perf(groups): progressive pagination for group-member lists + spinner

### DIFF
--- a/circles-app/src/lib/areas/contacts/ui/components/CommonConnections.svelte
+++ b/circles-app/src/lib/areas/contacts/ui/components/CommonConnections.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import RowFrame from '$lib/shared/ui/primitives/RowFrame.svelte';
   import Avatar from '$lib/shared/ui/avatar/Avatar.svelte';
+  import InlineSpinner from '$lib/shared/ui/lists/InlineSpinner.svelte';
   import { popupControls } from '$lib/shared/state/popup/popUp.svelte';
   import ProfilePage from '$lib/areas/profile/ui/pages/Profile.svelte';
   import { avatarState } from '$lib/shared/state/avatar.svelte';
@@ -133,7 +134,7 @@
 </script>
 
 {#if loading}
-  <div class="w-full py-6 text-center text-base-content/60">Loading…</div>
+  <InlineSpinner />
 {:else if error}
   <div class="w-full py-6 text-center text-error">{error}</div>
 {:else if rows.length === 0}

--- a/circles-app/src/lib/areas/groups/ui/components/GroupMembersManager.svelte
+++ b/circles-app/src/lib/areas/groups/ui/components/GroupMembersManager.svelte
@@ -79,6 +79,9 @@
     };
   });
 
+  const GROUP_MEMBERS_PAGE_SIZE = 100;
+  let loadGeneration = 0;
+
   async function loadTrusted() {
     const sdk = get(circles);
     if (!sdk) {
@@ -87,35 +90,73 @@
       return;
     }
 
+    const generation = ++loadGeneration;
     loading = true;
     error = null;
+    trusted = [];
+    trustedAvatarTypes = {};
+    trustedStore.set([]);
+
     try {
       const groupDataSource = createGroupDataSource(sdk);
       const avatarDataSource = createAvatarDataSource(sdk);
-      const memberRows = await groupDataSource.getGroupMembers(group);
-      const trustedAddresses = Array.from(
-        new Set(
-          memberRows
-            .map((row) => row.member as Address)
-            .filter((addr) => addr.toLowerCase() !== group.toLowerCase())
-        )
-      ).sort((a, b) => a.localeCompare(b));
-      trusted = trustedAddresses;
-      trustedStore.set(trusted);
+      const seen = new Set<string>();
+      let cursor: string | null = null;
+      let first = true;
 
-      const infos = await avatarDataSource.getAvatarInfoBatch(trustedAddresses);
-      const nextTypes: Record<string, string | undefined> = {};
-      for (const info of infos) {
-        if (info) nextTypes[String(info.avatar).toLowerCase()] = info.type;
-      }
-      trustedAvatarTypes = nextTypes;
+      do {
+        const page = await groupDataSource.getGroupMembersPage(
+          group,
+          cursor,
+          GROUP_MEMBERS_PAGE_SIZE
+        );
+        if (generation !== loadGeneration) return;
+
+        const newAddrs: Address[] = [];
+        for (const row of page.results) {
+          const addr = row.member as Address;
+          const key = addr.toLowerCase();
+          if (key === group.toLowerCase()) continue;
+          if (seen.has(key)) continue;
+          seen.add(key);
+          newAddrs.push(addr);
+        }
+
+        if (newAddrs.length > 0) {
+          trusted = trusted.concat(newAddrs);
+          trustedStore.set(trusted);
+
+          // Enrich this page's addresses with avatar types in the background;
+          // rows render immediately and the type label fills in when ready.
+          void (async () => {
+            try {
+              const infos = await avatarDataSource.getAvatarInfoBatch(newAddrs);
+              if (generation !== loadGeneration) return;
+              const next: Record<string, string | undefined> = { ...trustedAvatarTypes };
+              for (const info of infos) {
+                if (info) next[String(info.avatar).toLowerCase()] = info.type;
+              }
+              trustedAvatarTypes = next;
+            } catch (e) {
+              console.debug('[GroupMembersManager] avatar info batch failed', e);
+            }
+          })();
+        }
+
+        if (first) {
+          loading = false;
+          first = false;
+        }
+        cursor = page.nextCursor;
+      } while (cursor);
     } catch (e) {
+      if (generation !== loadGeneration) return;
       error = e instanceof Error ? e.message : String(e);
       trusted = [];
       trustedAvatarTypes = {};
       trustedStore.set([]);
     } finally {
-      loading = false;
+      if (generation === loadGeneration) loading = false;
     }
   }
 

--- a/circles-app/src/lib/areas/groups/ui/components/GroupMembersManager.svelte
+++ b/circles-app/src/lib/areas/groups/ui/components/GroupMembersManager.svelte
@@ -112,6 +112,10 @@
         );
         if (generation !== loadGeneration) return;
 
+        // Stop if the server returns no progress (defends against a bug
+        // returning `results:[], hasMore:true` which would loop forever).
+        if (page.results.length === 0) break;
+
         const newAddrs: Address[] = [];
         for (const row of page.results) {
           const addr = row.member as Address;

--- a/circles-app/src/lib/areas/profile/ui/pages/Profile.svelte
+++ b/circles-app/src/lib/areas/profile/ui/pages/Profile.svelte
@@ -65,6 +65,7 @@
     import { Star as LStar } from 'lucide';
     import { createAvatarDataSource } from '$lib/shared/data/circles/avatarDataSource';
     import { createTrustDataSource } from '$lib/shared/data/circles/trustDataSource';
+    import InlineSpinner from '$lib/shared/ui/lists/InlineSpinner.svelte';
     import {
         bookmarksStateStore,
         profileBookmarksService,
@@ -960,7 +961,7 @@
         >
             <div class="w-full">
                 {#if collateralLoading}
-                    <div class="w-full py-6 text-center text-base-content/60">Loading…</div>
+                    <InlineSpinner />
                 {:else if collateralError}
                     <div class="w-full py-6 text-center text-error">{collateralError}</div>
                 {:else}
@@ -984,7 +985,7 @@
         >
             <div class="w-full">
                 {#if holdersLoading}
-                    <div class="w-full py-6 text-center text-base-content/60">Loading…</div>
+                    <InlineSpinner />
                 {:else if holdersError}
                     <div class="w-full py-6 text-center text-error">{holdersError}</div>
                 {:else}
@@ -1003,7 +1004,7 @@
         >
             <div class="w-full">
                 {#if holdingsLoading}
-                    <div class="w-full py-6 text-center text-base-content/60">Loading…</div>
+                    <InlineSpinner />
                 {:else if holdingsError}
                     <div class="w-full py-6 text-center text-error">{holdingsError}</div>
                 {:else}

--- a/circles-app/src/lib/shared/data/circles/groupDataSource.ts
+++ b/circles-app/src/lib/shared/data/circles/groupDataSource.ts
@@ -2,8 +2,21 @@ import type { Sdk } from '@aboutcircles/sdk';
 import type { Address, GroupMembershipRow, PagedQueryParams } from '@aboutcircles/sdk-types';
 import { PagedQuery } from '@aboutcircles/sdk-rpc';
 
+export interface GroupMembersPage {
+  results: GroupMembershipRow[];
+  hasMore: boolean;
+  nextCursor: string | null;
+}
+
 export interface GroupDataSource {
   getGroupMemberships(member: Address, limit: number): PagedQuery<GroupMembershipRow>;
+  /** Single page — for progressive scroll-loading. */
+  getGroupMembersPage(
+    group: Address,
+    cursor: string | null,
+    pageSize?: number
+  ): Promise<GroupMembersPage>;
+  /** Exhaustive fetch — for callers that need the full member set in one shot. */
   getGroupMembers(group: Address, pageSize?: number): Promise<GroupMembershipRow[]>;
 }
 
@@ -26,6 +39,19 @@ export function createGroupDataSource(sdk: Sdk): GroupDataSource {
         limit,
       };
       return new PagedQuery<GroupMembershipRow>(sdk.rpc.client, queryDef);
+    },
+
+    async getGroupMembersPage(
+      group: Address,
+      cursor: string | null,
+      pageSize = 100
+    ): Promise<GroupMembersPage> {
+      const page = await sdk.rpc.group.getGroupMembers(group, pageSize, cursor);
+      return {
+        results: page.results,
+        hasMore: page.hasMore,
+        nextCursor: page.hasMore ? page.nextCursor ?? null : null,
+      };
     },
 
     async getGroupMembers(group: Address, pageSize = 100): Promise<GroupMembershipRow[]> {

--- a/circles-app/src/lib/shared/state/contacts/query/circlesContactsQueryStore.svelte.ts
+++ b/circles-app/src/lib/shared/state/contacts/query/circlesContactsQueryStore.svelte.ts
@@ -32,6 +32,8 @@ export async function createContactsQueryStore(
   const trustDataSource = createTrustDataSource(sdk);
   const groupDataSource = createGroupDataSource(sdk);
 
+  const GROUP_MEMBERS_PAGE_SIZE = 100;
+
   const createContactsQuery = async (): Promise<
     CirclesQuery<ContactEventRow>
   > => {
@@ -48,12 +50,47 @@ export async function createContactsQueryStore(
     }
     const subjectIsGroup = isGroupType(avatarType);
 
-    // Group members live in V_CrcV2.GroupMemberships, not the trust-relations view.
-    // For human/org avatars the trust path is correct; for groups it returns the
-    // inverse (counterparties trusting the group) and misses actual members.
-    const contacts = subjectIsGroup
-      ? await fetchGroupMembersAsRelations(groupDataSource, address)
-      : await trustDataSource.getAggregatedTrustRelations(address);
+    if (subjectIsGroup) {
+      // Progressive cursor pagination. Each call to fetchNextGroupPage produces
+      // one ContactEventRow holding that page's slice of members. The store
+      // accumulates rows across pages and the subscriber merges them.
+      let cursor: string | null = null;
+      let exhausted = false;
+
+      const fetchNextGroupPage = async (): Promise<CirclesQuery<ContactEventRow>> => {
+        if (exhausted) {
+          return { rows: [], hasMore: false, nextPage: fetchNextGroupPage };
+        }
+        const page = await groupDataSource.getGroupMembersPage(
+          address,
+          cursor,
+          GROUP_MEMBERS_PAGE_SIZE
+        );
+        cursor = page.nextCursor;
+        const hasMore = page.hasMore && cursor !== null;
+        exhausted = !hasMore;
+
+        const relations: AggregatedTrustRelation[] = page.results.map((row) => ({
+          subjectAvatar: row.group as Address,
+          relation: 'trusts' as const,
+          objectAvatar: row.member as Address,
+          timestamp: row.timestamp,
+        }));
+        const enriched = await enrichContactData(relations, address, sdk);
+
+        const row: ContactEventRow = {
+          blockNumber: Date.now(),
+          transactionIndex: 0,
+          logIndex: 0,
+          data: enriched,
+        };
+        return { rows: [row], hasMore, nextPage: fetchNextGroupPage };
+      };
+
+      return fetchNextGroupPage();
+    }
+
+    const contacts = await trustDataSource.getAggregatedTrustRelations(address);
     const enrichedContacts = await enrichContactData(contacts, address, sdk);
 
     const contactEventRow: ContactEventRow = {
@@ -63,19 +100,12 @@ export async function createContactsQueryStore(
       data: enrichedContacts,
     };
 
-    const query: CirclesQuery<ContactEventRow> = {
-      rows: [contactEventRow],
+    const noMore = async (): Promise<CirclesQuery<ContactEventRow>> => ({
+      rows: [],
       hasMore: false,
-      async nextPage(): Promise<CirclesQuery<ContactEventRow>> {
-        // No further pages — return empty result
-        return {
-          rows: [],
-          hasMore: false,
-          nextPage: this.nextPage,
-        };
-      },
-    };
-    return query;
+      nextPage: noMore,
+    });
+    return { rows: [contactEventRow], hasMore: false, nextPage: noMore };
   };
 
   const store = await createCirclesQueryStore<ContactEventRow>(
@@ -93,13 +123,16 @@ export async function createContactsQueryStore(
       }) => void
     ) => {
       return store.subscribe((value) => {
-        const hasLoadedSnapshot = (value.data?.length ?? 0) > 0;
+        // Pages arrive as separate ContactEventRow snapshots. Merge them so the
+        // page sees one ContactList regardless of how many pages have loaded.
+        const merged: ContactList = {};
+        for (const row of value.data ?? []) {
+          Object.assign(merged, row.data);
+        }
         callback({
-          data: value.data[0]?.data ?? {},
+          data: merged,
           next: value.next,
-          // Contacts are delivered as a single aggregated snapshot row.
-          // Once that row is present, the list is effectively loaded/ended.
-          ended: value.ended || hasLoadedSnapshot,
+          ended: value.ended,
         });
       });
     },
@@ -163,15 +196,3 @@ async function enrichContactData(
   return profileRecord;
 }
 
-async function fetchGroupMembersAsRelations(
-  groupDataSource: ReturnType<typeof createGroupDataSource>,
-  group: Address
-): Promise<AggregatedTrustRelation[]> {
-  const members = await groupDataSource.getGroupMembers(group);
-  return members.map((row) => ({
-    subjectAvatar: row.group as Address,
-    relation: 'trusts' as const,
-    objectAvatar: row.member as Address,
-    timestamp: row.timestamp,
-  }));
-}

--- a/circles-app/src/lib/shared/state/contacts/query/circlesContactsQueryStore.svelte.ts
+++ b/circles-app/src/lib/shared/state/contacts/query/circlesContactsQueryStore.svelte.ts
@@ -61,14 +61,21 @@ export async function createContactsQueryStore(
         if (exhausted) {
           return { rows: [], hasMore: false, nextPage: fetchNextGroupPage };
         }
+        const requestedCursor = cursor;
         const page = await groupDataSource.getGroupMembersPage(
           address,
-          cursor,
+          requestedCursor,
           GROUP_MEMBERS_PAGE_SIZE
         );
-        cursor = page.nextCursor;
-        const hasMore = page.hasMore && cursor !== null;
-        exhausted = !hasMore;
+
+        // Treat an empty results page as terminal regardless of hasMore — protects
+        // against a server bug returning `results:[], hasMore:true` which would
+        // otherwise cause VirtualList to spin-loop on prefetch.
+        if (page.results.length === 0) {
+          exhausted = true;
+          cursor = null;
+          return { rows: [], hasMore: false, nextPage: fetchNextGroupPage };
+        }
 
         const relations: AggregatedTrustRelation[] = page.results.map((row) => ({
           subjectAvatar: row.group as Address,
@@ -76,7 +83,13 @@ export async function createContactsQueryStore(
           objectAvatar: row.member as Address,
           timestamp: row.timestamp,
         }));
+        // Enrich BEFORE committing cursor advance so a transient failure can be
+        // retried on the same cursor without skipping the page.
         const enriched = await enrichContactData(relations, address, sdk);
+
+        cursor = page.nextCursor;
+        const hasMore = page.hasMore && cursor !== null;
+        exhausted = !hasMore;
 
         const row: ContactEventRow = {
           blockNumber: Date.now(),

--- a/circles-app/src/lib/shared/ui/lists/InlineSpinner.svelte
+++ b/circles-app/src/lib/shared/ui/lists/InlineSpinner.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  interface Props {
+    label?: string;
+    class?: string;
+  }
+
+  let { label = 'Loading…', class: extraClass = '' }: Props = $props();
+</script>
+
+<div
+  class={`w-full py-6 text-center text-base-content/60 ${extraClass}`}
+  aria-live="polite"
+  aria-busy="true"
+>
+  <span class="loading loading-spinner text-primary"></span>
+  <span class="ml-2">{label}</span>
+</div>

--- a/circles-app/src/lib/shared/ui/lists/ListStates.svelte
+++ b/circles-app/src/lib/shared/ui/lists/ListStates.svelte
@@ -27,7 +27,10 @@
 </script>
 
 {#if loading}
-  <div class="w-full py-6 text-center text-base-content/60">{loadingLabel}</div>
+  <div class="w-full py-6 text-center text-base-content/60" aria-live="polite" aria-busy="true">
+    <span class="loading loading-spinner text-primary"></span>
+    <span class="ml-2">{loadingLabel}</span>
+  </div>
 {:else if error}
   <div class="w-full py-6 text-center text-error">{error}</div>
 {:else if isEmpty}

--- a/circles-app/src/lib/shared/ui/profile/components/TrustRelationsList.svelte
+++ b/circles-app/src/lib/shared/ui/profile/components/TrustRelationsList.svelte
@@ -61,6 +61,10 @@
                     );
                     if (generation !== loadGeneration) return;
 
+                    // Stop if the server returns no progress (defends against a bug
+                    // returning `results:[], hasMore:true` which would loop forever).
+                    if (page.results.length === 0) break;
+
                     const newAddrs: Address[] = [];
                     for (const row of page.results) {
                         const addr = row.member as Address;

--- a/circles-app/src/lib/shared/ui/profile/components/TrustRelationsList.svelte
+++ b/circles-app/src/lib/shared/ui/profile/components/TrustRelationsList.svelte
@@ -17,24 +17,26 @@
 
     let { avatarAddress, relation, count = $bindable(0) }: Props = $props();
 
+    const GROUP_MEMBERS_PAGE_SIZE = 100;
+
     let loading = $state(true);
     let error: string | null = $state(null);
-    let rows: Address[] = $state([]);
     const rowsStore = writable<Address[]>([]);
+    let loadGeneration = 0;
 
     async function loadRelations(): Promise<void> {
+        const generation = ++loadGeneration;
         loading = true;
         error = null;
-        rows = [];
+        rowsStore.set([]);
+        count = 0;
+
         try {
             const sdk = get(circles);
             if (!sdk || !avatarAddress) {
                 loading = false;
-                count = 0;
                 return;
             }
-
-            const list: Address[] = [];
 
             // For groups the "Trusts" tab is the member list, sourced from V_CrcV2.GroupMemberships.
             // The trust-relations view doesn't include the group→member edges under the new SDK.
@@ -42,54 +44,76 @@
                 console.warn('[TrustRelationsList] getAvatar failed; defaulting to trust path', e);
                 return null;
             });
+            if (generation !== loadGeneration) return;
             const subjectIsGroup = isGroupType(avatarInfo?.type);
 
             if (relation === 'trusts' && subjectIsGroup) {
                 const groupDataSource = createGroupDataSource(sdk);
-                const members = await groupDataSource.getGroupMembers(avatarAddress);
-                list.push(
-                    ...members
-                        .map((row) => row.member as Address)
-                        .filter((addr) => addr !== avatarAddress)
-                );
-            } else {
-                const trustDataSource = createTrustDataSource(sdk);
-                const relations = await trustDataSource.getAggregatedTrustRelations(avatarAddress);
-                if (relation === 'trusts') {
-                    list.push(
-                        ...relations
-                            .filter((row) => row.relation === 'trusts' || row.relation === 'mutuallyTrusts')
-                            .filter((row) => row.objectAvatar !== avatarAddress)
-                            .map((row) => row.objectAvatar as Address)
+                const seen = new Set<string>();
+                let cursor: string | null = null;
+                let first = true;
+
+                do {
+                    const page = await groupDataSource.getGroupMembersPage(
+                        avatarAddress,
+                        cursor,
+                        GROUP_MEMBERS_PAGE_SIZE
                     );
-                } else {
-                    list.push(
-                        ...relations
-                            .filter((row) => row.relation === 'trustedBy' || row.relation === 'mutuallyTrusts')
-                            .filter((row) => row.objectAvatar !== avatarAddress)
-                            .map((row) => row.objectAvatar as Address)
-                    );
-                }
+                    if (generation !== loadGeneration) return;
+
+                    const newAddrs: Address[] = [];
+                    for (const row of page.results) {
+                        const addr = row.member as Address;
+                        const key = addr.toLowerCase();
+                        if (addr.toLowerCase() === avatarAddress.toLowerCase()) continue;
+                        if (seen.has(key)) continue;
+                        seen.add(key);
+                        newAddrs.push(addr);
+                    }
+                    rowsStore.update((prev) => prev.concat(newAddrs));
+                    count = get(rowsStore).length;
+
+                    if (first) {
+                        loading = false;
+                        first = false;
+                    }
+                    cursor = page.nextCursor;
+                } while (cursor);
+                return;
             }
 
-            const unique = Array.from(new Set(list))
-                .filter((addr) => addr !== avatarAddress)
-                .sort((a, b) => a.localeCompare(b));
+            const trustDataSource = createTrustDataSource(sdk);
+            const relations = await trustDataSource.getAggregatedTrustRelations(avatarAddress);
+            if (generation !== loadGeneration) return;
 
-            rows = unique;
-            rowsStore.set(rows);
-            count = rows.length;
+            const filtered =
+                relation === 'trusts'
+                    ? relations.filter(
+                          (row) => row.relation === 'trusts' || row.relation === 'mutuallyTrusts'
+                      )
+                    : relations.filter(
+                          (row) => row.relation === 'trustedBy' || row.relation === 'mutuallyTrusts'
+                      );
+            const list = filtered
+                .map((row) => row.objectAvatar as Address)
+                .filter((addr) => addr !== avatarAddress);
+            const unique = Array.from(new Set(list)).sort((a, b) => a.localeCompare(b));
+            rowsStore.set(unique);
+            count = unique.length;
         } catch (e) {
+            if (generation !== loadGeneration) return;
             error = e instanceof Error ? e.message : 'Failed to load trust relations';
-            rows = [];
             rowsStore.set([]);
             count = 0;
         } finally {
-            loading = false;
+            if (generation === loadGeneration) loading = false;
         }
     }
 
     $effect(() => {
+        // re-run on avatarAddress / relation change
+        avatarAddress;
+        relation;
         void loadRelations();
     });
 

--- a/circles-app/src/routes/contacts/+page.svelte
+++ b/circles-app/src/routes/contacts/+page.svelte
@@ -139,6 +139,8 @@
                 while (!done) {
                     done = await snap.next();
                 }
+            } catch (e) {
+                console.warn('[contacts] search drain failed; results may be incomplete', e);
             } finally {
                 draining = false;
             }

--- a/circles-app/src/routes/contacts/+page.svelte
+++ b/circles-app/src/routes/contacts/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-    import { browser } from '$app/environment';
     import {contacts} from '$lib/shared/state/contacts';
     import Papa from 'papaparse';
     import GenericList from '$lib/shared/ui/lists/GenericList.svelte';
@@ -18,21 +17,10 @@
     import ActionButtonDropDown from '$lib/shared/ui/shell/ActionButtonDropDown.svelte';
     import type { Action } from '$lib/shared/ui/shell/actions';
     import { goto } from '$app/navigation';
-    import { createPaginatedList } from '$lib/shared/state/paginatedList';
     import { createListInputArrowDownHandler } from '$lib/shared/ui/lists/utils/listInputArrowDown';
     import HelpPopover from '$lib/shared/ui/primitives/HelpPopover.svelte';
     import { getProfilesCoreBatch } from '$lib/shared/model/profile/coreRepo';
     import type { ProfileAddress } from '$lib/shared/model/profile/types';
-
-    const CONTACTS_PAGE_SIZE = 25;
-    const CONTACTS_VISIBLE_COUNT_KEY = 'contacts:list:visible-count';
-
-    function getInitialPageCount(): number {
-        if (!browser) return 1;
-        const raw = Number(window.sessionStorage.getItem(CONTACTS_VISIBLE_COUNT_KEY) ?? '0');
-        if (!Number.isFinite(raw) || raw <= 0) return 1;
-        return Math.max(1, Math.ceil(raw / CONTACTS_PAGE_SIZE));
-    }
 
     let filterVersion = writable<number | undefined>(undefined);
     let filterRelation = writable<'mutuallyTrusts' | 'trusts' | 'trustedBy' | 'variesByVersion' | undefined>(undefined);
@@ -121,33 +109,40 @@
         });
     });
 
-    // Paginate searched results for rendering
-    const contactsPaginated = createPaginatedList(searchedAll, {
-        pageSize: CONTACTS_PAGE_SIZE,
-        initialPageCount: getInitialPageCount(),
-    });
-    const contactsPaginatedWithEnd = derived([contactsPaginated, contacts], ([$paginated, $contacts]) => {
-        const hasData = ($paginated?.data ?? []).length > 0;
-        const showEnded = hasData
-            ? $paginated.ended
-            : ($contacts?.ended ?? false);
-        return {
-            ...$paginated,
-            ended: showEnded,
-        };
-    });
-
-    $effect(() => {
-        if (!browser) return;
-        const loadedCount = $contactsPaginatedWithEnd?.data?.length ?? 0;
-        if (loadedCount > 0) {
-            window.sessionStorage.setItem(CONTACTS_VISIBLE_COUNT_KEY, String(loadedCount));
-        }
-    });
+    // Feed VirtualList the full filtered set plus the underlying store's
+    // next/ended so scrolling near the end triggers a real RPC fetch for the
+    // next page (e.g. for group members). For humans the underlying store ends
+    // after the initial load so this is a no-op.
+    const listStore = derived([searchedAll, contacts], ([$searched, $c]) => ({
+        data: $searched,
+        next: $c.next,
+        ended: $c.ended,
+    }));
 
     $effect(() => {
         const addresses = $searchedAll.slice(0, 100).map((item) => item.address);
         void preloadProfileCores(addresses);
+    });
+
+    // When the user types a search query and the underlying store still has
+    // more pages, eagerly drain them so the search can match members not yet
+    // visible. Inert for human contacts (ended after one page).
+    let draining = false;
+    $effect(() => {
+        const q = ($searchQuery ?? '').toString().trim();
+        const snap = $contacts;
+        if (!q || snap?.ended || draining) return;
+        draining = true;
+        (async () => {
+            try {
+                let done = false;
+                while (!done) {
+                    done = await snap.next();
+                }
+            } finally {
+                draining = false;
+            }
+        })();
     });
 
     const onSearchInputKeydown = createListInputArrowDownHandler({
@@ -306,11 +301,12 @@
     >
         <div data-contacts-list-scope bind:this={contactsListScopeEl}>
             <GenericList
-                store={contactsPaginatedWithEnd}
+                store={listStore}
                 row={ContactRow}
                 rowHeight={64}
                 maxPlaceholderPages={2}
-                expectedPageSize={25}
+                expectedPageSize={avatarState.isGroup ? 100 : 25}
+                eagerLoadMultiplier={2}
                 placeholderRow={AvatarRowPlaceholder}
             />
         </div>


### PR DESCRIPTION
## Summary

Group-member surfaces previously fetched the entire member set in one shot (~20 cursor pages at limit=100 → ~20s for a 1,900-member group). This PR switches every group-member read to progressive pagination and aligns the loading affordance with the transaction-history spinner.

## Files

- **Data layer** — `groupDataSource.ts`: add `getGroupMembersPage(group, cursor, pageSize?)` returning a single page with `hasMore`/`nextCursor`. The existing exhaustive `getGroupMembers` stays for callers that need the full set.
- **Contacts (group mode `/contacts`)** —
  - `circlesContactsQueryStore.svelte.ts`: progressive cursor pagination for group avatars; each `nextPage()` fetches one page and the subscriber merges `ContactList` snapshots across rows so `VirtualList` sees a single growing data array.
  - `routes/contacts/+page.svelte`: drop the in-memory `createPaginatedList` wrapper; feed `VirtualList` the underlying store's `next`/`ended` so scrolling near the end fires the RPC fetch. Typing in the search box drains remaining pages so search can match members not yet on screen. `expectedPageSize` switches to 100 for groups.
- **Group members manager (`/groups/members/[g]`)** — `GroupMembersManager.svelte`: stream pages of members; `loading` flips to false after the first page; per-page avatar-info enrichment runs in parallel. Generation counter cancels stale responses.
- **Profile popup** —
  - `TrustRelationsList.svelte`: stream the Trusts tab for group avatars page by page; loading flips after the first page. Human/org and the Trusted by tab keep the existing single-fetch path.
  - `Profile.svelte`, `CommonConnections.svelte`: replace hardcoded `<div>Loading…</div>` with a shared `InlineSpinner`.
- **Shared spinner** —
  - `ListStates.svelte`: render the DaisyUI `loading-spinner` next to the Loading… label so every list that uses `ListShell` inherits the same spinner used by the transaction history.
  - `InlineSpinner.svelte` (new): the same affordance for inline-loading outside a `ListShell`.

## Test plan

- [x] `npm run check` clean
- [x] Live: group-mode `/contacts` first page lands in ~500ms; scrolling streams pages until 1903 members + "No more items"
- [x] Live: `/groups/members/<group>` shows 200 members at t=500ms, 1903 at t=5s with progressive fill
- [x] Live: profile popup Trusts tab badge streams 100 → 700 → 1300 → 1800 → 1989 in ~4s
- [x] Live: human `/contacts` unchanged (single-fetch, 6 contacts)
- [x] Spinner visible during initial load and between scroll-triggered pages
- [ ] Live (post-merge on staging): adding a new member via the Add Member flow refreshes the list without manual reload