### PR TITLE
fix(netlify): set base = circles-app so cd .. resolves to repo root

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,5 @@
 [build]
+  base = "circles-app"
   command = "cd .. && npm install && npm run build:packages && cd circles-app && npm run build"
   publish = "build"
 


### PR DESCRIPTION
## Summary

`netlify.toml` build command starts with `cd ..` and expects to land at workspace root (where `package.json` lives). Without `base` set, Netlify clones to `/opt/build/repo` and `cd ..` escapes the clone → `npm install` errors with `ENOENT: no such file or directory, open '/opt/build/package.json'`.

Setting `base = "circles-app"` makes the relative command work without any dashboard-side configuration.

## Why this surfaces now

Sites that have `Base directory: circles-app` set in their Netlify dashboard work fine (the build command resolves correctly). Sites without that dashboard setting fail. This makes the repo's deploy contract self-contained.

## Test plan

- [ ] PR Netlify deploy-preview goes green on the connector that was previously failing
- [ ] No regression on the connector that was already green (same effective config)