### PR TITLE
feat(groups): opt-out on Memberships; remove redundant dashboard refresh

### DIFF
--- a/circles-app/src/lib/areas/groups/ui/pages/LeaveGroup.svelte
+++ b/circles-app/src/lib/areas/groups/ui/pages/LeaveGroup.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+    import { wallet } from '$lib/shared/state/wallet.svelte';
+    import { executeTxSubmitFirst } from '$lib/shared/utils/txExecution';
+    import { sendRunnerTransactionAndWait } from '$lib/shared/utils/tx';
+    import { popupControls } from '$lib/shared/state/popup';
+    import Avatar from '$lib/shared/ui/avatar/Avatar.svelte';
+    import { shortenAddress } from '$lib/shared/utils/shared';
+
+    interface Props {
+        group: `0x${string}`;
+        onLeft?: () => void | Promise<void>;
+    }
+
+    let { group, onLeft }: Props = $props();
+
+    // ScoreGroup.optOut() — no args. Selector: keccak256("optOut()")[0:4]
+    const OPT_OUT_CALLDATA = '0xd4eec5a6';
+
+    async function leaveGroup() {
+        const runner: any = $wallet;
+        if (!runner) throw new Error('Wallet is not connected.');
+
+        void executeTxSubmitFirst({
+            name: `Leaving group ${shortenAddress(group)} ...`,
+            submit: async () => {
+                await sendRunnerTransactionAndWait(runner, {
+                    to: group,
+                    value: 0n,
+                    data: OPT_OUT_CALLDATA,
+                }, { label: 'Leave group' });
+            },
+            onSubmitted: async () => {
+                popupControls.close();
+                await onLeft?.();
+            },
+        });
+    }
+</script>
+
+<div class="space-y-4 p-1">
+    <p class="text-sm">
+        You're about to opt out of the following group:
+    </p>
+
+    <Avatar
+        address={group}
+        view="horizontal"
+        clickable={false}
+        bottomInfo={group}
+        showTypeInfo={true}
+    />
+
+    <div class="rounded-md bg-warning/10 text-warning-content border border-warning/30 p-3 text-sm">
+        Opting out revokes the group's trust of your avatar and prevents it from re-adding you
+        until you call <code>trust</code> on yourself again.
+    </div>
+
+    <div class="flex justify-end gap-2 pt-2">
+        <button type="button" class="btn btn-ghost btn-sm" onclick={() => popupControls.close()}>
+            Cancel
+        </button>
+        <button type="button" class="btn btn-error btn-sm" onclick={leaveGroup} disabled={!$wallet}>
+            Opt out
+        </button>
+    </div>
+</div>

--- a/circles-app/src/lib/areas/groups/utils/optOutSupport.ts
+++ b/circles-app/src/lib/areas/groups/utils/optOutSupport.ts
@@ -1,0 +1,68 @@
+import { JsonRpcProvider } from 'ethers';
+import { getActiveConfig } from '$lib/shared/state/settings.svelte';
+
+// Function selector for ScoreGroup.optOut() (no args).
+// keccak256("optOut()")[0:4]
+const OPT_OUT_SELECTOR = 'd4eec5a6';
+
+const CACHE_KEY_PREFIX = 'circles.optOutSupport.';
+
+// In-memory cache to dedupe concurrent probes for the same address.
+const inflight = new Map<string, Promise<boolean>>();
+
+function cacheKey(address: string): string {
+  return `${CACHE_KEY_PREFIX}${address.toLowerCase()}`;
+}
+
+function readCached(address: string): boolean | null {
+  if (typeof localStorage === 'undefined') return null;
+  const v = localStorage.getItem(cacheKey(address));
+  if (v === '1') return true;
+  if (v === '0') return false;
+  return null;
+}
+
+function writeCached(address: string, supported: boolean): void {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(cacheKey(address), supported ? '1' : '0');
+  } catch {
+    // localStorage quota / privacy mode — ignore, probe will repeat next session.
+  }
+}
+
+// Probe whether the contract at `address` exposes `optOut()` (selector 0xd4eec5a6).
+// Resolves to `false` on any RPC failure so callers default to hiding the action.
+export async function probeOptOutSupport(address: string): Promise<boolean> {
+  const cached = readCached(address);
+  if (cached !== null) return cached;
+
+  const key = address.toLowerCase();
+  const existing = inflight.get(key);
+  if (existing) return existing;
+
+  const probe = (async () => {
+    const config = getActiveConfig();
+    const rpcUrl = config.chainRpcUrl ?? config.circlesRpcUrl;
+    if (!rpcUrl) return false;
+
+    try {
+      const provider = new JsonRpcProvider(rpcUrl);
+      const code = await provider.getCode(address);
+      if (!code || code === '0x') return false;
+      const supported = code.toLowerCase().includes(OPT_OUT_SELECTOR);
+      writeCached(address, supported);
+      return supported;
+    } catch {
+      // Network or RPC error: do not cache. Next call may succeed.
+      return false;
+    }
+  })();
+
+  inflight.set(key, probe);
+  try {
+    return await probe;
+  } finally {
+    inflight.delete(key);
+  }
+}

