### PR TITLE
sync dev → main: groups opt-out, group/wallet bugfixes, perf + UX bundle

### DIFF
--- a/circles-app/src/lib/areas/groups/ui/pages/LeaveGroup.svelte
+++ b/circles-app/src/lib/areas/groups/ui/pages/LeaveGroup.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+    import { wallet } from '$lib/shared/state/wallet.svelte';
+    import { executeTxSubmitFirst } from '$lib/shared/utils/txExecution';
+    import { sendRunnerTransactionAndWait } from '$lib/shared/utils/tx';
+    import { popupControls } from '$lib/shared/state/popup';
+    import Avatar from '$lib/shared/ui/avatar/Avatar.svelte';
+    import { shortenAddress } from '$lib/shared/utils/shared';
+
+    interface Props {
+        group: `0x${string}`;
+        onLeft?: () => void | Promise<void>;
+    }
+
+    let { group, onLeft }: Props = $props();
+
+    // ScoreGroup.optOut() — no args. Selector: keccak256("optOut()")[0:4]
+    const OPT_OUT_CALLDATA = '0xd4eec5a6';
+
+    async function leaveGroup() {
+        const runner: any = $wallet;
+        if (!runner) throw new Error('Wallet is not connected.');
+
+        void executeTxSubmitFirst({
+            name: `Leaving group ${shortenAddress(group)} ...`,
+            submit: async () => {
+                await sendRunnerTransactionAndWait(runner, {
+                    to: group,
+                    value: 0n,
+                    data: OPT_OUT_CALLDATA,
+                }, { label: 'Leave group' });
+            },
+            onSubmitted: async () => {
+                popupControls.close();
+                await onLeft?.();
+            },
+        });
+    }
+</script>
+
+<div class="space-y-4 p-1">
+    <p class="text-sm">
+        You're about to opt out of the following group:
+    </p>
+
+    <Avatar
+        address={group}
+        view="horizontal"
+        clickable={false}
+        bottomInfo={group}
+        showTypeInfo={true}
+    />
+
+    <div class="rounded-md bg-warning/10 text-warning-content border border-warning/30 p-3 text-sm">
+        Opting out revokes the group's trust of your avatar and prevents it from re-adding you
+        until you call <code>trust</code> on yourself again.
+    </div>
+
+    <div class="flex justify-end gap-2 pt-2">
+        <button type="button" class="btn btn-ghost btn-sm" onclick={() => popupControls.close()}>
+            Cancel
+        </button>
+        <button type="button" class="btn btn-error btn-sm" onclick={leaveGroup} disabled={!$wallet}>
+            Opt out
+        </button>
+    </div>
+</div>

--- a/circles-app/src/lib/areas/groups/utils/optOutSupport.ts
+++ b/circles-app/src/lib/areas/groups/utils/optOutSupport.ts
@@ -1,0 +1,68 @@
+import { JsonRpcProvider } from 'ethers';
+import { getActiveConfig } from '$lib/shared/state/settings.svelte';
+
+// Function selector for ScoreGroup.optOut() (no args).
+// keccak256("optOut()")[0:4]
+const OPT_OUT_SELECTOR = 'd4eec5a6';
+
+const CACHE_KEY_PREFIX = 'circles.optOutSupport.';
+
+// In-memory cache to dedupe concurrent probes for the same address.
+const inflight = new Map<string, Promise<boolean>>();
+
+function cacheKey(address: string): string {
+  return `${CACHE_KEY_PREFIX}${address.toLowerCase()}`;
+}
+
+function readCached(address: string): boolean | null {
+  if (typeof localStorage === 'undefined') return null;
+  const v = localStorage.getItem(cacheKey(address));
+  if (v === '1') return true;
+  if (v === '0') return false;
+  return null;
+}
+
+function writeCached(address: string, supported: boolean): void {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(cacheKey(address), supported ? '1' : '0');
+  } catch {
+    // localStorage quota / privacy mode — ignore, probe will repeat next session.
+  }
+}
+
+// Probe whether the contract at `address` exposes `optOut()` (selector 0xd4eec5a6).
+// Resolves to `false` on any RPC failure so callers default to hiding the action.
+export async function probeOptOutSupport(address: string): Promise<boolean> {
+  const cached = readCached(address);
+  if (cached !== null) return cached;
+
+  const key = address.toLowerCase();
+  const existing = inflight.get(key);
+  if (existing) return existing;
+
+  const probe = (async () => {
+    const config = getActiveConfig();
+    const rpcUrl = config.chainRpcUrl ?? config.circlesRpcUrl;
+    if (!rpcUrl) return false;
+
+    try {
+      const provider = new JsonRpcProvider(rpcUrl);
+      const code = await provider.getCode(address);
+      if (!code || code === '0x') return false;
+      const supported = code.toLowerCase().includes(OPT_OUT_SELECTOR);
+      writeCached(address, supported);
+      return supported;
+    } catch {
+      // Network or RPC error: do not cache. Next call may succeed.
+      return false;
+    }
+  })();
+
+  inflight.set(key, probe);
+  try {
+    return await probe;
+  } finally {
+    inflight.delete(key);
+  }
+}

