### PR TITLE
fix(groups): stable count + pre-allocated scroll canvas while streaming

### DIFF
--- a/circles-app/src/lib/areas/groups/ui/components/GroupMembersManager.svelte
+++ b/circles-app/src/lib/areas/groups/ui/components/GroupMembersManager.svelte
@@ -26,6 +26,7 @@
   let trustedAvatarTypes: Record<string, string | undefined> = $state({});
   let selectedSet: Set<Address> = $state(new Set<Address>());
   let groupName: string | null = $state(null);
+  let totalMemberCount: number | undefined = $state(undefined);
   let searchInputEl: HTMLInputElement | null = $state(null);
   let trustedListEl: HTMLDivElement | null = $state(null);
   const trustedStore = writable<Address[]>([]);
@@ -98,10 +99,23 @@
     trusted = [];
     trustedAvatarTypes = {};
     trustedStore.set([]);
+    totalMemberCount = undefined;
 
     try {
       const groupDataSource = createGroupDataSource(sdk);
       const avatarDataSource = createAvatarDataSource(sdk);
+
+      // Pre-fetch authoritative member count so the header is stable from the
+      // first paint rather than ticking up as pages arrive.
+      void groupDataSource
+        .getGroupMemberCount(group)
+        .then((n) => {
+          if (generation === loadGeneration && typeof n === 'number') {
+            totalMemberCount = n;
+          }
+        })
+        .catch(() => {});
+
       const seen = new Set<string>();
       let cursor: string | null = null;
       let first = true;
@@ -285,7 +299,7 @@
     </div>
   </div>
 
-  <div class="text-xs opacity-70">{trusted.length} trusted avatar{trusted.length === 1 ? '' : 's'}</div>
+  <div class="text-xs opacity-70">{totalMemberCount ?? trusted.length} trusted avatar{(totalMemberCount ?? trusted.length) === 1 ? '' : 's'}</div>
 
   <div role="group" aria-label="Search trusted avatars">
     <ListShell

--- a/circles-app/src/lib/shared/data/circles/groupDataSource.ts
+++ b/circles-app/src/lib/shared/data/circles/groupDataSource.ts
@@ -1,5 +1,10 @@
 import type { Sdk } from '@aboutcircles/sdk';
-import type { Address, GroupMembershipRow, PagedQueryParams } from '@aboutcircles/sdk-types';
+import type {
+  Address,
+  GroupMembershipRow,
+  GroupRow,
+  PagedQueryParams,
+} from '@aboutcircles/sdk-types';
 import { PagedQuery } from '@aboutcircles/sdk-rpc';
 
 export interface GroupMembersPage {
@@ -18,6 +23,8 @@ export interface GroupDataSource {
   ): Promise<GroupMembersPage>;
   /** Exhaustive fetch — for callers that need the full member set in one shot. */
   getGroupMembers(group: Address, pageSize?: number): Promise<GroupMembershipRow[]>;
+  /** Total member count from V_CrcV2.Groups (lets the UI pre-allocate list height). */
+  getGroupMemberCount(group: Address): Promise<number | null>;
 }
 
 export function createGroupDataSource(sdk: Sdk): GroupDataSource {
@@ -63,6 +70,29 @@ export function createGroupDataSource(sdk: Sdk): GroupDataSource {
         cursor = page.hasMore ? page.nextCursor ?? null : null;
       } while (cursor);
       return all;
+    },
+
+    async getGroupMemberCount(group: Address): Promise<number | null> {
+      const queryDef: PagedQueryParams = {
+        namespace: 'V_CrcV2',
+        table: 'Groups',
+        columns: ['group', 'memberCount'],
+        filter: [
+          {
+            Type: 'FilterPredicate',
+            FilterType: 'Equals',
+            Column: 'group',
+            Value: group.toLowerCase(),
+          },
+        ],
+        sortOrder: 'DESC',
+        limit: 1,
+      };
+      const query = new PagedQuery<GroupRow>(sdk.rpc.client, queryDef);
+      if (!(await query.queryNextPage())) return null;
+      const row = query.currentPage?.results?.[0];
+      const count = row?.memberCount;
+      return typeof count === 'number' ? count : null;
     },
   };
 }