--- a/circles-app/src/lib/shared/state/circlesBalances.ts
+++ b/circles-app/src/lib/shared/state/circlesBalances.ts
@@ -24,35 +24,27 @@ const _circlesBalances = writable<{
   ended: boolean;
 }>({ data: [], next: async () => false, ended: false });
 
-// Strict fetch: throws on real errors so refresh callers can surface them.
-// Returns [] only when the indexer explicitly reports "No balances found".
-async function _fetchBalancesStrict(avatar: Avatar): Promise<TokenBalance[]> {
+async function _loadBalancesFor(avatar: Avatar): Promise<TokenBalance[]> {
   if (!avatar || typeof avatar !== 'object') {
-    throw new Error('Avatar is not properly initialized');
+    console.error('[Balances] Avatar is not properly initialized:', avatar);
+    return [];
   }
   if (
     !avatar.balances ||
     typeof avatar.balances.getTokenBalances !== 'function'
   ) {
-    throw new Error('Avatar balances API unavailable');
+    console.error(
+      '[Balances] No balances.getTokenBalances method available on avatar'
+    );
+    return [];
   }
   try {
-    return (await avatar.balances.getTokenBalances()) as unknown as TokenBalance[];
-  } catch (e: unknown) {
-    const errorMessage = e instanceof Error ? e.message : String(e);
-    if (errorMessage.includes('No balances found')) return [];
-    throw e;
-  }
-}
-
-// Graceful loader for boot/event paths — never throws, persists to IDB on success only.
-async function _loadBalancesFor(avatar: Avatar): Promise<TokenBalance[]> {
-  try {
-    const balances = await _fetchBalancesStrict(avatar);
+    const balances = (await avatar.balances.getTokenBalances()) as unknown as TokenBalance[];
     void writeBalances(makeScopeId(avatar.address), balances as any[]);
     return balances;
   } catch (e: unknown) {
     const errorMessage = e instanceof Error ? e.message : String(e);
+    if (errorMessage.includes('No balances found')) return [];
     console.error('[Balances] Error loading balances:', errorMessage);
     return [];
   }
@@ -107,17 +99,6 @@ export const initBalanceStore = (avatar: Avatar) => {
   );
 
   currentStoreUnsubscribe = store.subscribe(_circlesBalances.set);
-};
-
-// Re-fetch balances and patch the store in place. Does not rebuild the event
-// subscription, so no empty-state flash for subscribers (e.g. totalCirclesBalance).
-// Throws on RPC/network failure so the caller can surface an error instead of
-// silently overwriting visible balances with an empty array.
-export const refreshBalanceStore = async (avatar: Avatar): Promise<void> => {
-  if (!avatar) return;
-  const balances = await _fetchBalancesStrict(avatar);
-  void writeBalances(makeScopeId(avatar.address), balances as any[]);
-  _circlesBalances.update((s) => ({ ...s, data: balances }));
 };
 
 export const circlesBalances = _circlesBalances;

--- a/circles-app/src/routes/dashboard/+page.svelte
+++ b/circles-app/src/routes/dashboard/+page.svelte
@@ -10,10 +10,9 @@
     import { popupControls } from '$lib/shared/state/popup';
     import { ethers } from 'ethers';
     import Balances from '$lib/areas/wallet/ui/pages/Balances.svelte';
-    import { circlesBalances, refreshBalanceStore } from '$lib/shared/state/circlesBalances';
+    import { circlesBalances } from '$lib/shared/state/circlesBalances';
     import { totalCirclesBalance } from '$lib/shared/state/totalCirclesBalance';
     import { refreshTransactionHistory } from '$lib/shared/state/transactionHistory';
-    import { notifyError } from '$lib/shared/state/notifications.svelte';
     import { buildGroupOwnerSet } from '$lib/shared/utils/tokenClassification';
 
     import PageScaffold from '$lib/shared/ui/shell/PageScaffold.svelte';
@@ -21,7 +20,7 @@
     import { HumanAvatar } from '@aboutcircles/sdk';
 
     // lucide (standalone) icon nodes
-    import { Send as LSend, Banknote as LBanknote, BarChart3 as LBarChart3, ArrowLeftRight as LArrowLeftRight, ArrowUpDown as LArrowUpDown, RefreshCw as LRefreshCw } from 'lucide';
+    import { Send as LSend, Banknote as LBanknote, BarChart3 as LBarChart3, ArrowLeftRight as LArrowLeftRight, ArrowUpDown as LArrowUpDown } from 'lucide';
     import Lucide from '$lib/shared/ui/icons/Lucide.svelte';
     import HelpPopover from '$lib/shared/ui/primitives/HelpPopover.svelte';
     import TrustEventsPanel from './TrustEventsPanel.svelte';
@@ -111,24 +110,6 @@
         });
     }
 
