### PR TITLE
fix(groups): stop /groups/members count badge flicker

### DIFF
--- a/circles-app/src/lib/areas/groups/ui/components/GroupMembersManager.svelte
+++ b/circles-app/src/lib/areas/groups/ui/components/GroupMembersManager.svelte
@@ -53,6 +53,14 @@
   let loadGeneration = 0;
   let nextInflight: Promise<boolean> | null = null;
 
+  // Dedup guard for the init $effect. The `circles` store re-emits on every
+  // SDK lifecycle tick (new event subscriptions, balance updates, etc.) which
+  // would otherwise re-trigger the effect and wipe `totalMemberCount` /
+  // `items` mid-render — surfacing as a "0 ↔ 2820 trusted avatars" flicker.
+  // Only re-init when the group address or the SDK *instance* actually changes.
+  let initializedForGroup: string = '';
+  let initializedForSdkRef: unknown = null;
+
   const groupDisplayName = $derived(
     ((groupName ?? '') as string).length > 0
       ? ((groupName ?? '') as string)
@@ -176,11 +184,28 @@
 
   $effect(() => {
     const sdk = $circles;
-    if (!group || !sdk) {
-      resetState();
-      groupName = null;
+    const groupKey = group ? String(group).toLowerCase() : '';
+
+    if (!groupKey || !sdk) {
+      if (initializedForGroup !== '') {
+        initializedForGroup = '';
+        initializedForSdkRef = null;
+        resetState();
+        groupName = null;
+      }
       return;
     }
+
+    // Bail if we've already initialized for this group + SDK pair. Without
+    // this, every `circles` store re-emit (which fires often during normal
+    // SDK lifecycle) would reset `totalMemberCount` to undefined and clear
+    // `items`, producing a "0 ↔ N trusted avatars" flicker on the count badge
+    // until the count fetch resolves again.
+    if (groupKey === initializedForGroup && sdk === initializedForSdkRef) {
+      return;
+    }
+    initializedForGroup = groupKey;
+    initializedForSdkRef = sdk;
 
     // Bump generation so any in-flight enrich/page callbacks become no-ops.
     ++loadGeneration;
@@ -328,7 +353,24 @@
         // After a successful add we don't yet know which addresses landed;
         // reset and reload from page 1 so new members appear at the top.
         ++loadGeneration;
+        const generation = loadGeneration;
         resetState();
+
+        // Re-fetch authoritative count so the badge doesn't fall back to
+        // a growing $items.length while pages stream in.
+        const sdk = get(circles);
+        if (sdk) {
+          void createGroupDataSource(sdk)
+            .getGroupMemberCount(group)
+            .then((n) => {
+              if (generation === loadGeneration && typeof n === 'number') {
+                totalMemberCount = n;
+              }
+            })
+            .catch((e) => {
+              console.warn('[GroupMembersManager] member-count refetch failed', e);
+            });
+        }
         void loadNextPage();
       },
     });


### PR DESCRIPTION
## Summary

Hotfix for the \"2820 ↔ 0 trusted avatars\" flicker on \`/groups/members/[group]\` introduced by #202.

The init \`\$effect\` was re-running every time the \`circles\` store re-emitted (which happens on normal SDK lifecycle ticks, not just real wallet/group changes). Each re-run called \`resetState()\`, blanking \`totalMemberCount\` to \`undefined\` while the count refetch was still in flight, so the header fell back to \`\$items.length\` (==0 mid-rebuild) before snapping back to the authoritative count.

- Track the last (group, SDK-instance) pair the effect actually initialized for; bail on re-emits that don't represent a real change.
- After \`openAddTrustFlow.onCompleted\`, re-fetch the authoritative count so the badge doesn't fall back to a growing \`\$items.length\` while pages stream in.

## Test plan

- [ ] Sign in, visit \`/groups/members/<groupAddress>\`. Count badge resolves once to the authoritative number and stays.
- [ ] Wait 30s on the page. Badge does not flicker.
- [ ] Add a member via \"Add\". After the popup closes, the list reloads and the badge re-resolves to the new count.