--- a/circles-app/src/lib/shared/ui/lists/GenericList.svelte
+++ b/circles-app/src/lib/shared/ui/lists/GenericList.svelte
@@ -21,6 +21,7 @@
         expectedPageSize?: number;
         eagerLoadMultiplier?: number;
         overscan?: number;
+        totalKnownCount?: number;
     }
 
     let {
@@ -33,6 +34,7 @@
         expectedPageSize,
         eagerLoadMultiplier = 2,
         overscan = 8,
+        totalKnownCount,
     }: Props = $props();
 </script>
 
@@ -46,4 +48,5 @@
     {expectedPageSize}
     {eagerLoadMultiplier}
     {overscan}
+    {totalKnownCount}
 />

--- a/circles-app/src/lib/shared/ui/lists/SearchablePaginatedList.svelte
+++ b/circles-app/src/lib/shared/ui/lists/SearchablePaginatedList.svelte
@@ -23,6 +23,7 @@
 
     rowHeight?: number;
     pageSize?: number;
+    totalKnownCount?: number;
 
     emptyLabel?: string;
     noMatchesLabel?: string;
@@ -42,6 +43,7 @@
     emptyRequiresEnd = false,
     rowHeight = 64,
     pageSize = 25,
+    totalKnownCount,
     emptyLabel = 'No entries',
     noMatchesLabel = 'No matches',
     searchPlaceholder = 'Search by address or name',
@@ -87,6 +89,7 @@
     rowHeight={rowHeight}
     maxPlaceholderPages={2}
     expectedPageSize={pageSize}
+    {totalKnownCount}
     {placeholderRow}
   />
 </ListShell>

--- a/circles-app/src/lib/shared/ui/lists/VirtualList.svelte
+++ b/circles-app/src/lib/shared/ui/lists/VirtualList.svelte
@@ -433,7 +433,7 @@
         onfocusin={onVirtualSpaceFocusIn}
         onfocusout={onVirtualSpaceFocusOut}
     >
-        {#each virtualRows as vr (vr.kind === 'item' ? `${getKey(vr.item)}::${vr.index}` : `placeholder-${vr.placeholderIndex}`)}
+        {#each virtualRows as vr (vr.kind === 'item' ? getKey(vr.item) : `placeholder-${vr.placeholderIndex}`)}
             <div
                 class="virtual-row"
                 data-virtual-index={vr.index}

--- a/circles-app/src/lib/shared/ui/lists/VirtualList.svelte
+++ b/circles-app/src/lib/shared/ui/lists/VirtualList.svelte
@@ -25,6 +25,13 @@
         expectedPageSize?: number;
         eagerLoadMultiplier?: number;
         overscan?: number;
+        /**
+         * Reserve list height for this many rows from the start. Used when the
+         * total row count is known up-front (e.g. group memberCount). Pages
+         * stream in and replace placeholders 1:1, so the canvas height stays
+         * stable and the scrollbar doesn't jump as new pages arrive.
+         */
+        totalKnownCount?: number;
     }
 
     let {
@@ -37,6 +44,7 @@
         expectedPageSize,
         eagerLoadMultiplier = 2,
         overscan = 8,
+        totalKnownCount,
     }: Props = $props();
 
     let listEl: HTMLElement | undefined = $state();
@@ -50,8 +58,15 @@
     let stagedPlaceholders = $state(0);
     let placeholderPageSize = $state(0);
 
-    const totalPlaceholders = $derived(stagedPlaceholders);
     const loadedItems = $derived($store?.data ?? []);
+    // If the caller pre-declares the total row count, expand placeholders so
+    // the canvas reserves space for every unloaded row from the start. This
+    // keeps the scrollbar position stable as pages stream in.
+    const totalPlaceholders = $derived(
+        typeof totalKnownCount === 'number'
+            ? Math.max(stagedPlaceholders, Math.max(0, totalKnownCount - loadedItems.length))
+            : stagedPlaceholders
+    );
     const totalCount = $derived(loadedItems.length + totalPlaceholders);
 
     let rangeStart = $state(0);

--- a/circles-app/src/lib/shared/ui/profile/components/SearchablePaginatedAddressList.svelte
+++ b/circles-app/src/lib/shared/ui/profile/components/SearchablePaginatedAddressList.svelte
@@ -18,6 +18,7 @@
         error?: string | null;
         rowHeight?: number;
         pageSize?: number;
+        totalKnownCount?: number;
         searchPlaceholder?: string;
     }
 