--- a/circles-app/src/lib/areas/wallet/ui/pages/Balances.svelte
+++ b/circles-app/src/lib/areas/wallet/ui/pages/Balances.svelte
@@ -3,7 +3,6 @@
     import {circlesBalances} from '$lib/shared/state/circlesBalances';
     import { circles } from '$lib/shared/state/circles';
     import {derived, writable, type Writable} from 'svelte/store';
-    import { onMount } from 'svelte';
     import BalanceRow from '$lib/areas/wallet/ui/components/BalanceRow.svelte';
     import BalanceRowPlaceholder from '$lib/shared/ui/lists/placeholders/BalanceRowPlaceholder.svelte';
     import type {EventRow, TokenBalance} from '@aboutcircles/sdk-types';
@@ -44,7 +43,6 @@
     // visible (otherwise the list would silently exclude rows).
     const showFilters: Writable<boolean> = writable(initialFilterType !== undefined);
     const FILTER_PANEL_ID: string = 'balance-filters';
-    const BALANCES_HELP_DISMISSED_KEY = 'balances-help-dismissed-v1';
 
     let showBalancesHelp: boolean = $state(false);
     const wrappedStaticPrices = writable<WrappedStaticPriceMap>({});
@@ -61,20 +59,11 @@
 
     function dismissBalancesHelp(): void {
         showBalancesHelp = false;
-        if (browser) {
-            localStorage.setItem(BALANCES_HELP_DISMISSED_KEY, '1');
-        }
     }
 
     function openBalancesHelp(): void {
         showBalancesHelp = true;
     }
-
-    onMount(() => {
-        if (!browser) return;
-        const alreadyDismissed = localStorage.getItem(BALANCES_HELP_DISMISSED_KEY) === '1';
-        showBalancesHelp = !alreadyDismissed;
-    });
 
     let lastWrappedStaticPriceRequestKey = '';
 

--- a/circles-app/src/lib/areas/wallet/ui/pages/UnwrapTokens.svelte
+++ b/circles-app/src/lib/areas/wallet/ui/pages/UnwrapTokens.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { avatarState } from '$lib/shared/state/avatar.svelte';
   import PopupActionBar from '$lib/shared/ui/shell/PopupActionBar.svelte';
-  import { circles } from '$lib/shared/state/circles';
   import { ethers } from 'ethers';
   import BalanceRow from '$lib/areas/wallet/ui/components/BalanceRow.svelte';
   import type { TokenBalance } from '@aboutcircles/sdk-types';
