### PR TITLE
fix(groups,wallet): stream memberships, quiet session-restore, guard transient errors

### DIFF
--- a/circles-app/src/lib/areas/groups/utils/getGroupsByMemberBatch.ts
+++ b/circles-app/src/lib/areas/groups/utils/getGroupsByMemberBatch.ts
@@ -3,6 +3,33 @@ import type { Sdk } from '@aboutcircles/sdk';
 import type { GroupRow, GroupMembershipRow, PagedQueryParams } from '@aboutcircles/sdk-types';
 import { PagedQuery } from '@aboutcircles/sdk-rpc';
 
+// Keep aligned with GROUP_MEMBERS_PAGE_SIZE (the inverse direction) and the
+// transaction-history page size — all use 25 so paint feels consistent across
+// related lists.
+export const MEMBERSHIPS_PAGE_SIZE = 25;
+
+const GROUP_DETAIL_COLUMNS = [
+  'blockNumber',
+  'timestamp',
+  'transactionIndex',
+  'logIndex',
+  'transactionHash',
+  'group',
+  'type',
+  'owner',
+  'mintPolicy',
+  'mintHandler',
+  'treasury',
+  'service',
+  'feeCollection',
+  'memberCount',
+  'name',
+  'symbol',
+  'cidV0Digest',
+  'erc20WrapperDemurraged',
+  'erc20WrapperStatic',
+] as const;
+
 /**
  * Build an OR conjunction of Equals predicates to simulate an IN filter.
  * The new SDK FilterType does not support 'In'; use Conjunction instead.
@@ -23,18 +50,22 @@ function buildInFilter(column: string, values: string[]): Filter {
   };
 }
 
-function chunk<T>(arr: T[], size: number): T[][] {
-  const out: T[][] = [];
-  for (let i = 0; i < arr.length; i += size) {
-    out.push(arr.slice(i, i + size));
-  }
-  return out;
-}
+/**
+ * Stream group rows the avatar is a member of, page-by-page. The callback is
+ * invoked once per page of detail rows so the UI can render rows as they
+ * arrive instead of waiting for the full set.
+ *
+ * The page size aligns with GROUP_MEMBERS_PAGE_SIZE and the tx-history page
+ * size (25) — keeps the perceived load time consistent across related lists.
+ */
+export async function streamGroupsByMember(
+  sdk: Sdk,
+  member: Address,
+  onBatch: (batch: GroupRow[]) => void,
+  pageSize: number = MEMBERSHIPS_PAGE_SIZE
+): Promise<void> {
+  if (!sdk || !member) return;
 
-export async function getGroupsByMember(sdk: Sdk, member: Address): Promise<GroupRow[]> {
-  if (!sdk || !member) return [];
-
-  // Query GroupMemberships table for this member using PagedQuery
   const membershipsQueryDef: PagedQueryParams = {
     namespace: 'V_CrcV2',
     table: 'GroupMemberships',
@@ -48,72 +79,53 @@ export async function getGroupsByMember(sdk: Sdk, member: Address): Promise<Grou
       },
     ],
     sortOrder: 'DESC',
-    limit: 1000,
+    limit: pageSize,
   };
 
   const membershipsQuery = new PagedQuery<GroupMembershipRow>(sdk.rpc.client, membershipsQueryDef);
-  const memberships: GroupMembershipRow[] = [];
+  const seen = new Set<string>();
 
   while (await membershipsQuery.queryNextPage()) {
     const rows = membershipsQuery.currentPage?.results ?? [];
     if (rows.length === 0) break;
-    memberships.push(...rows);
+
+    const newAddrs = rows
+      .map((m) => (m.group ?? '').toLowerCase())
+      .filter((a) => a.length > 0 && !seen.has(a));
+    newAddrs.forEach((a) => seen.add(a));
+
+    if (newAddrs.length > 0) {
+      const detailQueryDef: PagedQueryParams = {
+        namespace: 'V_CrcV2',
+        table: 'Groups',
+        columns: [...GROUP_DETAIL_COLUMNS],
+        filter: [buildInFilter('group', newAddrs)],
+        sortOrder: 'DESC',
+        limit: pageSize * 2,
+      };
+      const detailQuery = new PagedQuery<GroupRow>(sdk.rpc.client, detailQueryDef);
+
+      const batch: GroupRow[] = [];
+      while (await detailQuery.queryNextPage()) {
+        const detailRows = detailQuery.currentPage?.results ?? [];
+        batch.push(...detailRows);
+        if (!detailQuery.currentPage?.hasMore) break;
+      }
+
+      if (batch.length > 0) onBatch(batch);
+    }
+
     if (!membershipsQuery.currentPage?.hasMore) break;
   }
