### PR TITLE
sync dev → main: BaseGroupFactory name (19) + symbol (16) byte caps

### DIFF
--- a/circles-app/src/lib/areas/groups/flows/createGroup/1_CreateGroup.svelte
+++ b/circles-app/src/lib/areas/groups/flows/createGroup/1_CreateGroup.svelte
@@ -5,7 +5,7 @@
     import OnChainNameSection from '$lib/shared/ui/flow/OnChainNameSection.svelte';
     import Tooltip from '$lib/shared/ui/primitives/Tooltip.svelte';
     import { ProfileFormStep } from '$lib/shared/ui/profile';
-    import { isValidSymbol, isValidOnChainName } from '$lib/shared/utils/isValid';
+    import { isValidSymbol, isValidName } from '$lib/shared/utils/isValid';
     import { openStep } from '$lib/shared/flow';
     import { wallet } from '$lib/shared/state/wallet.svelte';
     import Settings from './2_Settings.svelte';
@@ -16,6 +16,9 @@
     import { resetCreateGroupContext } from './context';
     import type { ProfileEditStepProps } from '$lib/shared/flow';
 
+    // Profile name is IPFS metadata only — no on-chain restriction. The
+    // on-chain name lives in `OnChainNameSection` and is capped at 19 bytes
+    // by BaseGroupFactory; truncation of the derived value is surfaced there.
     const PROFILE_NAME_MAX_LENGTH = 36;
 
     type Props = Partial<ProfileEditStepProps<CreateGroupFlowContext>> & {
@@ -62,7 +65,7 @@
     const showSymbolInvalid: boolean = $derived(symbolHasInput && !symbolValidNow);
     const trimmedOnChainName = $derived(onChainName.trim());
     const onChainNameHasInput = $derived(trimmedOnChainName.length > 0);
-    const onChainNameValid = $derived(onChainNameHasInput && isValidOnChainName(trimmedOnChainName));
+    const onChainNameValid = $derived(onChainNameHasInput && isValidName(trimmedOnChainName));
     const canContinue: boolean = $derived(profileNameValid && symbolValidNow && onChainNameValid);
 
     function next() {
@@ -100,6 +103,7 @@
                 class="input input-sm input-bordered w-full"
                 bind:value={ctx.profile.symbol}
                 placeholder="CRC…"
+                maxlength="16"
                 data-popup-initial-input
             />
             <div class="h-5 text-xs text-error pt-1">{#if showSymbolInvalid}Invalid symbol{/if}</div>
@@ -128,6 +132,7 @@
             sourceValue={displayName}
             placeholder="Group on-chain name…"
             invalid={onChainNameHasInput && !onChainNameValid}
+            maxBytes={19}
         />
     </div>
 

--- a/circles-app/src/lib/areas/groups/flows/createGroup/4_Create.svelte
+++ b/circles-app/src/lib/areas/groups/flows/createGroup/4_Create.svelte
@@ -7,7 +7,7 @@
     import { runTask } from '$lib/shared/utils/tasks';
     import { popupControls } from '$lib/shared/state/popup';
     import ProfilePreviewCard from '$lib/shared/ui/profile/ProfilePreviewCard.svelte';
-    import { isValidSymbol, isValidOnChainName } from '$lib/shared/utils/isValid';
+    import { isValidSymbol, isValidName } from '$lib/shared/utils/isValid';
     import {
         createGroupContext,
         type CreateGroupFlowContext,
@@ -41,7 +41,7 @@
         const profileNameLength: number = (ctx.profile.name ?? '').trim().length;
         const profileNameOk: boolean = profileNameLength > 0 && profileNameLength <= PROFILE_NAME_MAX_LENGTH;
         const symbolOk: boolean = isValidSymbol(ctx.profile.symbol);
-        const onChainOk: boolean = isValidOnChainName(onChainName);
+        const onChainOk: boolean = isValidName(onChainName);
         if (!hasSdk) { throw new Error('SDK not initialized'); }
         if (!hasWallet) { throw new Error('Wallet not connected'); }
         if (!profileNameOk || !symbolOk || !onChainOk) {

--- a/circles-app/src/lib/shared/ui/flow/OnChainNameSection.svelte
+++ b/circles-app/src/lib/shared/ui/flow/OnChainNameSection.svelte
@@ -6,6 +6,9 @@
     summaryWhenEmpty?: string;
     invalid?: boolean;
     invalidMessage?: string;
+    // On-chain byte cap. Default 32 matches the gateway shape; pass 19 from
+    // the group flow to match BaseGroupFactory's stricter requirement.
+    maxBytes?: number;
   }
 
   let {
@@ -14,23 +17,42 @@
     placeholder = 'On-chain name…',
     summaryWhenEmpty = 'Derived from the profile name',
     invalid = false,
-    invalidMessage = "Only ASCII letters, numbers, spaces, and - _ . ( ) ' & + # are allowed (max 32 chars).",
+    invalidMessage,
+    maxBytes = 32,
   }: Props = $props();
+
+  const effectiveInvalidMessage = $derived(
+    invalidMessage ??
+      `Only ASCII letters, numbers, spaces, and - _ . ( ) ' & + # are allowed (max ${maxBytes} chars).`
+  );
 
   let open = $state(false);
   let manual = $state(false);
   let initialized = $state(false);
 
-  function truncateAscii(v: string, maxBytes: number): string {
-    return v.length <= maxBytes ? v : v.slice(0, maxBytes);
+  function truncateAscii(v: string, max: number): string {
+    return v.length <= max ? v : v.slice(0, max);
   }
 
   function deriveOnChainName(v: string): string {
     const trimmed = (v ?? '').trim();
     if (!trimmed) return '';
     const sanitized = trimmed.replace(/[^0-9A-Za-z \-_.()'&+#]/g, '');
-    return truncateAscii(sanitized, 32);
+    return truncateAscii(sanitized, maxBytes);
   }
+
+  function sanitizedFull(v: string): string {
+    const trimmed = (v ?? '').trim();
+    if (!trimmed) return '';
+    return trimmed.replace(/[^0-9A-Za-z \-_.()'&+#]/g, '');
+  }
+
+  // True when the auto-derived on-chain name had to be cut off to fit the
+  // contract's byte cap. Shown in the collapsed summary so the user knows
+  // their on-chain name will differ from the off-chain profile name.
+  const derivationTruncated = $derived(
+    !manual && sanitizedFull(sourceValue).length > maxBytes
+  );
 
   $effect(() => {
     if (!initialized) {
@@ -58,7 +80,10 @@
 
   <div class="mt-1 text-xs text-base-content/60">
     {#if value}
-      {value}
+      <span>{value}</span>
+      {#if derivationTruncated}
+        <span class="ml-1 text-warning">· truncated to {maxBytes} chars from profile name</span>
+      {/if}
     {:else}
       {summaryWhenEmpty}
     {/if}
@@ -86,13 +111,14 @@
           bind:value
           {placeholder}
           disabled={!manual}
+          maxlength={maxBytes}
         />
       </label>
       <p class="text-xs text-base-content/60">
-        On-chain names follow stricter rules (ASCII only, max 32 characters).
+        On-chain names follow stricter rules (ASCII only, max {maxBytes} characters).
       </p>
       {#if invalid}
-        <p class="text-xs text-error">{invalidMessage}</p>
+        <p class="text-xs text-error">{effectiveInvalidMessage}</p>
       {/if}
     </div>
   {/if}


### PR DESCRIPTION
## Summary

Carries forward PR #206 from dev → main so production stops broadcasting group-create txs that revert on \`BaseGroupFactory.createBaseGroup\` for names > 19 bytes or symbols > 16 bytes.

Single-commit sync. Merge from \`dev\` is conflict-free against current \`main\` (last sync was PR #205, also from today).

## Verified on staging
- Truncation indicator visible when profile name > 19 chars
- On-chain name capped at 19, symbol input capped at 16
- Type-check 0 errors, build ✓