@@ -38,32 +37,28 @@
   }
 
   async function unwrap() {
-    const tokenInfo = await $circles?.rpc?.token?.getTokenInfo(asset.tokenAddress);
-    if (!tokenInfo) {
-      return;
-    }
     if (!avatarState.avatar) {
       throw new Error('Avatar not loaded');
     }
-    const avatar = avatarState.avatar;
 
     const amountWei = BigInt(ethers.parseEther(amount.toString()));
 
-    if (tokenInfo.type === 'CrcV2_ERC20WrapperDeployed_Inflationary') {
-      void executeTxSubmitFirst({
-        name: `Unwrap ${roundToDecimals(amount)} static tokens ...`,
-        submit: () => unwrapViaRunner(asset.tokenAddress, amountWei),
-        onSubmitted: () => popupControls.close(),
-      });
-    } else if (tokenInfo.type === 'CrcV2_ERC20WrapperDeployed_Demurraged') {
-      void executeTxSubmitFirst({
-        name: `Unwrap ${roundToDecimals(amount)} tokens ...`,
-        submit: () => unwrapViaRunner(asset.tokenAddress, amountWei),
-        onSubmitted: () => popupControls.close(),
-      });
-    } else {
-      throw new Error('Unsupported token type');
+    // asset.tokenType is the same field the row-action button gates on
+    // (BalanceRowActions.svelte) — by the time we're here it must be a wrapper.
+    const isInflationary =
+      asset.tokenType === 'CrcV2_ERC20WrapperDeployed_Inflationary';
+    const isDemurraged =
+      asset.tokenType === 'CrcV2_ERC20WrapperDeployed_Demurraged';
+
+    if (!isInflationary && !isDemurraged) {
+      throw new Error(`Unsupported token type: ${asset.tokenType ?? 'unknown'}`);
     }
+
+    void executeTxSubmitFirst({
+      name: `Unwrap ${roundToDecimals(amount)} ${isInflationary ? 'static ' : ''}tokens ...`,
+      submit: () => unwrapViaRunner(asset.tokenAddress, amountWei),
+      onSubmitted: () => popupControls.close(),
+    });
   }
 </script>
 

--- a/circles-app/src/lib/shared/state/circlesBalances.ts
+++ b/circles-app/src/lib/shared/state/circlesBalances.ts
@@ -24,6 +24,32 @@ const _circlesBalances = writable<{
   ended: boolean;
 }>({ data: [], next: async () => false, ended: false });
 
+async function _loadBalancesFor(avatar: Avatar): Promise<TokenBalance[]> {
+  if (!avatar || typeof avatar !== 'object') {
+    console.error('[Balances] Avatar is not properly initialized:', avatar);
+    return [];
+  }
+  if (
+    !avatar.balances ||
+    typeof avatar.balances.getTokenBalances !== 'function'
+  ) {
+    console.error(
+      '[Balances] No balances.getTokenBalances method available on avatar'
+    );
+    return [];
+  }
+  try {
+    const balances = (await avatar.balances.getTokenBalances()) as unknown as TokenBalance[];
+    void writeBalances(makeScopeId(avatar.address), balances as any[]);
+    return balances;
+  } catch (e: unknown) {
+    const errorMessage = e instanceof Error ? e.message : String(e);
+    if (errorMessage.includes('No balances found')) return [];
+    console.error('[Balances] Error loading balances:', errorMessage);
+    return [];
+  }
+}
+
 export const initBalanceStore = (avatar: Avatar) => {
   // Early return if already initialized for this avatar
   if (currentAvatarAddress === avatar.address) {
@@ -42,65 +68,14 @@ export const initBalanceStore = (avatar: Avatar) => {
     ended: false,
   });
 
-  const scopeId = makeScopeId(avatar.address);
-
-  const _initialLoad = async (): Promise<TokenBalance[]> => {
-    try {
-      // Validate avatar is properly initialized
-      if (!avatar || typeof avatar !== 'object') {
-        console.error('[Balances] Avatar is not properly initialized:', avatar);
-        return [];
-      }
-
-      // Use new SDK balances.getTokenBalances method
-      if (
-        !avatar.balances ||
-        typeof avatar.balances.getTokenBalances !== 'function'
-      ) {
-        console.error(
-          '[Balances] No balances.getTokenBalances method available on avatar'
-        );
-        return [];
-      }
-
-      const balances = await avatar.balances.getTokenBalances() as unknown as TokenBalance[];
-      void writeBalances(scopeId, balances as any[]);
-      return balances;
-    } catch (e: unknown) {
-      const errorMessage = e instanceof Error ? e.message : String(e);
-      if (errorMessage.includes('No balances found')) {
-        return [];
-      }
-      console.error('[Balances] Error loading balances:', errorMessage);
-      return [];
-    }
-  };
+  const _initialLoad = (): Promise<TokenBalance[]> => _loadBalancesFor(avatar);
 
   const _handleEvent = async (
     event: CirclesEvent,
     currentData: TokenBalance[]
   ): Promise<TokenBalance[]> => {
     if (!refreshOnEvents.has(event.$event)) return currentData;
-    try {
-      // Use new SDK balances.getTokenBalances method
-      if (
-        !avatar.balances ||
-        typeof avatar.balances.getTokenBalances !== 'function'
-      ) {
-        throw new Error('No balances.getTokenBalances method available');
-      }
-
-      const balances = await avatar.balances.getTokenBalances() as unknown as TokenBalance[];
-      void writeBalances(scopeId, balances as any[]);
-      return balances;
-    } catch (e: unknown) {
-      const errorMessage = e instanceof Error ? e.message : String(e);
-      if (errorMessage.includes('No balances found')) {
-        return [];
-      }
-      console.error('[Balances] Error refreshing balances:', errorMessage);
-      throw new Error(`Failed to refresh balances: ${errorMessage}`);
-    }
+    return _loadBalancesFor(avatar);
   };
 
   const _handleNextPage = async (currentData: TokenBalance[]) => {

--- a/circles-app/src/lib/shared/state/wallet.svelte.ts
+++ b/circles-app/src/lib/shared/state/wallet.svelte.ts
@@ -275,6 +275,10 @@ export async function restoreSession() {
     }
 
     circles.set(sdk);
+    // Publish the runner so tx-submission utilities (sendRunnerTransactionAndWait,
+    // gateway flows, unwrap, etc.) work after a page reload. The connect-wallet
+    // pages set this on first connect; restoreSession was missing the same call.
+    wallet.set(newRunner as ContractRunner);
 
     let savedGroup = CirclesStorage.getInstance().group;
 

--- a/circles-app/src/lib/shared/utils/trustActions.ts
+++ b/circles-app/src/lib/shared/utils/trustActions.ts
@@ -1,6 +1,7 @@
 import { get } from 'svelte/store';
 import { ethers } from 'ethers';
 import type { Address } from '@aboutcircles/sdk-types';
+import type { BaseGroupAvatar } from '@aboutcircles/sdk';
 
 import { avatarState } from '$lib/shared/state/avatar.svelte';
 import { circles } from '$lib/shared/state/circles';
@@ -38,9 +39,19 @@ export async function addTrustRelations(params: {
 
     // Group trust tx does not require event subscription; avoid websocket subscribe timeout path.
     const groupAvatar = await sdk.getAvatar(params.actorAddress, false);
+    // BaseGroup.trust is onlyOwner and bypasses membership-condition checks;
+    // BaseGroup.trustBatchWithConditions is onlyOwnerOrService and runs the
+    // condition gate — the correct entry point for managing group members.
+    const usesConditions =
+      groupAvatar.trust && 'addBatchWithConditions' in groupAvatar.trust;
     await runTask({
       name: `${shortenAddress(params.actorAddress)} trusts ${trustTargets.length} avatar${trustTargets.length === 1 ? '' : 's'} ...`,
-      promise: groupAvatar.trust.add(trustTargets),
+      promise: usesConditions
+        ? (groupAvatar as BaseGroupAvatar).trust.addBatchWithConditions(
+            trustTargets,
+            BigInt('0xFFFFFFFFFFFFFFFFFFFFFFFF'),
+          )
+        : groupAvatar.trust.add(trustTargets),
     });
     return;
   }

--- a/circles-app/src/lib/shared/utils/tx.ts
+++ b/circles-app/src/lib/shared/utils/tx.ts
@@ -1,6 +1,8 @@
 import { ethers } from 'ethers';
+import { get } from 'svelte/store';
 import { uint256ToAddress, CirclesConverter } from '@aboutcircles/sdk-utils';
 import { formatCurrency } from '$lib/shared/utils/money';
+import { circles } from '$lib/shared/state/circles';
 
 export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 export const isZeroAddress = (addr?: string | null) => (addr ?? '').toLowerCase() === ZERO_ADDRESS;
@@ -115,6 +117,18 @@ export async function waitForReceiptRaw(
   throw new Error(`${label} receipt timeout`);
 }
 
+// Fallback receipt-poller for runners (e.g. the Circles-native PK signer) that
+// broadcast successfully but don't expose a provider.send(). Wraps the SDK's
+// JSON-RPC client so eth_getTransactionReceipt still works.
+function getSdkRpcProvider(): { send: (method: string, params?: any[]) => Promise<any> } | null {
+  const sdk = get(circles) as any;
+  const call = sdk?.rpc?.client?.call;
+  if (typeof call !== 'function') return null;
+  return {
+    send: (method, params) => call.call(sdk.rpc.client, method, params ?? []),
+  };
+}
+
 export async function sendRunnerTransactionAndWait(
   runner: {
     sendTransaction?: (...args: any[]) => Promise<any>;
@@ -134,5 +148,14 @@ export async function sendRunnerTransactionAndWait(
     throw new Error('Transaction hash missing');
   }
 
-  return waitForReceiptRaw(runner.provider, txHash, options);
+  const provider = runner.provider?.send ? runner.provider : getSdkRpcProvider();
+  if (!provider) {
+    // Broadcast succeeded but no provider is available to confirm. Throw so the
+    // caller can surface an error — returning a hash-only object silently lies
+    // to callers that decode receipt.logs (e.g. ConfirmCreateGateway).
+    throw new Error(
+      `Transaction broadcast (hash: ${txHash}) but receipt cannot be verified — no provider available`
+    );
+  }
+  return waitForReceiptRaw(provider, txHash, options);
 }

--- a/circles-app/src/routes/dashboard/+page.svelte
+++ b/circles-app/src/routes/dashboard/+page.svelte
@@ -222,6 +222,7 @@
                 <Lucide icon={LBarChart3} size={20} class="shrink-0" />
                 See breakdown
             </button>
+
         </div>
     {/snippet}
 

--- a/circles-app/src/routes/groups/+page.svelte
+++ b/circles-app/src/routes/groups/+page.svelte
@@ -318,7 +318,14 @@
                 >
                     {#snippet children()}
                         {#each memberships as item (item.group)}
-                            <GroupRowView item={item} />
+                            <GroupRowView
+                                item={item}
+                                showOptOut={true}
+                                onLeft={async () => {
+                                    membershipsLoadedForAvatar = null;
+                                    await loadMemberships();
+                                }}
+                            />
                         {/each}
                     {/snippet}
                 </GroupTabPanel>

--- a/circles-app/src/routes/groups/GroupRowView.svelte
+++ b/circles-app/src/routes/groups/GroupRowView.svelte
@@ -4,12 +4,39 @@
     import { openProfilePopup } from '$lib/shared/ui/profile/openProfilePopup';
     import RowFrame from '$lib/shared/ui/primitives/RowFrame.svelte';
     import { createKeyboardListNavigator } from '$lib/shared/ui/lists/utils/keyboardListNavigator';
+    import { probeOptOutSupport } from '$lib/areas/groups/utils/optOutSupport';
+    import { openFlowPopup } from '$lib/shared/state/popup';
+    import LeaveGroup from '$lib/areas/groups/ui/pages/LeaveGroup.svelte';
 
-    interface Props { item: GroupRow; }
-    let { item }: Props = $props();
+    interface Props {
+        item: GroupRow;
+        showOptOut?: boolean;
+        onLeft?: () => void | Promise<void>;
+    }
+    let { item, showOptOut = false, onLeft }: Props = $props();
+
+    let optOutSupported: boolean = $state(false);
+
+    $effect(() => {
+        if (!showOptOut) return;
+        let cancelled = false;
+        void probeOptOutSupport(item.group).then((supported) => {
+            if (!cancelled) optOutSupported = supported;
+        });
+        return () => { cancelled = true; };
+    });
 
     function openProfile() {
         openProfilePopup(item.group);
+    }
+
+    function openLeaveGroupFlow(event: MouseEvent) {
+        event.stopPropagation();
+        openFlowPopup({
+            title: 'Opt out of group',
+            component: LeaveGroup,
+            props: { group: item.group, onLeft },
+        });
     }
 
     function focusGroupsSearchInput(current?: HTMLElement | null): void {
@@ -61,8 +88,22 @@
             />
         </div>
 
-    {#snippet trailing()}<div aria-hidden="true">
-            <img src="/chevron-right.svg" alt="" class="h-4 w-4 opacity-70" />
-        </div>{/snippet}
+    {#snippet trailing()}
+            <div class="flex items-center gap-2">
+                {#if showOptOut && optOutSupported}
+                    <button
+                        type="button"
+                        class="btn btn-xs btn-outline btn-error"
+                        onclick={openLeaveGroupFlow}
+                        aria-label={`Opt out of group ${item.group}`}
+                    >
+                        Opt out
+                    </button>
+                {/if}
+                <div aria-hidden="true">
+                    <img src="/chevron-right.svg" alt="" class="h-4 w-4 opacity-70" />
+                </div>
+            </div>
+        {/snippet}
     </RowFrame>
 </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10538,6 +10538,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10555,6 +10556,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10572,6 +10574,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10589,6 +10592,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10606,6 +10610,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10623,6 +10628,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10640,6 +10646,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10657,6 +10664,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10674,6 +10682,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10691,6 +10700,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10708,6 +10718,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10725,6 +10736,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10742,6 +10754,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10759,6 +10772,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10776,6 +10790,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10793,6 +10808,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10810,6 +10826,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10827,6 +10844,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10844,6 +10862,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10861,6 +10880,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10878,6 +10898,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10895,6 +10916,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10912,6 +10934,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10966,6 +10989,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }


### PR DESCRIPTION
## Summary

Promote accumulated dev work to main. Net delta is 12 files / +296 / -92.

This release branch contains the resolved merge of \`dev\` into \`main\`. Direct merge would conflict because the prior sync (#194) squashed dev commits onto main, leaving dev's original commits diverged. The resolution preserves:
- All dev's content (file diffs for the 12 changed files)
- main's \`base = "circles-app"\` line in \`netlify.toml\` (from the #195 Netlify-CI fix), since dev doesn't have it yet

## What's in this release

**User-facing fixes & features**
- Groups: member-side \`optOut()\` action surfaces on the Memberships tab for contracts whose bytecode exposes the selector (\`0xd4eec5a6\`). Probe cached per group address. (#197)
- Groups: trust-add for groups routes through \`addBatchWithConditions\` (gated \`onlyOwnerOrService\`) instead of \`trust.add\` (\`onlyOwner\`), unblocking adds on Safe-managed groups. (#196)
- Wallet: Unwrap branches on \`asset.tokenType\` directly. Removes the \`getTokenInfo\` round-trip that returned \`undefined\` for static-wrapper rows and surfaced as \"Unsupported token type\". (#196)
- Wallet: \`restoreSession\` now publishes the wallet runner to its store so a hard reload no longer leaves the first post-reload tx failing with \"Wallet runner is not available\". (#196)
- Balances UI: drop the auto-open of \"Why so many tokens?\" — popover opens only on the (?) button. (#196)
- Dashboard: remove the in-app Refresh button. With the runner-restore fix, Cmd/Ctrl-R preserves session and refreshes naturally. (#197)

**Transaction internals**
- \`sendRunnerTransactionAndWait\` falls back to \`sdk.rpc.client.call\` for receipt polling when the runner exposes no \`provider.send\`; throws (instead of returning a hash-only stub) when no provider is available — receipt-decoding callers no longer see a silent no-op success. (#196)

## Verification done on dev → app.circlesubi.network

- [x] Group trust add: calldata selector \`0x4141f954\` (\`trustBatchWithConditions\`), not \`0x75dcebc7\` (\`trust\`).
- [x] Unwrap static wrapper: submits without \"Unsupported token type\".
- [x] Hard reload mid-session: session restored, tx submit works on first try.
- [x] Memberships → Opt out: button shows only when bytecode has \`0xd4eec5a6\`. Probe verified positive (3 ScoreGroups) and negative (3 non-ScoreGroups).
- [x] Dashboard: no Refresh button; Cmd-R preserves session.
- [x] Typecheck on merged tree: 0 errors.
- [x] \`build:packages\` succeeds on merged tree.

## Test plan (post-merge, on app.aboutcircles.com)

- [ ] Land on dashboard, hard reload — session preserved, balances render.
- [ ] Groups → Memberships — Opt out button appears only on ScoreGroup memberships.
- [ ] Wallet → Unwrap on a wrapper balance — no \"Unsupported token type\".
- [ ] Add a member to a Safe-managed group whose conditions the candidate satisfies — tx lands.
- [ ] Balance breakdown — \"Why so many tokens?\" does not auto-open.