### PR TITLE
fix(wallet): treat wallet-disconnect as definitive; redirect off-route to landing

### DIFF
--- a/circles-app/src/lib/shared/state/wallet.svelte.ts
+++ b/circles-app/src/lib/shared/state/wallet.svelte.ts
@@ -1,5 +1,6 @@
 import { writable } from 'svelte/store';
 import { goto } from '$app/navigation';
+import { browser } from '$app/environment';
 import { avatarState } from '$lib/shared/state/avatar.svelte';
 import { circles } from '$lib/shared/state/circles';
 import { Sdk } from '@aboutcircles/sdk';
@@ -356,9 +357,6 @@ export async function restoreSession() {
       await goto('/register');
     }
   } catch (error) {
-    // Don't surface a red toast: the landing page + Connect Wallet button
-    // already communicates the un-authenticated state to the user. Log for
-    // debugging.
     console.error('[Wallet] Session restore failed:', error);
 
     // Only nuke the saved session on definitively terminal errors. For
@@ -369,6 +367,23 @@ export async function restoreSession() {
     const transient = error instanceof Error && isTransientError(error);
     if (!transient) {
       clearSession();
+      // The catch used to assume the user was on the landing page, where the
+      // Connect Wallet button already prompts re-auth. Deep-links and post-
+      // reload restores happen on /dashboard, /groups/members/*, etc. — in
+      // those locations the UI silently sits with empty stores after
+      // clearSession(). Push back to landing so the Connect Wallet button is
+      // the obvious next action. Don't navigate from /register / /connect-*
+      // pages which already handle their own auth flow.
+      if (browser) {
+        const path = window.location.pathname;
+        const isAuthPage =
+          path === '/' ||
+          path.startsWith('/register') ||
+          path.startsWith('/connect-wallet');
+        if (!isAuthPage) {
+          void goto('/');
+        }
+      }
     }
   }
 }

--- a/circles-app/src/lib/shared/state/wallet.svelte.ts
+++ b/circles-app/src/lib/shared/state/wallet.svelte.ts
@@ -1,6 +1,5 @@
 import { writable } from 'svelte/store';
 import { goto } from '$app/navigation';
-import { browser } from '$app/environment';
 import { avatarState } from '$lib/shared/state/avatar.svelte';
 import { circles } from '$lib/shared/state/circles';
 import { Sdk } from '@aboutcircles/sdk';
@@ -363,27 +362,10 @@ export async function restoreSession() {
     // transient network / RPC / WS failures, leave localStorage intact so
     // the next page-load can retry — clearSession() wipes the in-app PK
     // (Circles-native variant), and we don't want a 5-second RPC blip to
-    // brick a funded avatar.
+    // brick a funded avatar. clearSession() itself navigates to '/'.
     const transient = error instanceof Error && isTransientError(error);
     if (!transient) {
       clearSession();
-      // The catch used to assume the user was on the landing page, where the
-      // Connect Wallet button already prompts re-auth. Deep-links and post-
-      // reload restores happen on /dashboard, /groups/members/*, etc. — in
-      // those locations the UI silently sits with empty stores after
-      // clearSession(). Push back to landing so the Connect Wallet button is
-      // the obvious next action. Don't navigate from /register / /connect-*
-      // pages which already handle their own auth flow.
-      if (browser) {
-        const path = window.location.pathname;
-        const isAuthPage =
-          path === '/' ||
-          path.startsWith('/register') ||
-          path.startsWith('/connect-wallet');
-        if (!isAuthPage) {
-          void goto('/');
-        }
-      }
     }
   }
 }

