### PR TITLE
fix(wallet): redirect from auth-gated routes on empty session state

### DIFF
--- a/circles-app/src/lib/shared/state/wallet.svelte.ts
+++ b/circles-app/src/lib/shared/state/wallet.svelte.ts
@@ -215,14 +215,37 @@ export async function initNewEoaBrowserRunner(eoaAddress: Address) {
   return runner;
 }
 
+// Mirrors shouldBypassWalletRestore in +layout.svelte; the two lists must
+// stay in sync. Uses raw pathname instead of SvelteKit's parameterized
+// route id so it can run anywhere (incl. outside a SvelteKit context).
+export function isPublicRoute(pathname: string): boolean {
+  return (
+    pathname === '/' ||
+    pathname === '/util' ||
+    pathname.startsWith('/connect-wallet') ||
+    pathname.startsWith('/register') ||
+    pathname.startsWith('/privacy-policy') ||
+    pathname.startsWith('/terms') ||
+    pathname.startsWith('/kitchen-sink')
+  );
+}
+
 export async function restoreSession() {
   const privateKey = CirclesStorage.getInstance().privateKey;
   const savedAvatar = CirclesStorage.getInstance().avatar;
 
   // Fresh visit / signed-out state — nothing to restore. Skip silently instead
   // of throwing, otherwise every first-time landing fires a red "Session Restore
-  // Failed" error toast.
+  // Failed" error toast. If the user is on an auth-gated route (deep-linked
+  // /dashboard, or wagmi lost the connector between sessions), redirect to /
+  // so the landing-page Connect Wallet button is the obvious next step.
+  // Without this redirect the dashboard renders "0 Circles" with no recovery
+  // UI — the mid-session disconnect path is covered by clearSession()'s own
+  // goto('/'), this branch covers the no-storage-on-load path.
   if (!privateKey && !savedAvatar) {
+    if (typeof window !== 'undefined' && !isPublicRoute(window.location.pathname)) {
+      await goto('/');
+    }
     return;
   }
 

--- a/circles-app/tests/isPublicRoute.test.ts
+++ b/circles-app/tests/isPublicRoute.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { isPublicRoute } from '$lib/shared/state/wallet.svelte';
+
+describe('isPublicRoute', () => {
+  describe('public routes (no wallet required)', () => {
+    const publicPaths = [
+      '/',
+      '/util',
+      '/connect-wallet',
+      '/connect-wallet/connect-safe',
+      '/connect-wallet/import-circles-garden',
+      '/register',
+      '/register/some/nested/step',
+      '/privacy-policy',
+      '/terms',
+      '/kitchen-sink',
+      '/kitchen-sink/identity',
+    ];
+
+    for (const path of publicPaths) {
+      it(`treats ${JSON.stringify(path)} as public`, () => {
+        expect(isPublicRoute(path)).toBe(true);
+      });
+    }
+  });
+
+  describe('auth-gated routes (wallet required)', () => {
+    const authGatedPaths = [
+      '/dashboard',
+      '/groups',
+      '/groups/members/0xabc',
+      '/groups/metrics/0xdef',
+      '/contacts',
+      '/contacts/0xabc',
+      '/market',
+      '/admin',
+      '/avatar-search',
+      '/back-circles',
+      '/jump',
+      '/sales',
+      '/settings',
+    ];
+
+    for (const path of authGatedPaths) {
+      it(`treats ${JSON.stringify(path)} as auth-gated`, () => {
+        expect(isPublicRoute(path)).toBe(false);
+      });
+    }
+  });
+
+  describe('edge cases', () => {
+    it('rejects paths that contain but do not start with a public prefix', () => {
+      // `/dashboard/register` is NOT the register flow; it's a dashboard child.
+      // The startsWith check is intentional and only triggers on prefix match.
+      expect(isPublicRoute('/dashboard/register')).toBe(false);
+      expect(isPublicRoute('/groups/terms')).toBe(false);
+    });
+
+    it('treats empty string as auth-gated (defensive default)', () => {
+      expect(isPublicRoute('')).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

When `CirclesStorage` holds neither `privateKey` nor `savedAvatar`, `restoreSession()` returns silently (early-return at `wallet.svelte.ts:225-227`) to avoid a red "Session Restore Failed" toast on a first-ever visit.

If the user is on an auth-gated route at that point — deep-linked `/dashboard`, wagmi lost the connector between sessions, browser cleared site data — the dashboard renders `0 Circles` with no Connect Wallet affordance and no recovery path.

Same end-user symptom as the mid-session disconnect bug PR #209 fixed, different root cause: PR #209 only handles the `restoreSession` catch path (non-transient error during restore → `clearSession()` → `goto('/')`). The early-return doesn't throw and never reaches that handler.

## Changes

- **`circles-app/src/lib/shared/state/wallet.svelte.ts`**: new exported `isPublicRoute(pathname)` helper. Mirrors `shouldBypassWalletRestore` in `+layout.svelte` — the two lists must stay in sync (comment cross-references both directions). Uses raw pathname instead of SvelteKit's parameterized route id so the helper is callable outside a route-context.
- **`circles-app/src/lib/shared/state/wallet.svelte.ts`**: in the empty-storage early-return, when `typeof window !== 'undefined'` and the current pathname is not public, `await goto('/')` before returning.
- **`circles-app/tests/isPublicRoute.test.ts`**: 26 cases — 11 public routes, 13 auth-gated routes, 2 edge cases pinning prefix-match semantics (`/dashboard/register` stays auth-gated; empty string defaults to auth-gated).

## Test plan

- [x] `npm run check` — 0 errors, 21 pre-existing warnings.
- [x] `npm run test:run` — 19 files / 142 cases pass.
- [ ] On staging: deep-link `/dashboard` with no wallet ever connected → expect lands on `/` with Connect Wallet visible.
- [ ] On staging: hard-refresh `/dashboard` after browser clears site data → same expectation.
- [ ] On staging: regression — `/` still loads with Connect Wallet; `/register`, `/connect-wallet/*`, `/privacy-policy`, `/terms` still reachable without redirect.
- [ ] On staging: connected wallet, hard-refresh `/dashboard` → session restores normally (PR #209 verified path; this PR must not regress it).

## Notes

The full unauth-redirect feature (preserve return URL via `?next=<path>` and route the user back after sign-in) is a separate, larger PR. This change is the minimal redirect to close the visible "stuck on empty dashboard" symptom.