@@ -31,6 +32,7 @@
         error = null,
         rowHeight = 64,
         pageSize = 25,
+        totalKnownCount,
         searchPlaceholder = 'Search by address or name'
     }: Props = $props();
 
@@ -61,6 +63,7 @@
         noMatchesLabel={noMatchesLabel}
         rowHeight={rowHeight}
         pageSize={pageSize}
+        {totalKnownCount}
         searchPlaceholder={searchPlaceholder}
         placeholderRow={AvatarRowPlaceholder}
     />

--- a/circles-app/src/lib/shared/ui/profile/components/TrustRelationsList.svelte
+++ b/circles-app/src/lib/shared/ui/profile/components/TrustRelationsList.svelte
@@ -25,6 +25,7 @@
     let error: string | null = $state(null);
     const rowsStore = writable<Address[]>([]);
     let loadGeneration = 0;
+    let totalKnownCount: number | undefined = $state(undefined);
 
     async function loadRelations(): Promise<void> {
         const generation = ++loadGeneration;
@@ -32,6 +33,7 @@
         error = null;
         rowsStore.set([]);
         count = 0;
+        totalKnownCount = undefined;
 
         try {
             const sdk = get(circles);
@@ -51,6 +53,18 @@
 
             if (relation === 'trusts' && subjectIsGroup) {
                 const groupDataSource = createGroupDataSource(sdk);
+                // Pre-fetch total memberCount so the badge and the list canvas
+                // are stable from the first paint instead of jumping as pages
+                // arrive.
+                const total = await groupDataSource
+                    .getGroupMemberCount(avatarAddress)
+                    .catch(() => null);
+                if (generation !== loadGeneration) return;
+                if (typeof total === 'number') {
+                    totalKnownCount = total;
+                    count = total;
+                }
+
                 const seen = new Set<string>();
                 let cursor: string | null = null;
                 let first = true;
@@ -77,7 +91,12 @@
                         newAddrs.push(addr);
                     }
                     rowsStore.update((prev) => prev.concat(newAddrs));
-                    count = get(rowsStore).length;
+                    // Only update count from the loaded length if we couldn't
+                    // resolve the authoritative total. Otherwise keep the
+                    // stable count from getGroupMemberCount.
+                    if (totalKnownCount === undefined) {
+                        count = get(rowsStore).length;
+                    }
 
                     if (first) {
                         loading = false;
@@ -129,6 +148,7 @@
     addresses={rowsStore}
     loading={loading}
     {error}
+    {totalKnownCount}
     emptyLabel="No connections"
     noMatchesLabel="No matches"
 />

--- a/circles-app/src/routes/contacts/+page.svelte
+++ b/circles-app/src/routes/contacts/+page.svelte
@@ -91,7 +91,10 @@
                     return 0;
                 })
                 .map(([address, contact]) => ({
-                    blockNumber: Date.now(),
+                    // Stable per-address fake EventRow fields so VirtualList's
+                    // default key function doesn't see a fresh blockNumber on
+                    // every derivation (which would remount every row).
+                    blockNumber: 0,
                     transactionIndex: 0,
                     logIndex: 0,
                     address,
@@ -332,6 +335,7 @@
             <GenericList
                 store={listStore}
                 row={ContactRow}
+                getKey={(item) => item.address}
                 rowHeight={64}
                 maxPlaceholderPages={2}
                 expectedPageSize={25}

--- a/circles-app/src/routes/contacts/+page.svelte
+++ b/circles-app/src/routes/contacts/+page.svelte
@@ -21,6 +21,10 @@
     import HelpPopover from '$lib/shared/ui/primitives/HelpPopover.svelte';
     import { getProfilesCoreBatch } from '$lib/shared/model/profile/coreRepo';
     import type { ProfileAddress } from '$lib/shared/model/profile/types';
+    import { circles } from '$lib/shared/state/circles';
+    import { createGroupDataSource } from '$lib/shared/data/circles/groupDataSource';
+    import type { Address } from '@aboutcircles/sdk-types';
+    import { get } from 'svelte/store';
 
     let filterVersion = writable<number | undefined>(undefined);
     let filterRelation = writable<'mutuallyTrusts' | 'trusts' | 'trustedBy' | 'variesByVersion' | undefined>(undefined);
@@ -122,6 +126,29 @@
     $effect(() => {
         const addresses = $searchedAll.slice(0, 100).map((item) => item.address);
         void preloadProfileCores(addresses);
+    });
+
+    // For group avatars, fetch the authoritative memberCount so the count badge
+    // is stable from the first paint and the list canvas can pre-allocate the
+    // full scroll height. Inert for human avatars.
+    let groupMemberCount: number | undefined = $state(undefined);
+    $effect(() => {
+        const isGroup = avatarState.isGroup;
+        const addr = avatarState.avatar?.address;
+        const sdk = get(circles);
+        groupMemberCount = undefined;
+        if (!isGroup || !addr || !sdk) return;
+        const ds = createGroupDataSource(sdk);
+        let cancelled = false;
+        void ds
+            .getGroupMemberCount(addr as Address)
+            .then((n) => {
+                if (!cancelled && typeof n === 'number') groupMemberCount = n;
+            })
+            .catch(() => {});
+        return () => {
+            cancelled = true;
+        };
     });
 
     // When the user types a search query and the underlying store still has
@@ -226,7 +253,7 @@
     {/snippet}
 
     {#snippet meta()}
-        {$filteredAll.length} {countLabel}
+        {avatarState.isGroup && groupMemberCount !== undefined ? groupMemberCount : $filteredAll.length} {countLabel}
     {/snippet}
 
     {#snippet headerActions()}
@@ -236,7 +263,7 @@
     {#snippet collapsedLeft()}
         <div class="truncate flex items-center gap-2">
             <span class="font-medium">{titleText}</span>
-            <span class="text-sm text-base-content/60">{$filteredAll.length} {countLabel}</span>
+            <span class="text-sm text-base-content/60">{avatarState.isGroup && groupMemberCount !== undefined ? groupMemberCount : $filteredAll.length} {countLabel}</span>
         </div>
     {/snippet}
 
@@ -309,6 +336,7 @@
                 maxPlaceholderPages={2}
                 expectedPageSize={25}
                 eagerLoadMultiplier={2}
+                totalKnownCount={avatarState.isGroup ? groupMemberCount : undefined}
                 placeholderRow={AvatarRowPlaceholder}
             />
         </div>


### PR DESCRIPTION
## Summary

- Pre-fetch authoritative `memberCount` from `V_CrcV2.Groups` for group-mode contact lists and the profile-popup "Trusts" tab badge, so the count is stable from the first paint instead of climbing as pages stream in.
- Pre-allocate VirtualList scroll canvas to the known total so the scrollbar position doesn't jump while pages stream in.
- Fix two compounding row-identity bugs that were remounting visible rows on every re-derivation:
  - `/contacts` synthesized fake-EventRow items used `blockNumber: Date.now()`, which made the default VirtualList key change on every page load and profile-cache update. Switched to a constant blockNumber + explicit address-based `getKey`.
  - VirtualList's `{#each}` key suffixed the item key with `::<index>`, tying identity to absolute position. Removed so identity is solely `getKey`.

## Test plan

- [ ] Sign in as a group with many members (≥ ~1k). Open `/contacts`:
  - [ ] Header count shows the authoritative total from first paint, doesn't climb.
  - [ ] Scrolling does not jump as pages stream in.
  - [ ] Visible avatar rows persist across page loads; nothing flips or is replaced under the cursor.
- [ ] Open a group profile popup as a non-member: "Trusts" tab badge shows the total immediately, doesn't climb.
- [ ] Open `/groups/members/<group>`: member count in the header is stable.
- [ ] As a human user with mixed trust relations, `/contacts` still renders normally and ordering matches `mutuallyTrusts → trusts → trustedBy`.