### PR TITLE
feat(groups): show full + interactive addresses in GroupMembersManager

### DIFF
--- a/circles-app/src/lib/areas/groups/ui/components/GroupMembersManager.svelte
+++ b/circles-app/src/lib/areas/groups/ui/components/GroupMembersManager.svelte
@@ -19,6 +19,7 @@
   } from '$lib/areas/groups/utils/groupKind';
   import { signer, wallet } from '$lib/shared/state/wallet.svelte';
   import ActionButton from '$lib/shared/ui/primitives/ActionButton.svelte';
+  import AddressView from '$lib/shared/ui/primitives/Address.svelte';
   import SearchablePaginatedList from '$lib/shared/ui/lists/SearchablePaginatedList.svelte';
   import AvatarRowPlaceholder from '$lib/shared/ui/lists/placeholders/AvatarRowPlaceholder.svelte';
   import GroupMemberRow, {
@@ -518,19 +519,27 @@
     <div class="text-xs rounded border border-warning/40 bg-warning/10 px-2 py-1">
       Your account can manage this group, but only when connected via the
       Safe that owns it
-      <span class="font-mono">({groupOwner ? shortenAddress(groupOwner) : 'unknown'})</span>.
+      {#if groupOwner}
+        (<AddressView address={groupOwner} full explorer />).
+      {:else}
+        (<span class="opacity-60">unknown</span>).
+      {/if}
       Disconnect and reconnect using that Safe.
     </div>
   {:else if capsLoaded && !canManageEnabled && manageReason === 'not-an-owner'}
     <div class="text-xs rounded border border-warning/40 bg-warning/10 px-2 py-1">
       View-only. This group is owned by
-      <span class="font-mono">{groupOwner ? shortenAddress(groupOwner) : 'another account'}</span>
+      {#if groupOwner}
+        <AddressView address={groupOwner} full explorer />
+      {:else}
+        <span class="opacity-60">another account</span>
+      {/if}
       — sign in with the Safe that owns this group to add or remove members.
     </div>
   {:else if capsLoaded && managingViaOwnerSafe}
     <div class="text-xs opacity-70 rounded border border-base-300/60 bg-base-200/40 px-2 py-1">
       Managing as
-      <span class="font-mono">{shortenAddress(managingViaOwnerSafe)}</span>
+      <AddressView address={managingViaOwnerSafe} full explorer />
       (the Safe that owns this group). Trust changes are routed through it.
     </div>
   {/if}

--- a/circles-app/src/lib/shared/ui/primitives/Address.svelte
+++ b/circles-app/src/lib/shared/ui/primitives/Address.svelte
@@ -5,21 +5,82 @@
   let copyIcon = $state('/copy.svg');
   interface Props {
     address: Address;
+    // When true, render the full 0x… address (no shortening). Inline variant
+    // — no button chrome — so it composes inside flowing banner text.
+    full?: boolean;
+    // When true, render a small explorer-link icon next to the address.
+    explorer?: boolean;
   }
 
-  let { address }: Props = $props();
+  let { address, full = false, explorer = false }: Props = $props();
+  let copyFailed = $state(false);
 
-  function handleCopy() {
-    navigator.clipboard.writeText(address);
-    copyIcon = '/check.svg';
+  async function handleCopy() {
+    // Clipboard write can fail or be unavailable:
+    //  - navigator.clipboard undefined (older mobile, http:// dev mirrors)
+    //  - permission denied (iOS Safari without user gesture, some iframes)
+    //  - document not focused (Firefox in some embeds)
+    // Only flip to the success icon when the write actually resolved; on
+    // failure surface a small visual signal so the user doesn't silently
+    // paste nothing.
+    try {
+      if (!navigator?.clipboard?.writeText) {
+        throw new Error('Clipboard API unavailable in this browser context');
+      }
+      await navigator.clipboard.writeText(address);
+      copyIcon = '/check.svg';
+      copyFailed = false;
+    } catch (e) {
+      console.warn('[Address] Clipboard write failed:', e);
+      copyFailed = true;
+    }
 
     setTimeout(() => {
       copyIcon = '/copy.svg';
-    }, 1000);
+      copyFailed = false;
+    }, 1500);
   }
 </script>
 
-<button onclick={handleCopy} class="btn btn-sm">
-  {shortenAddress(address)}
-  <img src={copyIcon} alt="Copy" class="w-4 h-4 inline" />
-</button>
+{#if full}
+  <span class="inline-flex items-center gap-1 align-baseline">
+    <button
+      type="button"
+      onclick={handleCopy}
+      title={copyFailed ? 'Copy failed — select and copy manually' : 'Copy address'}
+      class="font-mono break-all underline decoration-dotted hover:opacity-70 cursor-pointer"
+    >
+      {address}
+    </button>
+    {#if copyFailed}
+      <span class="text-error text-xs shrink-0" title="Clipboard blocked by browser">!</span>
+    {:else}
+      <img src={copyIcon} alt="Copy" class="w-3 h-3 inline shrink-0" />
+    {/if}
+    {#if explorer}
+      <a
+        href="https://gnosisscan.io/address/{address}"
+        target="_blank"
+        rel="noopener noreferrer"
+        title="View on Gnosisscan"
+        class="opacity-60 hover:opacity-100 shrink-0"
+        aria-label="View on Gnosisscan"
+      >
+        ↗
+      </a>
+    {/if}
+  </span>
+{:else}
+  <button
+    onclick={handleCopy}
+    class="btn btn-sm"
+    title={copyFailed ? 'Copy failed — select and copy manually' : 'Copy address'}
+  >
+    {shortenAddress(address)}
+    {#if copyFailed}
+      <span class="text-error text-xs">!</span>
+    {:else}
+      <img src={copyIcon} alt="Copy" class="w-4 h-4 inline" />
+    {/if}
+  </button>
+{/if}

--- a/circles-app/src/lib/shared/utils/trustActions.ts
+++ b/circles-app/src/lib/shared/utils/trustActions.ts
@@ -214,11 +214,14 @@ async function sendGroupTrustTx(params: {
   // Preflight failed and we can't route. Surface a meaningful, address-bearing
   // error instead of letting the user hit the opaque execTransaction revert.
   if (isOwnerCheckFailure) {
+    // Full addresses, not shortened — error toasts surface to the user when
+    // they need to take action (switch Safe, copy an address, look it up on
+    // an explorer). Shortened addresses force a tedious back-and-forth.
     const ownerHint = params.caps.owner
-      ? ` Manage this group from the Safe that owns it (${shortenAddress(params.caps.owner)}).`
+      ? ` Manage this group from the Safe that owns it (${params.caps.owner}).`
       : '';
     throw new Error(
-      `You don't have permission to update trust on this group from ${shortenAddress(from)}.${ownerHint}`
+      `You don't have permission to update trust on this group from ${from}.${ownerHint}`
     );
   }
   throw new Error(`Group trust call would revert: ${preflight.reason}`);

--- a/circles-app/src/routes/groups/members/[group]/+page.svelte
+++ b/circles-app/src/routes/groups/members/[group]/+page.svelte
@@ -9,6 +9,7 @@
   import type { Action } from '$lib/shared/ui/shell/actions';
   import { getProfileDisplayName } from '$lib/areas/groups/ui/utils/profileDisplayName';
   import GroupMembersManager from '$lib/areas/groups/ui/components/GroupMembersManager.svelte';
+  import AddressView from '$lib/shared/ui/primitives/Address.svelte';
 
   const group = $derived(($page.params.group ?? '').toLowerCase() as Address | '');
   const shortAddr = (a?: string) => (a ? `${a.slice(0, 6)}…${a.slice(-4)}` : '');
@@ -87,7 +88,9 @@
 
   {#snippet meta()}
     {#if group}
-      <span class="text-xs opacity-70">{shortAddr(group)}</span>
+      <span class="text-xs opacity-70">
+        <AddressView address={group} full explorer />
+      </span>
     {:else}
       <span class="text-xs opacity-70">Missing group address.</span>
     {/if}


### PR DESCRIPTION
## Summary

Group members page rendered owner / managing-Safe / page-subtitle addresses via `shortenAddress(...)`, with no copy or explorer affordance. When a banner asks the user to switch to a specific Safe, the truncated address is the exact thing they need to act on — and they can't.

## Changes

- **`Address.svelte`** — add optional `full` and `explorer` props. Default behavior preserved for the 7 existing callers. `full` switches to an inline copy-on-click button rendering the full `0x…` address; `explorer` adds a small `↗` link to gnosisscan. Clipboard write is now awaited and surfaces a visible `!` indicator on failure (older mobile browsers, insecure contexts, denied permissions) so the user doesn't silently paste nothing.
- **`GroupMembersManager.svelte`** — three banners (view-only / eoa-must-switch-wallet / managing-as) use the new `<AddressView full explorer />` form. Aliased import to avoid colliding with the `Address` type from `@aboutcircles/sdk-types`.
- **`/groups/members/[group]/+page.svelte`** — page subtitle uses the same component instead of the inert `shortAddr(group)` span.
- **`trustActions.ts`** — drop `shortenAddress(...)` in the `OnlyOwnerOrService()` throw message; full addresses in error toasts. Task-name labels in `runTask(...)` still use the shortened form since those are display strings, not actionable.

## Test plan

- [ ] Visit `/groups/members/<owned-group>` — page subtitle shows full address with copy + explorer icons.
- [ ] Visit `/groups/members/<group-you-do-not-own>` — View-only banner renders full owner-Safe address with copy + explorer icons.
- [ ] Visit `/groups/members/<nested-Safe-group>` — Managing-as banner renders full owner-Safe address with copy + explorer icons.
- [ ] Click the address in any banner — clipboard receives the full 0x40-hex string; icon flips to ✓ for ~1.5s.
- [ ] Click `↗` icon — gnosisscan opens in a new tab to `/address/<addr>`.
- [ ] Existing callers of `<Address />` (Profile, register, kitchen-sink/identity, ManageTrust, GatewaysPanel, SettingProfile) render unchanged (default short + copy button).
- [ ] In a browser without clipboard API (or denied permission), click the address — `!` indicator appears, no thrown error in console other than the warn.