+}
 
-  const groupAddresses = Array.from(
-    new Set(
-      memberships
-        .map((m) => (m.group ?? '').toLowerCase())
-        .filter((g) => g.length > 0)
-    )
-  ) as Address[];
-
-  if (groupAddresses.length === 0) return [];
-
+/**
+ * Exhaustive collect-all wrapper preserved for callers that need the full
+ * array up front (e.g. the "My groups" tab which merges memberships with
+ * owner-based results).
+ */
+export async function getGroupsByMember(sdk: Sdk, member: Address): Promise<GroupRow[]> {
   const acc: GroupRow[] = [];
-  const groupChunks = chunk(groupAddresses, 200);
-
-  for (const groups of groupChunks) {
-    const queryDef: PagedQueryParams = {
-      namespace: 'V_CrcV2',
-      table: 'Groups',
-      columns: [
-        'blockNumber',
-        'timestamp',
-        'transactionIndex',
-        'logIndex',
-        'transactionHash',
-        'group',
-        'type',
-        'owner',
-        'mintPolicy',
-        'mintHandler',
-        'treasury',
-        'service',
-        'feeCollection',
-        'memberCount',
-        'name',
-        'symbol',
-        'cidV0Digest',
-        'erc20WrapperDemurraged',
-        'erc20WrapperStatic',
-      ],
-      filter: [
-        buildInFilter('group', groups.map((g) => g.toLowerCase())),
-      ],
-      sortOrder: 'DESC',
-      limit: 1000,
-    };
-
-    const query = new PagedQuery<GroupRow>(sdk.rpc.client, queryDef);
-    while (await query.queryNextPage()) {
-      const rows = query.currentPage?.results ?? [];
-      if (rows.length === 0) break;
-      acc.push(...rows);
-      if (!query.currentPage?.hasMore) break;
-    }
-  }
-
+  await streamGroupsByMember(sdk, member, (batch) => acc.push(...batch));
   return acc;
 }

--- a/circles-app/src/lib/shared/state/wallet.svelte.ts
+++ b/circles-app/src/lib/shared/state/wallet.svelte.ts
@@ -23,7 +23,6 @@ import type { GroupType } from '@aboutcircles/sdk-types';
 import { privateKeyToAccount } from 'viem/accounts';
 import { gnosisChainConfig } from '$lib/shared/integrations/chain/chainConfig';
 import { isHumanType, isGroupType, isOrganizationType } from '$lib/shared/utils/avatarHelpers';
-import { handleError } from '$lib/shared/utils/errorHandler';
 import { withRetry, isTransientError } from '$lib/shared/utils/retry';
 import { EoaBrowserRunner } from '$lib/shared/integrations/wallet/EoaBrowserRunner';
 import { clearAll as clearCache } from '$lib/shared/cache';
