### PR TITLE
fix(groups,wallet,dashboard): group-trust batch, unwrap by tokenType, refresh button

### DIFF
--- a/circles-app/src/lib/areas/wallet/ui/pages/Balances.svelte
+++ b/circles-app/src/lib/areas/wallet/ui/pages/Balances.svelte
@@ -3,7 +3,6 @@
     import {circlesBalances} from '$lib/shared/state/circlesBalances';
     import { circles } from '$lib/shared/state/circles';
     import {derived, writable, type Writable} from 'svelte/store';
-    import { onMount } from 'svelte';
     import BalanceRow from '$lib/areas/wallet/ui/components/BalanceRow.svelte';
     import BalanceRowPlaceholder from '$lib/shared/ui/lists/placeholders/BalanceRowPlaceholder.svelte';
     import type {EventRow, TokenBalance} from '@aboutcircles/sdk-types';
@@ -44,7 +43,6 @@
     // visible (otherwise the list would silently exclude rows).
     const showFilters: Writable<boolean> = writable(initialFilterType !== undefined);
     const FILTER_PANEL_ID: string = 'balance-filters';
-    const BALANCES_HELP_DISMISSED_KEY = 'balances-help-dismissed-v1';
 
     let showBalancesHelp: boolean = $state(false);
     const wrappedStaticPrices = writable<WrappedStaticPriceMap>({});
@@ -61,20 +59,11 @@
 
     function dismissBalancesHelp(): void {
         showBalancesHelp = false;
-        if (browser) {
-            localStorage.setItem(BALANCES_HELP_DISMISSED_KEY, '1');
-        }
     }
 
     function openBalancesHelp(): void {
         showBalancesHelp = true;
     }
-
-    onMount(() => {
-        if (!browser) return;
-        const alreadyDismissed = localStorage.getItem(BALANCES_HELP_DISMISSED_KEY) === '1';
-        showBalancesHelp = !alreadyDismissed;
-    });
 
     let lastWrappedStaticPriceRequestKey = '';
 

--- a/circles-app/src/lib/areas/wallet/ui/pages/UnwrapTokens.svelte
+++ b/circles-app/src/lib/areas/wallet/ui/pages/UnwrapTokens.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { avatarState } from '$lib/shared/state/avatar.svelte';
   import PopupActionBar from '$lib/shared/ui/shell/PopupActionBar.svelte';
-  import { circles } from '$lib/shared/state/circles';
   import { ethers } from 'ethers';
   import BalanceRow from '$lib/areas/wallet/ui/components/BalanceRow.svelte';
   import type { TokenBalance } from '@aboutcircles/sdk-types';
