### PR TITLE
fix(groups): refresh memberships on opt-out success; avoid avatar-label clipping

### DIFF
--- a/circles-app/src/lib/areas/groups/ui/pages/LeaveGroup.svelte
+++ b/circles-app/src/lib/areas/groups/ui/pages/LeaveGroup.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { wallet } from '$lib/shared/state/wallet.svelte';
-    import { executeTxSubmitFirst } from '$lib/shared/utils/txExecution';
+    import { executeTxConfirmFirst } from '$lib/shared/utils/txExecution';
     import { sendRunnerTransactionAndWait } from '$lib/shared/utils/tx';
     import { popupControls } from '$lib/shared/state/popup';
     import Avatar from '$lib/shared/ui/avatar/Avatar.svelte';
@@ -8,6 +8,8 @@
 
     interface Props {
         group: `0x${string}`;
+        // Fires only after the opt-out tx receipt is back. The parent typically
+        // removes the group from the visible list here (confirmed-then-update UX).
         onLeft?: () => void | Promise<void>;
     }
 
@@ -20,16 +22,14 @@
         const runner: any = $wallet;
         if (!runner) throw new Error('Wallet is not connected.');
 
-        void executeTxSubmitFirst({
+        await executeTxConfirmFirst({
             name: `Leaving group ${shortenAddress(group)} ...`,
-            submit: async () => {
-                await sendRunnerTransactionAndWait(runner, {
-                    to: group,
-                    value: 0n,
-                    data: OPT_OUT_CALLDATA,
-                }, { label: 'Leave group' });
-            },
-            onSubmitted: async () => {
+            submit: () => sendRunnerTransactionAndWait(runner, {
+                to: group,
+                value: 0n,
+                data: OPT_OUT_CALLDATA,
+            }, { label: 'Leave group' }),
+            onSuccess: async () => {
                 popupControls.close();
                 await onLeft?.();
             },

--- a/circles-app/src/lib/shared/ui/avatar/HorizontalAvatarLayout.svelte
+++ b/circles-app/src/lib/shared/ui/avatar/HorizontalAvatarLayout.svelte
@@ -64,13 +64,13 @@
   </button>
   <div class={`flex flex-col gap-y-0.5 min-w-0 ${reverse ? 'items-end pr-4 text-right' : 'items-start pl-4'}`}>
     {#if topInfo}
-      <p class="text-xs text-base-content/70 truncate w-full">
+      <p class="text-xs text-base-content/70 truncate w-full leading-normal">
         {topInfo}
       </p>
     {/if}
-    <span class="font-semibold text-base-content truncate w-full">{profile?.name ?? ''}</span>
+    <span class="block font-semibold text-base-content truncate w-full leading-normal">{profile?.name ?? ''}</span>
     {#if bottomInfo}
-      <p class="text-xs text-base-content/70 truncate w-full">
+      <p class="text-xs text-base-content/70 truncate w-full leading-normal">
         {bottomInfo}
       </p>
     {/if}

--- a/circles-app/src/routes/groups/+page.svelte
+++ b/circles-app/src/routes/groups/+page.svelte
@@ -322,8 +322,18 @@
                                 item={item}
                                 showOptOut={true}
                                 onLeft={async () => {
-                                    membershipsLoadedForAvatar = null;
-                                    await loadMemberships();
+                                    // onLeft fires after the opt-out receipt is back (LeaveGroup
+                                    // uses executeTxConfirmFirst). Remove the row immediately so
+                                    // the UI reflects the confirmed on-chain state, then refetch
+                                    // a few seconds later to let the indexer catch up.
+                                    const groupKey = item.group.toLowerCase();
+                                    memberships = memberships.filter(
+                                        (m) => m.group.toLowerCase() !== groupKey
+                                    );
+                                    setTimeout(() => {
+                                        membershipsLoadedForAvatar = null;
+                                        void loadMemberships();
+                                    }, 5000);
                                 }}
                             />
                         {/each}


### PR DESCRIPTION
## Summary

Two follow-ups from live verification of #197:

1. After a successful opt-out the Memberships list stayed showing the group. Root cause: \`LeaveGroup.svelte\` used \`executeTxSubmitFirst\`, which fires \`onSubmitted\` right after broadcast — before the receipt is back, and long before the indexer has processed the new Hub trust event. The parent re-fetch ran against stale indexer state and returned the same list.
2. Avatar labels (the group/avatar name) appeared visually clipped at the bottom by a pixel in some browsers, especially on rows with default group icons.

## What changed

- \`LeaveGroup.svelte\`: switch to \`executeTxConfirmFirst\`. \`onSuccess\` now fires only after the opt-out tx receipt is back, so the contract state (\`optOuts[member] = true\` + \`Hub.trust(group, member, 0)\`) is already on-chain when the parent runs its refresh.
- \`routes/groups/+page.svelte\`: on the Memberships tab's \`onLeft\`, remove the just-opted-out row from the visible list immediately (the contract state is already updated), then schedule a refetch 5s later to let the indexer reconcile.
- \`shared/ui/avatar/HorizontalAvatarLayout.svelte\`: set \`display:block\` on the name span and \`leading-normal\` on all three label lines. Tailwind's \`truncate\` (\`overflow:hidden\`) on an inline span without an explicit line-height could clip the bottom row of glyphs in some browser/font-metric combos. Making the element a proper block with explicit line-height removes the ambiguity.

## Test plan

- [ ] Memberships tab → Opt out on a ScoreGroup → confirm in wallet → tx mines → the row disappears immediately. 5s later the list refetches; the group stays absent.
- [ ] Avatar labels on /groups and /contacts no longer show pixel-clipping at the bottom of the bold name line.