@@ -217,9 +216,17 @@ export async function initNewEoaBrowserRunner(eoaAddress: Address) {
 }
 
 export async function restoreSession() {
+  const privateKey = CirclesStorage.getInstance().privateKey;
+  const savedAvatar = CirclesStorage.getInstance().avatar;
+
+  // Fresh visit / signed-out state — nothing to restore. Skip silently instead
+  // of throwing, otherwise every first-time landing fires a red "Session Restore
+  // Failed" error toast.
+  if (!privateKey && !savedAvatar) {
+    return;
+  }
+
   try {
-    const privateKey = CirclesStorage.getInstance().privateKey;
-    const savedAvatar = CirclesStorage.getInstance().avatar;
     const rings: boolean = CirclesStorage.getInstance().rings ? true : false;
 
     // Sync settings with stored rings preference
@@ -244,9 +251,11 @@ export async function restoreSession() {
       // Use the new SDK with runner - get config from settings
       const activeConfig = getActiveConfig();
       sdk = new Sdk(activeConfig, newRunner);
-    } else if (savedAvatar) {
-      // Safe + browser provider (EOA != Safe) — reconnect wagmi first so the
-      // connector is available for the browser runner.
+    } else {
+      // savedAvatar present without a private key → Safe + browser provider
+      // path (EOA != Safe). Reconnect wagmi first so the connector is available
+      // for the browser runner. The "neither" case was already short-circuited
+      // at the top of the function.
       signer.privateKey = undefined;
       try {
         signer.address = await getSigner();
@@ -266,8 +275,6 @@ export async function restoreSession() {
       // Use the new SDK with runner - get config from settings
       const activeConfig = getActiveConfig();
       sdk = new Sdk(activeConfig, newRunner);
-    } else {
-      throw new Error('No private key or saved avatar found in localStorage');
     }
 
     if (!sdk) {
@@ -334,11 +341,20 @@ export async function restoreSession() {
       await goto('/register');
     }
   } catch (error) {
-    handleError(error, {
-      context: 'wallet',
-      title: 'Session Restore Failed',
-    });
-    clearSession();
+    // Don't surface a red toast: the landing page + Connect Wallet button
+    // already communicates the un-authenticated state to the user. Log for
+    // debugging.
+    console.error('[Wallet] Session restore failed:', error);
+
+    // Only nuke the saved session on definitively terminal errors. For
+    // transient network / RPC / WS failures, leave localStorage intact so
+    // the next page-load can retry — clearSession() wipes the in-app PK
+    // (Circles-native variant), and we don't want a 5-second RPC blip to
+    // brick a funded avatar.
+    const transient = error instanceof Error && isTransientError(error);
+    if (!transient) {
+      clearSession();
+    }
   }
 }
 

--- a/circles-app/src/routes/groups/+page.svelte
+++ b/circles-app/src/routes/groups/+page.svelte
@@ -18,7 +18,7 @@
     import {circles} from '$lib/shared/state/circles';
     import {CirclesStorage} from '$lib/shared/utils/storage';
     import { getBaseAndCmgGroupsByOwnerBatch } from '$lib/shared/utils/getGroupsByOwnerBatch';
-    import { getGroupsByMember } from '$lib/areas/groups/utils/getGroupsByMemberBatch';
+    import { getGroupsByMember, streamGroupsByMember } from '$lib/areas/groups/utils/getGroupsByMemberBatch';
     import type { GroupRow } from '@aboutcircles/sdk-types';
     import Tabs from '$lib/shared/ui/primitives/tabs/Tabs.svelte';
     import Tab from '$lib/shared/ui/primitives/tabs/Tab.svelte';
@@ -40,6 +40,11 @@
     let membershipsError: string | null = $state(null);
     let ownedGroupsLoadedForAvatar: string | null = $state(null);
     let membershipsLoadedForAvatar: string | null = $state(null);
+
+    // Generation counter used to cancel stale streamGroupsByMember callbacks
+    // when the user switches avatars (or otherwise triggers a refetch)
+    // before the in-flight stream finishes.
+    let membershipsLoadGeneration = 0;
 
     const TAB_IDS = ['yours', 'memberships', 'all'] as const;
     type TabId = TabIdOf<typeof TAB_IDS>;
@@ -106,16 +111,39 @@
             return;
         }
 
+        const generation = ++membershipsLoadGeneration;
+        const targetOwner = String(ownerAddress).toLowerCase();
+
         membershipsLoading = true;
         membershipsError = null;
+        memberships = [];
         try {
-            memberships = await getGroupsByMember($circles, ownerAddress as Address);
-            membershipsLoadedForAvatar = String(ownerAddress).toLowerCase();
+            // Stream rows in 25-at-a-time batches so the first paint happens
+            // quickly even for avatars with many memberships. Same page size
+            // as the group-members and tx-history lists.
+            await streamGroupsByMember(
+                $circles,
+                ownerAddress as Address,
+                (batch) => {
+                    // Drop stale batches if a newer load started (e.g. avatar
+                    // switched mid-stream) so we don't contaminate the new
+                    // avatar's list with old data.
+                    if (generation !== membershipsLoadGeneration) return;
+                    memberships = [...memberships, ...batch];
+                }
+            );
+            if (generation === membershipsLoadGeneration) {
+                membershipsLoadedForAvatar = targetOwner;
+            }
         } catch (e) {
-            membershipsError = e instanceof Error ? e.message : String(e);
-            memberships = [];
+            if (generation === membershipsLoadGeneration) {
+                membershipsError = e instanceof Error ? e.message : String(e);
+                memberships = [];
+            }
         } finally {
-            membershipsLoading = false;
+            if (generation === membershipsLoadGeneration) {
+                membershipsLoading = false;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Three correctness + UX fixes after live-testing the recent groups PRs.

## What changed

**Groups — streaming memberships loader**
- New \`streamGroupsByMember(sdk, member, onBatch, pageSize=25)\` pages through GroupMemberships in 25-at-a-time batches; for each batch fires the Groups detail query and invokes \`onBatch\` so the UI can render rows as they arrive.
- New \`MEMBERSHIPS_PAGE_SIZE = 25\` aligns with \`GROUP_MEMBERS_PAGE_SIZE\` and the tx-history page size (was \`1000\` here — inconsistent with the rest of the app).
- \`getGroupsByMember\` becomes a thin collect-all wrapper, preserving the existing call-site signature used by the My groups tab.
- \`/groups\` Memberships tab consumes the stream so rows paint progressively instead of after the full set is buffered.

**Groups — avatar-switch race guard**
- \`loadMemberships()\` now uses a generation counter; if the user switches avatars (or otherwise triggers a refetch) before the in-flight stream completes, stale \`onBatch\` callbacks are dropped — they can no longer contaminate the new avatar's list, and stale terminal writes (\`membershipsLoadedForAvatar\`, \`membershipsLoading = false\`, etc.) no longer overwrite the new load's state.

**Wallet — quiet \`restoreSession\`**
- Short-circuits at the top when there is no saved session at all (no \`privateKey\` and no \`savedAvatar\`). Previously this case threw and the catch fired a red \"Session Restore Failed\" toast on every fresh visit.
- Catch block no longer shows the toast. The landing page + Connect Wallet button already communicates the unauthenticated state.

**Wallet — guard transient errors before nuking the saved session**
- \`clearSession()\` (which calls \`CirclesStorage.clear()\` and wipes the in-app private key for the Circles-native variant) is now gated on \`!isTransientError(error)\`. A 5-second RPC blip during avatar restore no longer destroys a funded avatar's only PK copy. Terminal errors (signer rejected, avatar not found, etc.) still clear the saved session as before.

## Test plan

- [ ] Fresh visit (clean localStorage, no saved session): land on \`/\` without any red toast.
- [ ] Closed and reopened wallet (savedAvatar present but wagmi connector cold): land on \`/\` without any red toast; Connect Wallet button reconnects normally.
- [ ] \`/groups\` → Memberships: rows appear in 25-at-a-time batches; for avatars with many memberships first paint is visibly faster than before.
- [ ] Switch avatar while Memberships is mid-stream: new avatar's list does not contain stale entries from the previous avatar.
- [ ] Opt out flow (existing): tx receipt → row removed from list → 5s refetch reconciles with indexer.

## Notes

The wider \`clearSession()\` behavior on transient errors had a pre-existing latent issue flagged by the security review (PK wipe on RPC blip). This PR narrows the trigger to terminal errors only; a follow-up could add Sentry/error-id and observability around the catch.