@@ -38,32 +37,28 @@
   }
 
   async function unwrap() {
-    const tokenInfo = await $circles?.rpc?.token?.getTokenInfo(asset.tokenAddress);
-    if (!tokenInfo) {
-      return;
-    }
     if (!avatarState.avatar) {
       throw new Error('Avatar not loaded');
     }
-    const avatar = avatarState.avatar;
 
     const amountWei = BigInt(ethers.parseEther(amount.toString()));
 
-    if (tokenInfo.type === 'CrcV2_ERC20WrapperDeployed_Inflationary') {
-      void executeTxSubmitFirst({
-        name: `Unwrap ${roundToDecimals(amount)} static tokens ...`,
-        submit: () => unwrapViaRunner(asset.tokenAddress, amountWei),
-        onSubmitted: () => popupControls.close(),
-      });
-    } else if (tokenInfo.type === 'CrcV2_ERC20WrapperDeployed_Demurraged') {
-      void executeTxSubmitFirst({
-        name: `Unwrap ${roundToDecimals(amount)} tokens ...`,
-        submit: () => unwrapViaRunner(asset.tokenAddress, amountWei),
-        onSubmitted: () => popupControls.close(),
-      });
-    } else {
-      throw new Error('Unsupported token type');
+    // asset.tokenType is the same field the row-action button gates on
+    // (BalanceRowActions.svelte) — by the time we're here it must be a wrapper.
+    const isInflationary =
+      asset.tokenType === 'CrcV2_ERC20WrapperDeployed_Inflationary';
+    const isDemurraged =
+      asset.tokenType === 'CrcV2_ERC20WrapperDeployed_Demurraged';
+
+    if (!isInflationary && !isDemurraged) {
+      throw new Error(`Unsupported token type: ${asset.tokenType ?? 'unknown'}`);
     }
+
+    void executeTxSubmitFirst({
+      name: `Unwrap ${roundToDecimals(amount)} ${isInflationary ? 'static ' : ''}tokens ...`,
+      submit: () => unwrapViaRunner(asset.tokenAddress, amountWei),
+      onSubmitted: () => popupControls.close(),
+    });
   }
 </script>
 

--- a/circles-app/src/lib/shared/state/circlesBalances.ts
+++ b/circles-app/src/lib/shared/state/circlesBalances.ts
@@ -24,6 +24,40 @@ const _circlesBalances = writable<{
   ended: boolean;
 }>({ data: [], next: async () => false, ended: false });
 
+// Strict fetch: throws on real errors so refresh callers can surface them.
+// Returns [] only when the indexer explicitly reports "No balances found".
+async function _fetchBalancesStrict(avatar: Avatar): Promise<TokenBalance[]> {
+  if (!avatar || typeof avatar !== 'object') {
+    throw new Error('Avatar is not properly initialized');
+  }
+  if (
+    !avatar.balances ||
+    typeof avatar.balances.getTokenBalances !== 'function'
+  ) {
+    throw new Error('Avatar balances API unavailable');
+  }
+  try {
+    return (await avatar.balances.getTokenBalances()) as unknown as TokenBalance[];
+  } catch (e: unknown) {
+    const errorMessage = e instanceof Error ? e.message : String(e);
+    if (errorMessage.includes('No balances found')) return [];
+    throw e;
+  }
+}
+
+// Graceful loader for boot/event paths — never throws, persists to IDB on success only.
+async function _loadBalancesFor(avatar: Avatar): Promise<TokenBalance[]> {
+  try {
+    const balances = await _fetchBalancesStrict(avatar);
+    void writeBalances(makeScopeId(avatar.address), balances as any[]);
+    return balances;
+  } catch (e: unknown) {
+    const errorMessage = e instanceof Error ? e.message : String(e);
+    console.error('[Balances] Error loading balances:', errorMessage);
+    return [];
+  }
+}
+
 export const initBalanceStore = (avatar: Avatar) => {
   // Early return if already initialized for this avatar
   if (currentAvatarAddress === avatar.address) {
@@ -42,65 +76,14 @@ export const initBalanceStore = (avatar: Avatar) => {
     ended: false,
   });
 
-  const scopeId = makeScopeId(avatar.address);
-
-  const _initialLoad = async (): Promise<TokenBalance[]> => {
-    try {
-      // Validate avatar is properly initialized
-      if (!avatar || typeof avatar !== 'object') {
-        console.error('[Balances] Avatar is not properly initialized:', avatar);
-        return [];
-      }
-
-      // Use new SDK balances.getTokenBalances method
-      if (
-        !avatar.balances ||
-        typeof avatar.balances.getTokenBalances !== 'function'
-      ) {
-        console.error(
-          '[Balances] No balances.getTokenBalances method available on avatar'
-        );
-        return [];
-      }
-
-      const balances = await avatar.balances.getTokenBalances() as unknown as TokenBalance[];
-      void writeBalances(scopeId, balances as any[]);
-      return balances;
-    } catch (e: unknown) {
-      const errorMessage = e instanceof Error ? e.message : String(e);
-      if (errorMessage.includes('No balances found')) {
-        return [];
-      }
-      console.error('[Balances] Error loading balances:', errorMessage);
-      return [];
-    }
-  };
+  const _initialLoad = (): Promise<TokenBalance[]> => _loadBalancesFor(avatar);
 
   const _handleEvent = async (
     event: CirclesEvent,
     currentData: TokenBalance[]
   ): Promise<TokenBalance[]> => {
     if (!refreshOnEvents.has(event.$event)) return currentData;
-    try {
-      // Use new SDK balances.getTokenBalances method
-      if (
-        !avatar.balances ||
-        typeof avatar.balances.getTokenBalances !== 'function'
-      ) {
-        throw new Error('No balances.getTokenBalances method available');
-      }
-
-      const balances = await avatar.balances.getTokenBalances() as unknown as TokenBalance[];
-      void writeBalances(scopeId, balances as any[]);
-      return balances;
-    } catch (e: unknown) {
-      const errorMessage = e instanceof Error ? e.message : String(e);
-      if (errorMessage.includes('No balances found')) {
-        return [];
-      }
-      console.error('[Balances] Error refreshing balances:', errorMessage);
-      throw new Error(`Failed to refresh balances: ${errorMessage}`);
-    }
+    return _loadBalancesFor(avatar);
   };
 
   const _handleNextPage = async (currentData: TokenBalance[]) => {
@@ -124,6 +107,17 @@ export const initBalanceStore = (avatar: Avatar) => {
   );
 
   currentStoreUnsubscribe = store.subscribe(_circlesBalances.set);
+};
+
+// Re-fetch balances and patch the store in place. Does not rebuild the event
+// subscription, so no empty-state flash for subscribers (e.g. totalCirclesBalance).
+// Throws on RPC/network failure so the caller can surface an error instead of
+// silently overwriting visible balances with an empty array.
+export const refreshBalanceStore = async (avatar: Avatar): Promise<void> => {
+  if (!avatar) return;
+  const balances = await _fetchBalancesStrict(avatar);
+  void writeBalances(makeScopeId(avatar.address), balances as any[]);
+  _circlesBalances.update((s) => ({ ...s, data: balances }));
 };
 
 export const circlesBalances = _circlesBalances;

--- a/circles-app/src/lib/shared/state/wallet.svelte.ts
+++ b/circles-app/src/lib/shared/state/wallet.svelte.ts
@@ -275,6 +275,10 @@ export async function restoreSession() {
     }
 
     circles.set(sdk);
+    // Publish the runner so tx-submission utilities (sendRunnerTransactionAndWait,
+    // gateway flows, unwrap, etc.) work after a page reload. The connect-wallet
+    // pages set this on first connect; restoreSession was missing the same call.
+    wallet.set(newRunner as ContractRunner);
 
     let savedGroup = CirclesStorage.getInstance().group;
 

--- a/circles-app/src/lib/shared/utils/trustActions.ts
+++ b/circles-app/src/lib/shared/utils/trustActions.ts
@@ -1,6 +1,7 @@
 import { get } from 'svelte/store';
 import { ethers } from 'ethers';
 import type { Address } from '@aboutcircles/sdk-types';
+import type { BaseGroupAvatar } from '@aboutcircles/sdk';
 
 import { avatarState } from '$lib/shared/state/avatar.svelte';
 import { circles } from '$lib/shared/state/circles';
@@ -38,9 +39,19 @@ export async function addTrustRelations(params: {
 
     // Group trust tx does not require event subscription; avoid websocket subscribe timeout path.
     const groupAvatar = await sdk.getAvatar(params.actorAddress, false);
+    // BaseGroup.trust is onlyOwner and bypasses membership-condition checks;
+    // BaseGroup.trustBatchWithConditions is onlyOwnerOrService and runs the
+    // condition gate — the correct entry point for managing group members.
+    const usesConditions =
+      groupAvatar.trust && 'addBatchWithConditions' in groupAvatar.trust;
     await runTask({
       name: `${shortenAddress(params.actorAddress)} trusts ${trustTargets.length} avatar${trustTargets.length === 1 ? '' : 's'} ...`,
-      promise: groupAvatar.trust.add(trustTargets),
+      promise: usesConditions
+        ? (groupAvatar as BaseGroupAvatar).trust.addBatchWithConditions(
+            trustTargets,
+            BigInt('0xFFFFFFFFFFFFFFFFFFFFFFFF'),
+          )
+        : groupAvatar.trust.add(trustTargets),
     });
     return;
   }

--- a/circles-app/src/lib/shared/utils/tx.ts
+++ b/circles-app/src/lib/shared/utils/tx.ts
@@ -1,6 +1,8 @@
 import { ethers } from 'ethers';
+import { get } from 'svelte/store';
 import { uint256ToAddress, CirclesConverter } from '@aboutcircles/sdk-utils';
 import { formatCurrency } from '$lib/shared/utils/money';
+import { circles } from '$lib/shared/state/circles';
 
 export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 export const isZeroAddress = (addr?: string | null) => (addr ?? '').toLowerCase() === ZERO_ADDRESS;
@@ -115,6 +117,18 @@ export async function waitForReceiptRaw(
   throw new Error(`${label} receipt timeout`);
 }
 
+// Fallback receipt-poller for runners (e.g. the Circles-native PK signer) that
+// broadcast successfully but don't expose a provider.send(). Wraps the SDK's
+// JSON-RPC client so eth_getTransactionReceipt still works.
+function getSdkRpcProvider(): { send: (method: string, params?: any[]) => Promise<any> } | null {
+  const sdk = get(circles) as any;
+  const call = sdk?.rpc?.client?.call;
+  if (typeof call !== 'function') return null;
+  return {
+    send: (method, params) => call.call(sdk.rpc.client, method, params ?? []),
+  };
+}
+
 export async function sendRunnerTransactionAndWait(
   runner: {
     sendTransaction?: (...args: any[]) => Promise<any>;
@@ -134,5 +148,14 @@ export async function sendRunnerTransactionAndWait(
     throw new Error('Transaction hash missing');
   }
 
-  return waitForReceiptRaw(runner.provider, txHash, options);
+  const provider = runner.provider?.send ? runner.provider : getSdkRpcProvider();
+  if (!provider) {
+    // Broadcast succeeded but no provider is available to confirm. Throw so the
+    // caller can surface an error — returning a hash-only object silently lies
+    // to callers that decode receipt.logs (e.g. ConfirmCreateGateway).
+    throw new Error(
+      `Transaction broadcast (hash: ${txHash}) but receipt cannot be verified — no provider available`
+    );
+  }
+  return waitForReceiptRaw(provider, txHash, options);
 }

--- a/circles-app/src/routes/dashboard/+page.svelte
+++ b/circles-app/src/routes/dashboard/+page.svelte
@@ -10,9 +10,10 @@
     import { popupControls } from '$lib/shared/state/popup';
     import { ethers } from 'ethers';
     import Balances from '$lib/areas/wallet/ui/pages/Balances.svelte';
-    import { circlesBalances } from '$lib/shared/state/circlesBalances';
+    import { circlesBalances, refreshBalanceStore } from '$lib/shared/state/circlesBalances';
     import { totalCirclesBalance } from '$lib/shared/state/totalCirclesBalance';
     import { refreshTransactionHistory } from '$lib/shared/state/transactionHistory';
+    import { notifyError } from '$lib/shared/state/notifications.svelte';
     import { buildGroupOwnerSet } from '$lib/shared/utils/tokenClassification';
 
     import PageScaffold from '$lib/shared/ui/shell/PageScaffold.svelte';
@@ -20,7 +21,7 @@
     import { HumanAvatar } from '@aboutcircles/sdk';
 
     // lucide (standalone) icon nodes
-    import { Send as LSend, Banknote as LBanknote, BarChart3 as LBarChart3, ArrowLeftRight as LArrowLeftRight, ArrowUpDown as LArrowUpDown } from 'lucide';
+    import { Send as LSend, Banknote as LBanknote, BarChart3 as LBarChart3, ArrowLeftRight as LArrowLeftRight, ArrowUpDown as LArrowUpDown, RefreshCw as LRefreshCw } from 'lucide';
     import Lucide from '$lib/shared/ui/icons/Lucide.svelte';
     import HelpPopover from '$lib/shared/ui/primitives/HelpPopover.svelte';
     import TrustEventsPanel from './TrustEventsPanel.svelte';
@@ -110,6 +111,24 @@
         });
     }
 
+    // In-app refresh — avoids forcing the user to reload the page (which loses session).
+    let refreshing: boolean = $state(false);
+    async function refreshDashboard() {
+        const avatar = avatarState.avatar;
+        if (!avatar || refreshing) return;
+        refreshing = true;
+        try {
+            await Promise.all([
+                refreshBalanceStore(avatar),
+                refreshTransactionHistory(),
+            ]);
+        } catch (error) {
+            console.error('[Dashboard] Refresh failed:', error);
+            notifyError(error, 'Refresh failed');
+        } finally {
+            refreshing = false;
+        }
+    }
 </script>
 
 <PageScaffold
@@ -167,6 +186,18 @@
             </button>
         {/if}
 
+        <button
+            type="button"
+            class="btn btn-ghost btn-sm"
+            onclick={refreshDashboard}
+            disabled={refreshing}
+            title="Refresh"
+            aria-label="Refresh"
+        >
+            <Lucide icon={LRefreshCw} size={16} class={`shrink-0 ${refreshing ? 'animate-spin' : ''}`} />
+            Refresh
+        </button>
+
         {#if mintableAmount >= 0.01}
             <button type="button" class="btn btn-primary btn-sm" onclick={mintPersonalCircles}>
                 <Lucide icon={LBanknote} size={16} class="shrink-0" />
@@ -221,6 +252,16 @@
             >
                 <Lucide icon={LBarChart3} size={20} class="shrink-0" />
                 See breakdown
+            </button>
+
+            <button
+                    type="button"
+                    class="btn btn-ghost min-h-0 h-[var(--collapsed-h)] md:h-[var(--collapsed-h-md)] justify-start px-3"
+                    onclick={refreshDashboard}
+                    disabled={refreshing}
+            >
+                <Lucide icon={LRefreshCw} size={20} class={`shrink-0 ${refreshing ? 'animate-spin' : ''}`} />
+                Refresh
             </button>
         </div>
     {/snippet}


### PR DESCRIPTION
## Summary

Three reported regressions + three issues uncovered during verification, all in scope of the same flows.

## What changed

**Groups**
- \`trustActions.ts\` routes group-avatar trust adds through \`BaseGroupAvatar.trust.addBatchWithConditions(...)\` instead of \`trust.add(...)\`. The new path lands on the contract's \`onlyOwnerOrService\` modifier and runs membership-condition checks; the old single-target path required strict \`onlyOwner\` and reverted with \`execTransaction reverted\` for Safe-managed groups. Feature-detected via \`'addBatchWithConditions' in groupAvatar.trust\` so non-group avatars still use the single-target \`trust.add\`. Mirrors the working pattern already used by the parallel "manage group members" flow.

**Wallet — Unwrap**
- \`UnwrapTokens.svelte\` switches on \`asset.tokenType\` directly (\`CrcV2_ERC20WrapperDeployed_Inflationary\` / \`_Demurraged\`). Removes the \`sdk.rpc.token.getTokenInfo\` round-trip which returned \`undefined\` for static-wrapper rows on the current RPC and caused the \`Unsupported token type\` error.

**Dashboard — Refresh**
- New Refresh button (and collapsed-menu entry) that runs \`refreshBalanceStore\` + \`refreshTransactionHistory\` in parallel. Avoids forcing a page reload, which currently loses the session.
- \`refreshBalanceStore\` is a new export: patches the writable store in place without rebuilding the event subscription, so derived stores (\`totalCirclesBalance\`) don't flash empty.
- A strict fetch helper (\`_fetchBalancesStrict\`) throws on RPC failure so a transient error surfaces via \`notifyError\` instead of silently overwriting the visible balances with an empty array (and persisting the empty array to IDB).
- Refresh failures are caught and toasted; the spinner clears in \`finally\`.

**Wallet — Session restore**
- \`restoreSession()\` now publishes \`newRunner\` to the wallet runner store. Without this, a hard page reload after a Circles-native session left the store \`undefined\`, and the first tx submit threw \`Wallet runner is not available\`. Only initial \`/connect-wallet/*\` flows previously set the store.

**Transactions — Receipt polling**
- \`sendRunnerTransactionAndWait\` falls back to \`sdk.rpc.client.call\` when the runner exposes no \`provider.send\` (case: Circles-native PK signer). Throws when no provider is available at all, instead of returning a hash-only stub — receipt-decoding callers (\`ConfirmCreateGateway\`) no longer see a silent no-op "success" if the stub ever surfaces.

**Balances UI**
- Drops the \`onMount\` + \`localStorage\` flag that auto-opened the "Why so many tokens?" popover until dismissed. Popover now only opens on the (?) button click.

## Notes

- The receipt-polling fallback uses \`sdk.rpc.client\` which on Gnosis prod sits behind the same host as chain RPC. On Chiado the URLs differ; the fallback may not resolve \`eth_getTransactionReceipt\` there. Production targets Gnosis; Chiado fallback can be wired to \`chainRpcUrl\` separately if needed.

## Test plan

- [x] Group trust add (test group, Safe-managed): tx broadcasts. Calldata selector verified as \`0x4141f954\` (\`trustBatchWithConditions(address[],uint96)\`), not the old \`0x75dcebc7\` (\`trust(address,uint96)\`). Membership-condition revert is the correct downstream gate.
- [x] Unwrap static wrapper (Inflationary): popup submits without \`Unsupported token type\`; wrapper balance decreases on-chain.
- [x] Dashboard Refresh button: clicking updates balance and tx history without a page reload; no logout; disabled during in-flight.
- [x] Hard page reload mid-session followed by a tx submit: no \`Wallet runner is not available\`.
- [x] "Why so many tokens?" popover: no auto-open on Balance breakdown; opens only on (?) click.
- [x] Filter buttons on dashboard ("From N people" / "M groups"): correctly pre-filter the breakdown view.