### PR TITLE
fix(contacts): memoize per-address row items to stop flicker on streaming load

### DIFF
--- a/circles-app/src/routes/contacts/+page.svelte
+++ b/circles-app/src/routes/contacts/+page.svelte
@@ -68,6 +68,19 @@
         }
     }
 
+    // Per-address memo: keeps the same item object reference across derivations
+    // when neither the underlying contact nor the profile-cache entry changed.
+    // Without this, every page load rebuilds every item object, ContactRow's
+    // `item` prop gets a fresh reference, and Avatar/ContactGroupRow flicker.
+    type ContactItem = {
+        blockNumber: number;
+        transactionIndex: number;
+        logIndex: number;
+        address: string;
+        contact: any;
+    };
+    const itemMemo = new Map<string, { item: ContactItem; contactRef: any; profileRef: any }>();
+
     // Build the full filtered array (not paginated)
     const filteredAll = derived(
         [contacts, filterVersion, filterRelation, profileCoreCache],
@@ -90,19 +103,27 @@
                     if (bRelation === 'trusts' && aRelation === 'trustedBy') return 1;
                     return 0;
                 })
-                .map(([address, contact]) => ({
-                    // Stable per-address fake EventRow fields so VirtualList's
-                    // default key function doesn't see a fresh blockNumber on
-                    // every derivation (which would remount every row).
-                    blockNumber: 0,
-                    transactionIndex: 0,
-                    logIndex: 0,
-                    address,
-                    contact: {
-                        ...contact,
-                        contactProfile: contact?.contactProfile ?? $profileCache.get(address.toLowerCase()),
-                    },
-                }));
+                .map(([address, contact]) => {
+                    const profileRef = $profileCache.get(address.toLowerCase());
+                    const cached = itemMemo.get(address);
+                    if (cached && cached.contactRef === contact && cached.profileRef === profileRef) {
+                        return cached.item;
+                    }
+                    const contactFinal = contact?.contactProfile
+                        ? contact
+                        : profileRef
+                          ? { ...contact, contactProfile: profileRef }
+                          : contact;
+                    const item: ContactItem = {
+                        blockNumber: 0,
+                        transactionIndex: 0,
+                        logIndex: 0,
+                        address,
+                        contact: contactFinal,
+                    };
+                    itemMemo.set(address, { item, contactRef: contact, profileRef });
+                    return item;
+                });
         }
     );
 


### PR DESCRIPTION
## Summary

- Per-address memo for the contacts page's row items. As long as the underlying contact reference and the profile-cache entry reference are unchanged, the same item object (and the same nested contact reference) is returned across derivations.
- Without this, the page re-mapped every contact into a fresh `{ ...contact, contactProfile: ... }` object on every store update — which for a streaming group member list happens once per page (e.g. 75 times for a 1903-member group). The new object reference propagated into ContactRow's `item` prop and through ContactGroupRow into Avatar internals, causing visible avatars to flicker on the rows currently in view.
- Item identity is now whatever the address+contact+profile combination resolves to; new contacts and late-arriving profiles still flow through normally.

## Test plan

- [ ] Sign in as a group with many members (≥ ~1k). Open `/contacts` and scroll: visible avatar rows stay visible while pages stream in — no on/off flicker, no avatar swaps under the cursor.
- [ ] Late-arriving profile updates from the profile cache still show up (e.g. a member whose profile resolved after the initial batch now displays its real name).
- [ ] As a human user, `/contacts` still renders normally and relation-based ordering still applies.