### PR TITLE
perf(groups): align group-member page size with transaction history (25)

### DIFF
--- a/circles-app/src/lib/areas/groups/ui/components/GroupMembersManager.svelte
+++ b/circles-app/src/lib/areas/groups/ui/components/GroupMembersManager.svelte
@@ -79,7 +79,9 @@
     };
   });
 
-  const GROUP_MEMBERS_PAGE_SIZE = 100;
+  // Match the transaction-history page size so the first batch of members
+  // renders quickly; remaining pages fill in the background.
+  const GROUP_MEMBERS_PAGE_SIZE = 25;
   let loadGeneration = 0;
 
   async function loadTrusted() {

--- a/circles-app/src/lib/shared/state/contacts/query/circlesContactsQueryStore.svelte.ts
+++ b/circles-app/src/lib/shared/state/contacts/query/circlesContactsQueryStore.svelte.ts
@@ -32,7 +32,9 @@ export async function createContactsQueryStore(
   const trustDataSource = createTrustDataSource(sdk);
   const groupDataSource = createGroupDataSource(sdk);
 
-  const GROUP_MEMBERS_PAGE_SIZE = 100;
+  // Match the transaction-history page size for a fast first paint; further
+  // pages stream in via VirtualList's scroll-driven prefetch.
+  const GROUP_MEMBERS_PAGE_SIZE = 25;
 
   const createContactsQuery = async (): Promise<
     CirclesQuery<ContactEventRow>

--- a/circles-app/src/lib/shared/ui/profile/components/TrustRelationsList.svelte
+++ b/circles-app/src/lib/shared/ui/profile/components/TrustRelationsList.svelte
@@ -17,7 +17,9 @@
 
     let { avatarAddress, relation, count = $bindable(0) }: Props = $props();
 
-    const GROUP_MEMBERS_PAGE_SIZE = 100;
+    // Match the transaction-history page size so the Trusts tab renders
+    // its first batch of members quickly; remaining pages stream in.
+    const GROUP_MEMBERS_PAGE_SIZE = 25;
 
     let loading = $state(true);
     let error: string | null = $state(null);

--- a/circles-app/src/routes/contacts/+page.svelte
+++ b/circles-app/src/routes/contacts/+page.svelte
@@ -307,7 +307,7 @@
                 row={ContactRow}
                 rowHeight={64}
                 maxPlaceholderPages={2}
-                expectedPageSize={avatarState.isGroup ? 100 : 25}
+                expectedPageSize={25}
                 eagerLoadMultiplier={2}
                 placeholderRow={AvatarRowPlaceholder}
             />


### PR DESCRIPTION
## Summary

Drop the group-member RPC page size from 100 to 25 — matching the transaction-history default — so the first batch of members renders in ~200ms instead of ~1s. Subsequent pages still stream in via VirtualList's scroll-driven prefetch.

## Why

With page size 100, the first page of a large group required loading 100 members + enriching their profiles before any row could render. For groups with thousands of members the perceived "first paint" was ~1s.

## Measurement

Same 1903-member group, local dev (warmed):

| t      | page size 100 | page size 25 |
|-------:|--------------:|-------------:|
| 200ms  | 0             | 25           |
| 400ms  | 0             | 150          |
| 600ms  | 0             | 350          |
| 1000ms | 200           | 550          |
| 2000ms | 1200          | 925          |
| 5000ms | 1900          | 1350         |

Trade-off: total time to load the entire 1903-member set is a couple seconds longer at the smaller page size (more round trips), but VirtualList only loads what the user actually scrolls past, so the typical session loads far fewer rows.

## Files

- `circlesContactsQueryStore.svelte.ts` — `GROUP_MEMBERS_PAGE_SIZE`
- `GroupMembersManager.svelte` — `GROUP_MEMBERS_PAGE_SIZE`
- `TrustRelationsList.svelte` — `GROUP_MEMBERS_PAGE_SIZE`
- `routes/contacts/+page.svelte` — `expectedPageSize` (sizes VirtualList's prefetch runway)

## Test plan

- [x] `npm run check` clean
- [x] Local: 25 rows in `/groups/members/<g>` rendered at t=200ms, 350 at t=600ms, full 1903 around t=10s with continuous fill
- [ ] Post-merge: same numbers on `app.circlesubi.network`