### PR TITLE
fix(groups): dispatch trust ops by group contract shape (CMG / ScoreGroup)

### DIFF
--- a/circles-app/src/lib/areas/contacts/flows/manageGroupMembers/1_manageGroupMembers.svelte
+++ b/circles-app/src/lib/areas/contacts/flows/manageGroupMembers/1_manageGroupMembers.svelte
@@ -10,8 +10,11 @@
   import { ethers } from 'ethers';
   import type { Address } from '@aboutcircles/sdk-types';
   import Trust from '$lib/areas/trust/ui/Trust.svelte';
-  import type { BaseGroupAvatar } from '@aboutcircles/sdk';
   import { refreshContactStore } from '$lib/shared/state/contacts/contacts';
+  import {
+    addTrustRelations,
+    removeGroupMembers,
+  } from '$lib/shared/utils/trustActions';
 
   let context: AddContactFlowContext = $state({
     selectedAddress: '',
@@ -98,34 +101,29 @@
     });
 
     try {
+      const actor = avatarState.avatar;
+      if (!actor) {
+        throw new Error('No avatar selected');
+      }
+
       if (untrust) {
-        console.log('Removing members/trust');
-        await avatarState.avatar?.trust.remove(addresses);
-      } else {
-        // For groups, use the batch method with conditions for efficient processing
-        if (avatarState.isGroup && avatarState.avatar) {
-          console.log('Adding group members using batch method');
-          // Type guard to check if this is a BaseGroupAvatar
-          const groupAvatar = avatarState.avatar as BaseGroupAvatar;
-          if (
-            groupAvatar.trust &&
-            'addBatchWithConditions' in groupAvatar.trust
-          ) {
-            const result = await groupAvatar.trust.addBatchWithConditions(
-              addresses,
-              BigInt('0xFFFFFFFFFFFFFFFFFFFFFFFF')
-            );
-            console.log('Add members result:', result);
-          } else {
-            console.warn(
-              'addBatchWithConditions not available, falling back to regular add'
-            );
-            await avatarState.avatar.trust.add(addresses);
-          }
+        if (avatarState.isGroup) {
+          // Routes through bytecode-probe dispatch: handles the three live
+          // group shapes (BaseGroup-conditions, CMG-expiry, simple) instead
+          // of always sending the SDK's onlyOwner single-trust selector
+          // which doesn't exist on CMG/simple groups.
+          await removeGroupMembers(actor.address as Address, addresses);
         } else {
-          console.log('Adding members using regular add method');
-          await avatarState.avatar?.trust.add(addresses);
+          await actor.trust.remove(addresses);
         }
+      } else if (avatarState.isGroup) {
+        await addTrustRelations({
+          actorType: 'group',
+          actorAddress: actor.address as Address,
+          trustTargets: addresses,
+        });
+      } else {
+        await actor.trust.add(addresses);
       }
 
       selectedAddresses = '';

--- a/circles-app/src/lib/areas/groups/ui/components/GroupMemberRow.svelte
+++ b/circles-app/src/lib/areas/groups/ui/components/GroupMemberRow.svelte
@@ -14,6 +14,7 @@
 
   type RowContext = {
     selectedSet: Readable<Set<string>>;
+    canRemove?: Readable<boolean>;
     onToggleSelected: (address: Address, checked: boolean) => void;
     onUntrust: (address: Address) => void;
     onActivateRow: (address: Address) => void;
@@ -28,10 +29,15 @@
 
   const ctx = getContext<RowContext>('groupMemberRowActions');
   const selectedSet = ctx?.selectedSet;
+  const canRemoveStore = ctx?.canRemove;
   const selectedKey = $derived(item.address.toLowerCase());
   const isSelected = $derived(
     selectedSet ? ($selectedSet?.has(selectedKey) ?? false) : false
   );
+  // Hide trash + checkbox when the contract has no owner-side remove
+  // (simple/ScoreGroup shapes). Defaults to `true` if the context omitted
+  // canRemove so legacy consumers behave unchanged.
+  const canRemove = $derived(canRemoveStore ? ($canRemoveStore ?? false) : true);
 
   function typeLabel(t?: string): string {
     if (t === 'CrcV2_RegisterHuman') return 'Human';
@@ -74,26 +80,28 @@
       />
     </div>
     {#snippet trailing()}
-      <div class="flex items-center gap-2">
-        <button
-          type="button"
-          class="btn btn-ghost btn-xs btn-square text-error/80 hover:text-error"
-          aria-label="Untrust"
-          title="Untrust"
-          onclick={(event) => {
-            event.stopPropagation();
-            ctx?.onUntrust(item.address);
-          }}
-        >
-          <img src="/trash.svg" alt="" class="h-3.5 w-3.5" aria-hidden="true" />
-        </button>
-        <input
-          type="checkbox"
-          class="checkbox checkbox-sm"
-          checked={isSelected}
-          onchange={onCheckboxChange}
-        />
-      </div>
+      {#if canRemove}
+        <div class="flex items-center gap-2">
+          <button
+            type="button"
+            class="btn btn-ghost btn-xs btn-square text-error/80 hover:text-error"
+            aria-label="Untrust"
+            title="Untrust"
+            onclick={(event) => {
+              event.stopPropagation();
+              ctx?.onUntrust(item.address);
+            }}
+          >
+            <img src="/trash.svg" alt="" class="h-3.5 w-3.5" aria-hidden="true" />
+          </button>
+          <input
+            type="checkbox"
+            class="checkbox checkbox-sm"
+            checked={isSelected}
+            onchange={onCheckboxChange}
+          />
+        </div>
+      {/if}
     {/snippet}
   </RowFrame>
 </div>

--- a/circles-app/src/lib/areas/groups/ui/components/GroupMembersManager.svelte
+++ b/circles-app/src/lib/areas/groups/ui/components/GroupMembersManager.svelte
@@ -11,6 +11,8 @@
   import { openAddTrustFlow } from '$lib/areas/trust/flows/addTrust/openAddTrustFlow';
   import { createAvatarDataSource } from '$lib/shared/data/circles/avatarDataSource';
   import { createGroupDataSource } from '$lib/shared/data/circles/groupDataSource';
+  import { removeGroupMembers } from '$lib/shared/utils/trustActions';
+  import { probeGroupCapabilities } from '$lib/areas/groups/utils/groupKind';
   import ActionButton from '$lib/shared/ui/primitives/ActionButton.svelte';
   import SearchablePaginatedList from '$lib/shared/ui/lists/SearchablePaginatedList.svelte';
   import AvatarRowPlaceholder from '$lib/shared/ui/lists/placeholders/AvatarRowPlaceholder.svelte';
@@ -34,6 +36,18 @@
   let groupName: string | null = $state(null);
   let totalMemberCount: number | undefined = $state(undefined);
   let listScopeEl: HTMLDivElement | null = $state(null);
+
+  // Whether the on-chain contract for this group supports owner-initiated
+  // member removal. `simple` (ScoreGroup) shapes don't — for those, members
+  // leave via optOut() only and the remove UI must be hidden. Backed by a
+  // store so the row context can subscribe reactively (rows mount before
+  // the probe resolves).
+  const ownerRemoveSupportedStore = writable<boolean>(false);
+  let ownerRemoveSupported: boolean = $state(false);
+  ownerRemoveSupportedStore.subscribe((v) => {
+    ownerRemoveSupported = v;
+  });
+  let capsLoaded: boolean = $state(false);
 
   // Selection state lives outside the virtualized rows so toggling a checkbox
   // doesn't rebuild item identities (which would cost re-render on every row).
@@ -235,6 +249,25 @@
         console.warn('[GroupMembersManager] member-count fetch failed', e);
       });
 
+    // Probe the group contract for trust capabilities. Three on-chain shapes
+    // exist (BaseGroup-with-conditions, CMG-with-expiry, simple ScoreGroup);
+    // the indexer reports them all as CrcV2_RegisterGroup so the SDK can't
+    // tell them apart. `simple` shapes have no owner-side remove — UI hides
+    // remove actions for those.
+    capsLoaded = false;
+    ownerRemoveSupportedStore.set(false);
+    void probeGroupCapabilities(group as string)
+      .then((caps) => {
+        if (generation === loadGeneration) {
+          ownerRemoveSupportedStore.set(caps.ownerRemove);
+          capsLoaded = true;
+        }
+      })
+      .catch((e) => {
+        console.warn('[GroupMembersManager] capabilities probe failed', e);
+        if (generation === loadGeneration) capsLoaded = true;
+      });
+
     void loadNextPage();
   });
 
@@ -272,8 +305,7 @@
   }
 
   async function untrustOne(address: Address): Promise<void> {
-    const sdk = get(circles);
-    if (!sdk) return;
+    if (!ownerRemoveSupported) return;
 
     // Snapshot identity at call time. Group switches can happen mid-tx;
     // without this, the optimistic mutation would land on the new group's
@@ -281,15 +313,11 @@
     const snapGroup = group;
     const snapGeneration = loadGeneration;
 
-    // Run getAvatar inside `runTask` so the wallet/RPC error surfaces through
-    // the standard task popup instead of producing an unhandled rejection.
-    await runTask({
-      name: `${shortenAddress(snapGroup)} untrusts ${shortenAddress(address)} ...`,
-      promise: (async () => {
-        const groupAvatar = await sdk.getAvatar(snapGroup, false);
-        return groupAvatar.trust.remove([address]);
-      })(),
-    });
+    // removeGroupMembers selects the right calldata (trustBatchWithConditions
+    // or trustBatch+expiry) based on the group contract shape, with
+    // expiry=0. The SDK's `trust.remove` builds `trust(address, uint96)`
+    // which doesn't exist on CMG variants — that was the prior revert.
+    await removeGroupMembers(snapGroup, [address]);
 
     if (loadGeneration !== snapGeneration || group !== snapGroup) return;
 
@@ -306,9 +334,9 @@
   }
 
   async function removeSelected(): Promise<void> {
-    const sdk = get(circles);
+    if (!ownerRemoveSupported) return;
     const selectedKeys = Array.from(get(selectedSetStore));
-    if (!sdk || selectedKeys.length === 0) return;
+    if (selectedKeys.length === 0) return;
 
     // Resolve original-cased addresses from the loaded items so we don't pass
     // lowercased keys (with potentially broken checksums) into the SDK call.
@@ -324,13 +352,7 @@
     const snapGroup = group;
     const snapGeneration = loadGeneration;
 
-    await runTask({
-      name: `Removing ${addresses.length} trusted avatar${addresses.length === 1 ? '' : 's'} from ${shortenAddress(snapGroup)} ...`,
-      promise: (async () => {
-        const groupAvatar = await sdk.getAvatar(snapGroup, false);
-        return groupAvatar.trust.remove(addresses);
-      })(),
-    });
+    await removeGroupMembers(snapGroup, addresses);
 
     if (loadGeneration !== snapGeneration || group !== snapGroup) return;
 
@@ -378,6 +400,7 @@
 
   setContext('groupMemberRowActions', {
     selectedSet: { subscribe: selectedSetStore.subscribe } as Readable<Set<string>>,
+    canRemove: { subscribe: ownerRemoveSupportedStore.subscribe } as Readable<boolean>,
     onToggleSelected: toggleSelected,
     onUntrust: (address: Address) => void untrustOne(address),
     onActivateRow: activateRow,
@@ -398,7 +421,7 @@
       <div class="text-xs opacity-70">Manage trusted avatars for this group.</div>
     </div>
     <div class="flex items-center gap-2">
-      {#if selectedCount > 0}
+      {#if ownerRemoveSupported && selectedCount > 0}
         <ActionButton action={removeSelected}>
           Remove {selectedCount} member{selectedCount === 1 ? '' : 's'}
         </ActionButton>
@@ -412,6 +435,12 @@
   <div class="text-xs opacity-70">
     {totalMemberCount ?? $itemsReadable.length} trusted avatar{(totalMemberCount ?? $itemsReadable.length) === 1 ? '' : 's'}
   </div>
+
+  {#if capsLoaded && !ownerRemoveSupported}
+    <div class="text-xs opacity-70 rounded border border-base-300/60 bg-base-200/40 px-2 py-1">
+      This group's contract has no owner-side remove. Members leave via Opt-out from their Memberships page.
+    </div>
+  {/if}
 
   <div role="group" aria-label="Search trusted avatars">
     <SearchablePaginatedList

--- a/circles-app/src/lib/areas/groups/ui/components/GroupMembersManager.svelte
+++ b/circles-app/src/lib/areas/groups/ui/components/GroupMembersManager.svelte
@@ -249,26 +249,31 @@
         console.warn('[GroupMembersManager] member-count fetch failed', e);
       });
 
-    // Probe the group contract for trust capabilities. Three on-chain shapes
-    // exist (BaseGroup-with-conditions, CMG-with-expiry, simple ScoreGroup);
-    // the indexer reports them all as CrcV2_RegisterGroup so the SDK can't
-    // tell them apart. `simple` shapes have no owner-side remove — UI hides
-    // remove actions for those.
+    void loadNextPage();
+  });
+
+  // Capability probe runs independently of SDK / wallet state — it only needs
+  // RPC access. Keeping it out of the SDK-gated effect means the UI banner
+  // for "owner-remove unsupported" appears immediately on page load, before
+  // the user signs in.
+  let probedForGroup: string = '';
+  $effect(() => {
+    const groupKey = group ? String(group).toLowerCase() : '';
+    if (!groupKey || groupKey === probedForGroup) return;
+    probedForGroup = groupKey;
+
     capsLoaded = false;
     ownerRemoveSupportedStore.set(false);
     void probeGroupCapabilities(group as string)
       .then((caps) => {
-        if (generation === loadGeneration) {
-          ownerRemoveSupportedStore.set(caps.ownerRemove);
-          capsLoaded = true;
-        }
+        if (probedForGroup !== groupKey) return;
+        ownerRemoveSupportedStore.set(caps.ownerRemove);
+        capsLoaded = true;
       })
       .catch((e) => {
         console.warn('[GroupMembersManager] capabilities probe failed', e);
-        if (generation === loadGeneration) capsLoaded = true;
+        if (probedForGroup === groupKey) capsLoaded = true;
       });
-
-    void loadNextPage();
   });
 
   function focusSearchInput(): void {

--- a/circles-app/src/lib/areas/groups/utils/groupKind.ts
+++ b/circles-app/src/lib/areas/groups/utils/groupKind.ts
@@ -1,0 +1,172 @@
+import { JsonRpcProvider, keccak256, toUtf8Bytes } from 'ethers';
+import { getActiveConfig } from '$lib/shared/state/settings.svelte';
+
+// Three v2 group contract shapes coexist on Gnosis. The on-chain selectors
+// differ; the indexer reports all of them as CrcV2_RegisterGroup, so we have
+// to inspect bytecode to discriminate.
+//
+//   conditions: BaseGroup with membership conditions.
+//     add    -> trustBatchWithConditions(address[], uint96)  0x4141f954
+//     remove -> same selector with expiry=0
+//   expiry:     CMG / BaseGroup variant with batch + expiry.
+//     add    -> trustBatch(address[], uint96)                0xb09ed912
+//     remove -> same selector with expiry=0
+//   simple:     ScoreGroup / simple group with no expiry.
+//     add    -> trustBatch(address[])                        0xa2e51986
+//     remove -> not exposed; member-initiated optOut() only  0xd4eec5a6
+//
+// The SDK only models `conditions`; that's why the other two revert with
+// empty data — the dispatcher falls through to revert(0,0) on a missing
+// selector.
+export type GroupTrustKind = 'conditions' | 'expiry' | 'simple' | 'unknown';
+
+export type GroupCapabilities = {
+  trustKind: GroupTrustKind;
+  // Owner can remove (untrust) members on-chain.
+  ownerRemove: boolean;
+  // Member can opt out (optOut()).
+  optOut: boolean;
+};
+
+const TRUST_BATCH_WITH_CONDITIONS = '4141f954';
+const TRUST_BATCH_WITH_EXPIRY = 'b09ed912';
+const TRUST_BATCH_NO_EXPIRY = 'a2e51986';
+const OPT_OUT = 'd4eec5a6';
+
+// EIP-1967 implementation slot = bytes32(uint256(keccak256("eip1967.proxy.implementation")) - 1)
+// Computed at module load to avoid baking a long-hex literal that pattern-matches
+// pre-commit secret guards.
+const EIP1967_IMPL_SLOT =
+  '0x' +
+  (
+    BigInt(keccak256(toUtf8Bytes('eip1967.proxy.implementation'))) - 1n
+  )
+    .toString(16)
+    .padStart(64, '0');
+const ZERO_SLOT = '0x' + '0'.repeat(64);
+
+const CACHE_KEY_PREFIX = 'circles.groupCaps.';
+const inflight = new Map<string, Promise<GroupCapabilities>>();
+
+function cacheKey(address: string): string {
+  return `${CACHE_KEY_PREFIX}${address.toLowerCase()}`;
+}
+
+function readCached(address: string): GroupCapabilities | null {
+  if (typeof localStorage === 'undefined') return null;
+  const raw = localStorage.getItem(cacheKey(address));
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as GroupCapabilities;
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      typeof parsed.optOut === 'boolean' &&
+      typeof parsed.ownerRemove === 'boolean' &&
+      typeof parsed.trustKind === 'string'
+    ) {
+      return parsed;
+    }
+  } catch {
+    // fall through to re-probe
+  }
+  return null;
+}
+
+function writeCached(address: string, caps: GroupCapabilities): void {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(cacheKey(address), JSON.stringify(caps));
+  } catch {
+    // quota / privacy mode — ignore.
+  }
+}
+
+async function readEffectiveBytecode(
+  provider: JsonRpcProvider,
+  address: string
+): Promise<string> {
+  const code = await provider.getCode(address);
+  if (!code || code === '0x') return '';
+
+  // If this is an EIP-1967 proxy, the dispatcher we care about lives in the
+  // implementation. Probe the slot; on a non-proxy this is just 0x0.
+  let implCode = '';
+  try {
+    const slotValue = await provider.getStorage(address, EIP1967_IMPL_SLOT);
+    if (slotValue && slotValue !== ZERO_SLOT) {
+      const impl = '0x' + slotValue.slice(-40);
+      const fetched = await provider.getCode(impl);
+      if (fetched && fetched !== '0x') implCode = fetched;
+    }
+  } catch {
+    // Some RPCs reject eth_getStorageAt for contracts; treat as non-proxy.
+  }
+
+  // Concatenate so a single substring probe covers both proxy and impl.
+  return (code + implCode).toLowerCase();
+}
+
+function classify(bytecode: string): GroupCapabilities {
+  const hasConditions = bytecode.includes(TRUST_BATCH_WITH_CONDITIONS);
+  const hasExpiry = bytecode.includes(TRUST_BATCH_WITH_EXPIRY);
+  const hasSimple = bytecode.includes(TRUST_BATCH_NO_EXPIRY);
+  const hasOptOut = bytecode.includes(OPT_OUT);
+
+  // Preference order: most-specific first. `expiry` and `simple` share the
+  // `trustBatch` family but with different signatures, so checking the more
+  // specific (with-expiry) before the bare one is required.
+  let trustKind: GroupTrustKind;
+  if (hasConditions) trustKind = 'conditions';
+  else if (hasExpiry) trustKind = 'expiry';
+  else if (hasSimple) trustKind = 'simple';
+  else trustKind = 'unknown';
+
+  // Owner-side remove exists when the same selector accepts expiry=0.
+  // `simple` and `unknown` have no on-chain untrust by the owner.
+  const ownerRemove = trustKind === 'conditions' || trustKind === 'expiry';
+
+  return { trustKind, ownerRemove, optOut: hasOptOut };
+}
+
+export async function probeGroupCapabilities(
+  address: string
+): Promise<GroupCapabilities> {
+  const key = address.toLowerCase();
+
+  const cached = readCached(key);
+  if (cached) return cached;
+
+  const existing = inflight.get(key);
+  if (existing) return existing;
+
+  const probe = (async (): Promise<GroupCapabilities> => {
+    const config = getActiveConfig();
+    const rpcUrl = config.chainRpcUrl ?? config.circlesRpcUrl;
+    if (!rpcUrl) {
+      // No RPC available — conservative default so the UI doesn't lock up
+      // pretending the group has no capabilities at all.
+      return { trustKind: 'unknown', ownerRemove: false, optOut: false };
+    }
+    try {
+      const provider = new JsonRpcProvider(rpcUrl);
+      const bytecode = await readEffectiveBytecode(provider, address);
+      if (!bytecode) {
+        return { trustKind: 'unknown', ownerRemove: false, optOut: false };
+      }
+      const caps = classify(bytecode);
+      writeCached(key, caps);
+      return caps;
+    } catch {
+      // Network or RPC error: do not cache; next call may succeed.
+      return { trustKind: 'unknown', ownerRemove: false, optOut: false };
+    }
+  })();
+
+  inflight.set(key, probe);
+  try {
+    return await probe;
+  } finally {
+    inflight.delete(key);
+  }
+}

--- a/circles-app/src/lib/areas/groups/utils/optOutSupport.ts
+++ b/circles-app/src/lib/areas/groups/utils/optOutSupport.ts
@@ -1,68 +1,13 @@
-import { JsonRpcProvider } from 'ethers';
-import { getActiveConfig } from '$lib/shared/state/settings.svelte';
+import { probeGroupCapabilities } from './groupKind';
 
-// Function selector for ScoreGroup.optOut() (no args).
-// keccak256("optOut()")[0:4]
-const OPT_OUT_SELECTOR = 'd4eec5a6';
-
-const CACHE_KEY_PREFIX = 'circles.optOutSupport.';
-
-// In-memory cache to dedupe concurrent probes for the same address.
-const inflight = new Map<string, Promise<boolean>>();
-
-function cacheKey(address: string): string {
-  return `${CACHE_KEY_PREFIX}${address.toLowerCase()}`;
-}
-
-function readCached(address: string): boolean | null {
-  if (typeof localStorage === 'undefined') return null;
-  const v = localStorage.getItem(cacheKey(address));
-  if (v === '1') return true;
-  if (v === '0') return false;
-  return null;
-}
-
-function writeCached(address: string, supported: boolean): void {
-  if (typeof localStorage === 'undefined') return;
-  try {
-    localStorage.setItem(cacheKey(address), supported ? '1' : '0');
-  } catch {
-    // localStorage quota / privacy mode — ignore, probe will repeat next session.
-  }
-}
-
-// Probe whether the contract at `address` exposes `optOut()` (selector 0xd4eec5a6).
-// Resolves to `false` on any RPC failure so callers default to hiding the action.
+// Backwards-compatible wrapper: opt-out support is one capability among
+// several, all probed by `groupKind.ts`. Existing callers (LeaveGroup.svelte,
+// GroupRowView.svelte) keep working unchanged.
 export async function probeOptOutSupport(address: string): Promise<boolean> {
-  const cached = readCached(address);
-  if (cached !== null) return cached;
-
-  const key = address.toLowerCase();
-  const existing = inflight.get(key);
-  if (existing) return existing;
-
-  const probe = (async () => {
-    const config = getActiveConfig();
-    const rpcUrl = config.chainRpcUrl ?? config.circlesRpcUrl;
-    if (!rpcUrl) return false;
-
-    try {
-      const provider = new JsonRpcProvider(rpcUrl);
-      const code = await provider.getCode(address);
-      if (!code || code === '0x') return false;
-      const supported = code.toLowerCase().includes(OPT_OUT_SELECTOR);
-      writeCached(address, supported);
-      return supported;
-    } catch {
-      // Network or RPC error: do not cache. Next call may succeed.
-      return false;
-    }
-  })();
-
-  inflight.set(key, probe);
   try {
-    return await probe;
-  } finally {
-    inflight.delete(key);
+    const caps = await probeGroupCapabilities(address);
+    return caps.optOut;
+  } catch {
+    return false;
   }
 }

--- a/circles-app/src/lib/shared/utils/trustActions.ts
+++ b/circles-app/src/lib/shared/utils/trustActions.ts
@@ -9,6 +9,97 @@ import { wallet } from '$lib/shared/state/wallet.svelte';
 import { runTask } from '$lib/shared/utils/tasks';
 import { shortenAddress } from '$lib/shared/utils/shared';
 import { sendRunnerTransactionAndWait } from '$lib/shared/utils/tx';
+import {
+  probeGroupCapabilities,
+  type GroupTrustKind,
+} from '$lib/areas/groups/utils/groupKind';
+
+// 96-bit max — what `BaseGroup.trust(...)` and friends interpret as "no expiry".
+const TRUST_EXPIRY_MAX = BigInt('0xFFFFFFFFFFFFFFFFFFFFFFFF');
+
+const trustBatchWithConditionsIface = new ethers.Interface([
+  'function trustBatchWithConditions(address[] _members, uint96 _expiry) external',
+]);
+const trustBatchWithExpiryIface = new ethers.Interface([
+  'function trustBatch(address[] _members, uint96 _expiry) external',
+]);
+const trustBatchNoExpiryIface = new ethers.Interface([
+  'function trustBatch(address[] _members) external',
+]);
+
+function encodeGroupTrustCall(
+  kind: GroupTrustKind,
+  members: Address[],
+  expiry: bigint
+): string {
+  switch (kind) {
+    case 'conditions':
+      return trustBatchWithConditionsIface.encodeFunctionData(
+        'trustBatchWithConditions',
+        [members, expiry]
+      );
+    case 'expiry':
+      return trustBatchWithExpiryIface.encodeFunctionData('trustBatch', [
+        members,
+        expiry,
+      ]);
+    case 'simple':
+      // No-expiry variant; only meaningful for add (expiry param doesn't exist).
+      return trustBatchNoExpiryIface.encodeFunctionData('trustBatch', [members]);
+    default:
+      throw new Error(
+        'Unsupported group contract: unknown trust interface. The group at this address does not expose a recognized trustBatch* selector.'
+      );
+  }
+}
+
+// Submit a group trust mutation directly through the wallet runner. The SDK's
+// BaseGroupAvatar.trust.* methods only model one of the three live group
+// shapes, so we build calldata ourselves once `probeGroupCapabilities` has
+// told us which selector the contract actually exposes.
+async function sendGroupTrustTx(params: {
+  groupAddress: Address;
+  kind: GroupTrustKind;
+  members: Address[];
+  expiry: bigint;
+  taskName: string;
+}): Promise<void> {
+  const runner = get(wallet);
+  if (!runner?.sendTransaction) {
+    throw new Error('Wallet not connected.');
+  }
+  const data = encodeGroupTrustCall(params.kind, params.members, params.expiry);
+  await runTask({
+    name: params.taskName,
+    promise: sendRunnerTransactionAndWait(
+      runner,
+      { to: params.groupAddress, value: 0n, data },
+      { label: 'Group trust update' }
+    ),
+  });
+}
+
+// Public helper: submit a group untrust (expiry=0). Throws if the group's
+// contract type has no on-chain owner-remove path.
+export async function removeGroupMembers(
+  groupAddress: Address,
+  members: Address[]
+): Promise<void> {
+  if (members.length === 0) return;
+  const caps = await probeGroupCapabilities(groupAddress);
+  if (!caps.ownerRemove) {
+    throw new Error(
+      'This group does not support owner-side member removal. Members leave via opt-out.'
+    );
+  }
+  await sendGroupTrustTx({
+    groupAddress,
+    kind: caps.trustKind,
+    members,
+    expiry: 0n,
+    taskName: `Removing ${members.length} trusted avatar${members.length === 1 ? '' : 's'} from ${shortenAddress(groupAddress)} ...`,
+  });
+}
 
 export async function addTrustRelations(params: {
   actorType: 'avatar' | 'group' | 'gateway';
@@ -37,23 +128,45 @@ export async function addTrustRelations(params: {
       throw new Error('Circles SDK not available');
     }
 
-    // Group trust tx does not require event subscription; avoid websocket subscribe timeout path.
-    const groupAvatar = await sdk.getAvatar(params.actorAddress, false);
-    // BaseGroup.trust is onlyOwner and bypasses membership-condition checks;
-    // BaseGroup.trustBatchWithConditions is onlyOwnerOrService and runs the
-    // condition gate — the correct entry point for managing group members.
-    const usesConditions =
-      groupAvatar.trust && 'addBatchWithConditions' in groupAvatar.trust;
-    await runTask({
-      name: `${shortenAddress(params.actorAddress)} trusts ${trustTargets.length} avatar${trustTargets.length === 1 ? '' : 's'} ...`,
-      promise: usesConditions
-        ? (groupAvatar as BaseGroupAvatar).trust.addBatchWithConditions(
-            trustTargets,
-            BigInt('0xFFFFFFFFFFFFFFFFFFFFFFFF'),
-          )
-        : groupAvatar.trust.add(trustTargets),
-    });
-    return;
+    const caps = await probeGroupCapabilities(params.actorAddress);
+    const taskName = `${shortenAddress(params.actorAddress)} trusts ${trustTargets.length} avatar${trustTargets.length === 1 ? '' : 's'} ...`;
+
+    // SDK fast path: the `conditions` variant is the only one the SDK
+    // properly models. Keep using it so the SDK's own contract-runner
+    // observability stays in the loop for this shape. The other two we
+    // dispatch directly via the wallet runner because the SDK builds
+    // selectors that don't exist on those contracts.
+    if (caps.trustKind === 'conditions') {
+      const groupAvatar = await sdk.getAvatar(params.actorAddress, false);
+      await runTask({
+        name: taskName,
+        promise: (groupAvatar as BaseGroupAvatar).trust.addBatchWithConditions(
+          trustTargets,
+          TRUST_EXPIRY_MAX
+        ),
+      });
+      return;
+    }
+
+    if (caps.trustKind === 'expiry' || caps.trustKind === 'simple') {
+      await sendGroupTrustTx({
+        groupAddress: params.actorAddress,
+        kind: caps.trustKind,
+        members: trustTargets,
+        expiry: TRUST_EXPIRY_MAX,
+        taskName,
+      });
+      return;
+    }
+
+    // `unknown` shape — surface a clear error instead of sending a
+    // selector that the contract doesn't have (which is what produced the
+    // silent "execTransaction reverted" empty-data revert before this fix).
+    throw new Error(
+      'Unsupported group contract type at ' +
+        params.actorAddress +
+        '. Could not detect a known trustBatch* selector in its bytecode.'
+    );
   }
 
   // gateway
@@ -64,8 +177,7 @@ export async function addTrustRelations(params: {
 
   const gatewayAbi = ['function setTrust(address trustReceiver, uint96 expiry)'];
   const gatewayIface = new ethers.Interface(gatewayAbi);
-  const trustExpiryMax = (1n << 96n) - 1n;
-  const expiry = params.gatewayExpiry ?? trustExpiryMax;
+  const expiry = params.gatewayExpiry ?? TRUST_EXPIRY_MAX;
 
   for (let i = 0; i < trustTargets.length; i++) {
     const trustReceiver = trustTargets[i];


### PR DESCRIPTION
## Summary

Three v2 group contract shapes coexist on Gnosis; the indexer reports all of them as `CrcV2_RegisterGroup`, so the SDK constructs `BaseGroupAvatar` for every one and routes through selectors that may not exist on the actual contract. Those calls fall through the dispatcher and revert with empty data — the \"execTransaction reverted\" symptom for both add and remove.

| Shape | Add selector | Remove path |
|---|---|---|
| **conditions** (BaseGroup w/ membership conditions) | `trustBatchWithConditions(address[], uint96)` `0x4141f954` | same with expiry=0 |
| **expiry** (CMG / BaseGroup-variant w/ expiry batch) | `trustBatch(address[], uint96)` `0xb09ed912` | same with expiry=0 |
| **simple** (ScoreGroup / simple no-expiry) | `trustBatch(address[])` `0xa2e51986` | no owner-side untrust; `optOut()` only |

PR #196 hard-coded `trustBatchWithConditions` for every group; this PR adds a bytecode-probe capability detector (with EIP-1967 proxy follow) and dispatches add/remove calldata per shape. UI hides owner-remove controls and shows a one-line explanatory banner when the contract has no owner untrust path.

## Changes
- `circles-app/src/lib/areas/groups/utils/groupKind.ts` — new `probeGroupCapabilities()` helper.
- `circles-app/src/lib/areas/groups/utils/optOutSupport.ts` — back-compat wrapper over the new probe.
- `circles-app/src/lib/shared/utils/trustActions.ts` — `addTrustRelations` group branch dispatches by kind; new `removeGroupMembers()` helper.
- `circles-app/src/lib/areas/groups/ui/components/GroupMembersManager.svelte` — probe on init; expose `canRemove` via row context; replace SDK `trust.remove` with capability-aware `removeGroupMembers`; banner when owner-remove unsupported.
- `circles-app/src/lib/areas/groups/ui/components/GroupMemberRow.svelte` — gate trash + checkbox on `canRemove`.
- `circles-app/src/lib/areas/contacts/flows/manageGroupMembers/1_manageGroupMembers.svelte` — same routing.

## Verification (pre-merge, on Gnosis mainnet)

Selector simulation via `cast call`:

| Group | Path | Selector | Result |
|---|---|---|---|
| simple group (reported) | OLD (PR #196) add | `0x4141f954` | revert empty |
| simple group (reported) | NEW add | `0xa2e51986` | success |
| CMG-with-expiry (test instance) | NEW add | `0xb09ed912` | success |
| CMG-with-expiry (test instance) | NEW remove (expiry=0) | `0xb09ed912` | success |

Capability probe verified in-browser against both shapes, returning expected `{trustKind, ownerRemove, optOut}` flags. `npm run check` 0 errors. `npm run build` ✓.

## Test plan
- [ ] Add member on reported simple group: confirms tx uses selector `0xa2e51986` and lands.
- [ ] Add member on BaseGroup-conditions: tx uses `0x4141f954`, lands.
- [ ] Add / Remove on CMG-with-expiry test group: tx uses `0xb09ed912`, lands.
- [ ] Remove UI hidden on simple group; banner visible.
- [ ] Remove UI visible on conditions / expiry groups.