-    // In-app refresh — avoids forcing the user to reload the page (which loses session).
-    let refreshing: boolean = $state(false);
-    async function refreshDashboard() {
-        const avatar = avatarState.avatar;
-        if (!avatar || refreshing) return;
-        refreshing = true;
-        try {
-            await Promise.all([
-                refreshBalanceStore(avatar),
-                refreshTransactionHistory(),
-            ]);
-        } catch (error) {
-            console.error('[Dashboard] Refresh failed:', error);
-            notifyError(error, 'Refresh failed');
-        } finally {
-            refreshing = false;
-        }
-    }
 </script>
 
 <PageScaffold
@@ -186,18 +167,6 @@
             </button>
         {/if}
 
-        <button
-            type="button"
-            class="btn btn-ghost btn-sm"
-            onclick={refreshDashboard}
-            disabled={refreshing}
-            title="Refresh"
-            aria-label="Refresh"
-        >
-            <Lucide icon={LRefreshCw} size={16} class={`shrink-0 ${refreshing ? 'animate-spin' : ''}`} />
-            Refresh
-        </button>
-
         {#if mintableAmount >= 0.01}
             <button type="button" class="btn btn-primary btn-sm" onclick={mintPersonalCircles}>
                 <Lucide icon={LBanknote} size={16} class="shrink-0" />
@@ -254,15 +223,6 @@
                 See breakdown
             </button>
 
-            <button
-                    type="button"
-                    class="btn btn-ghost min-h-0 h-[var(--collapsed-h)] md:h-[var(--collapsed-h-md)] justify-start px-3"
-                    onclick={refreshDashboard}
-                    disabled={refreshing}
-            >
-                <Lucide icon={LRefreshCw} size={20} class={`shrink-0 ${refreshing ? 'animate-spin' : ''}`} />
-                Refresh
-            </button>
         </div>
     {/snippet}
 

--- a/circles-app/src/routes/groups/+page.svelte
+++ b/circles-app/src/routes/groups/+page.svelte
@@ -318,7 +318,14 @@
                 >
                     {#snippet children()}
                         {#each memberships as item (item.group)}
-                            <GroupRowView item={item} />
+                            <GroupRowView
+                                item={item}
+                                showOptOut={true}
+                                onLeft={async () => {
+                                    membershipsLoadedForAvatar = null;
+                                    await loadMemberships();
+                                }}
+                            />
                         {/each}
                     {/snippet}
                 </GroupTabPanel>

--- a/circles-app/src/routes/groups/GroupRowView.svelte
+++ b/circles-app/src/routes/groups/GroupRowView.svelte
@@ -4,12 +4,39 @@
     import { openProfilePopup } from '$lib/shared/ui/profile/openProfilePopup';
     import RowFrame from '$lib/shared/ui/primitives/RowFrame.svelte';
     import { createKeyboardListNavigator } from '$lib/shared/ui/lists/utils/keyboardListNavigator';
+    import { probeOptOutSupport } from '$lib/areas/groups/utils/optOutSupport';
+    import { openFlowPopup } from '$lib/shared/state/popup';
+    import LeaveGroup from '$lib/areas/groups/ui/pages/LeaveGroup.svelte';
 
-    interface Props { item: GroupRow; }
-    let { item }: Props = $props();
+    interface Props {
+        item: GroupRow;
+        showOptOut?: boolean;
+        onLeft?: () => void | Promise<void>;
+    }
+    let { item, showOptOut = false, onLeft }: Props = $props();
+
+    let optOutSupported: boolean = $state(false);
+
+    $effect(() => {
+        if (!showOptOut) return;
+        let cancelled = false;
+        void probeOptOutSupport(item.group).then((supported) => {
+            if (!cancelled) optOutSupported = supported;
+        });
+        return () => { cancelled = true; };
+    });
 
     function openProfile() {
         openProfilePopup(item.group);
+    }
+
+    function openLeaveGroupFlow(event: MouseEvent) {
+        event.stopPropagation();
+        openFlowPopup({
+            title: 'Opt out of group',
+            component: LeaveGroup,
+            props: { group: item.group, onLeft },
+        });
     }
 
     function focusGroupsSearchInput(current?: HTMLElement | null): void {
@@ -61,8 +88,22 @@
             />
         </div>
 
-    {#snippet trailing()}<div aria-hidden="true">
-            <img src="/chevron-right.svg" alt="" class="h-4 w-4 opacity-70" />
-        </div>{/snippet}
+    {#snippet trailing()}
+            <div class="flex items-center gap-2">
+                {#if showOptOut && optOutSupported}
+                    <button
+                        type="button"
+                        class="btn btn-xs btn-outline btn-error"
+                        onclick={openLeaveGroupFlow}
+                        aria-label={`Opt out of group ${item.group}`}
+                    >
+                        Opt out
+                    </button>
+                {/if}
+                <div aria-hidden="true">
+                    <img src="/chevron-right.svg" alt="" class="h-4 w-4 opacity-70" />
+                </div>
+            </div>
+        {/snippet}
     </RowFrame>
 </div>


### PR DESCRIPTION
## Summary

Follow-up to the previous bugfix bundle, addressing two findings surfaced during the live verification round:

1. The in-app Refresh button on the dashboard is now redundant. With the wallet-runner-restore fix from the prior PR, Cmd/Ctrl-R already preserves the session and reloads everything — the button was a workaround for the pre-fix logout-on-reload bug.
2. Some group contracts expose a member-side \`optOut()\` (selector \`0xd4eec5a6\`); detect at runtime and render an opt-out action on the Memberships tab only when the contract exposes it.

## What changed

**Groups — opt-out detection + action**
- New utility \`optOutSupport.ts\`: \`probeOptOutSupport(address)\` reads the contract's bytecode via \`JsonRpcProvider.getCode\` and scans for the \`0xd4eec5a6\` selector. Result is cached in \`localStorage\` keyed by \`circles.optOutSupport.<lowercased addr>\` — bytecode is immutable per address so the cache is safe indefinitely. Concurrent probes for the same address share a single in-flight \`Promise\`.
- \`GroupRowView\`: when the parent passes \`showOptOut={true}\`, probes on mount and renders an \"Opt out\" button in the trailing area only when the probe resolves true. Probe errors / network failures → button hidden (conservative).
- New flow \`LeaveGroup.svelte\`: confirms with the user, then submits a bare-selector tx (\`{ to: groupAddress, data: '0xd4eec5a6' }\`) via the wallet runner. On submit the popup closes and the parent's \`onLeft\` callback reloads the memberships list.
- \`/groups\` Memberships tab wires \`showOptOut={true}\` + an \`onLeft\` callback that invalidates the dedup guard and reruns \`loadMemberships\`. The \"My groups\" and \"All groups\" tabs are unchanged.

**Dashboard — remove redundant refresh**
- Removes the Refresh button (both header and collapsed-menu entries), the \`refreshing\` \`$state\`, the \`refreshDashboard\` handler, and the now-orphan imports (\`refreshBalanceStore\`, \`notifyError\`, \`LRefreshCw\`).

**Balances state — revert strict/graceful split**
- The previous PR added \`_fetchBalancesStrict\` and \`refreshBalanceStore\` to back the dashboard's manual refresh. With that caller gone, both are orphan; restoring the original single graceful \`_loadBalancesFor\` keeps boot/event behavior unchanged.

## Notes

- \`tx.ts\` change from the prior PR (throw instead of synthetic-receipt stub when no provider is available) is preserved — that remains valuable for receipt-decoding callers like \`ConfirmCreateGateway\`.
- Probe uses \`chainRpcUrl\` (falls back to \`circlesRpcUrl\`) per the wallet-runner pattern; \`eth_getCode\` is not served by the circles RPC, so chain RPC is required.

## Test plan

- [ ] Memberships tab: a Score Group membership shows an \"Opt out\" button next to the row chevron; a non-Score group (default BaseGroup) does not.
- [ ] Opt out flow: click \"Opt out\" → confirm dialog → submit → tx broadcasts → on success the membership list reloads and the group disappears.
- [ ] Probe cache: open the Memberships tab twice; the second load issues zero \`eth_getCode\` calls for previously-probed groups.
- [ ] Dashboard: no Refresh button visible (header or collapsed menu); Cmd/Ctrl-R preserves session and reloads balances naturally.
- [ ] Other tabs: \"My groups\" and \"All groups\" unchanged (no opt-out button).