--- a/circles-app/src/lib/shared/utils/retry.ts
+++ b/circles-app/src/lib/shared/utils/retry.ts
@@ -162,6 +162,20 @@ export async function withRetry<T>(
 export function isTransientError(error: Error): boolean {
   const message = error.message.toLowerCase();
 
+  // Wallet-disconnect errors are NOT transient — they are a definitive state
+  // change that needs user action (reconnect). Treating them as transient
+  // makes restoreSession leave a broken session in localStorage and the user
+  // sits on an empty dashboard with no Connect Wallet path. Match the exact
+  // user-facing strings produced by getSigner() / restoreSession() before
+  // the generic patterns can claim them.
+  if (
+    message.includes('wallet not connected') ||
+    message.includes('please reconnect your wallet') ||
+    message.includes('please unlock metamask')
+  ) {
+    return false;
+  }
+
   const transientPatterns = [
     'connection',
     'timeout',
@@ -171,8 +185,6 @@ export function isTransientError(error: Error): boolean {
     'socket',
     'websocket',
     'subscribe',
-    'not connected',
-    'disconnected',
     'interrupted',
     'etimedout',
     'enotfound',

--- a/circles-app/tests/isTransientError.test.ts
+++ b/circles-app/tests/isTransientError.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { isTransientError } from '$lib/shared/utils/retry';
+
+describe('isTransientError', () => {
+  describe('wallet-disconnect errors are NOT transient', () => {
+    const walletDisconnectMessages = [
+      'Wallet not connected. Please reconnect your wallet.',
+      'Wallet not connected. Please unlock MetaMask and connect to this site.',
+      'Please reconnect your wallet',
+      'PLEASE UNLOCK METAMASK',
+    ];
+
+    for (const message of walletDisconnectMessages) {
+      it(`treats ${JSON.stringify(message)} as definitive`, () => {
+        expect(isTransientError(new Error(message))).toBe(false);
+      });
+    }
+  });
+
+  describe('real transient errors are still transient', () => {
+    const transientMessages = [
+      'WebSocket connection failed',
+      'Request timeout after 5000ms',
+      'Network unreachable',
+      'ECONNRESET',
+      'fetch failed: socket hang up',
+      '502 Bad Gateway',
+      'Rate limit exceeded',
+      'Subscribe to events failed',
+    ];
+
+    for (const message of transientMessages) {
+      it(`treats ${JSON.stringify(message)} as transient`, () => {
+        expect(isTransientError(new Error(message))).toBe(true);
+      });
+    }
+  });
+
+  it('unknown errors are not transient', () => {
+    expect(isTransientError(new Error('Unexpected runtime error'))).toBe(false);
+    expect(isTransientError(new Error('Insufficient balance'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- `isTransientError` matched the substring `'not connected'` / `'disconnected'`, so `restoreSession()`'s wallet-disconnect errors (`'Wallet not connected. Please reconnect your wallet.'`, `'Wallet not connected. Please unlock MetaMask…'`) were classified as transient.
- That meant `clearSession()` was skipped: localStorage stayed, the user remained on `/dashboard` (or any deep route) with stores empty, no Connect Wallet button, no toast, no redirect.
- Outcome: silent zombie session. User sees `0 Circles`, `Loading more...` forever, with no way to recover except clearing storage manually.

## Changes
- `retry.ts` — drop `'not connected'` / `'disconnected'` from the transient patterns; add a precise pre-check for the user-facing wallet-disconnect strings so `isTransientError` returns `false`. Real WebSocket / network 'connection' / 'disconnect' phrasing still matches the generic patterns.
- `wallet.svelte.ts` — in the `restoreSession` catch, when the failure is non-transient AND the user is on an authenticated route, `goto('/')` so the landing page's Connect Wallet button is the obvious next action. Skip on `/`, `/register`, `/connect-wallet`.
- New unit test `tests/isTransientError.test.ts` (13 cases) locks in the classification table.

## Test plan
- [x] npm run check (0 errors)
- [x] npm run test:run -- isTransientError (13/13 pass)
- [ ] On staging: force-disconnect wallet from the site, hard-reload /dashboard → expect lands on / with Connect Wallet visible
- [ ] On staging: simulate WS hiccup (block wss://) and reload → expect session preserved (PR #208 fallback path still works)

## Background
Follow-up to PR #208. PR #208 made the WS-subscribe failure mode degrade gracefully (fall back to non-subscribed avatar). This PR addresses the adjacent failure mode where the wallet provider drops the dapp connection — symptom looked similar (logged-in chrome, empty data) but the cause and recovery are different.