### PR TITLE
sync dev → main: nested-Safe group trust, unwrap branching, SW kill-switch, wallet redirects (#208, #209, #210, #211)

### DIFF
--- a/circles-app/src/lib/areas/groups/ui/components/GroupMembersManager.svelte
+++ b/circles-app/src/lib/areas/groups/ui/components/GroupMembersManager.svelte
@@ -19,6 +19,7 @@
   } from '$lib/areas/groups/utils/groupKind';
   import { signer, wallet } from '$lib/shared/state/wallet.svelte';
   import ActionButton from '$lib/shared/ui/primitives/ActionButton.svelte';
+  import AddressView from '$lib/shared/ui/primitives/Address.svelte';
   import SearchablePaginatedList from '$lib/shared/ui/lists/SearchablePaginatedList.svelte';
   import AvatarRowPlaceholder from '$lib/shared/ui/lists/placeholders/AvatarRowPlaceholder.svelte';
   import GroupMemberRow, {
@@ -518,19 +519,27 @@
     <div class="text-xs rounded border border-warning/40 bg-warning/10 px-2 py-1">
       Your account can manage this group, but only when connected via the
       Safe that owns it
-      <span class="font-mono">({groupOwner ? shortenAddress(groupOwner) : 'unknown'})</span>.
+      {#if groupOwner}
+        (<AddressView address={groupOwner} full explorer />).
+      {:else}
+        (<span class="opacity-60">unknown</span>).
+      {/if}
       Disconnect and reconnect using that Safe.
     </div>
   {:else if capsLoaded && !canManageEnabled && manageReason === 'not-an-owner'}
     <div class="text-xs rounded border border-warning/40 bg-warning/10 px-2 py-1">
       View-only. This group is owned by
-      <span class="font-mono">{groupOwner ? shortenAddress(groupOwner) : 'another account'}</span>
+      {#if groupOwner}
+        <AddressView address={groupOwner} full explorer />
+      {:else}
+        <span class="opacity-60">another account</span>
+      {/if}
       — sign in with the Safe that owns this group to add or remove members.
     </div>
   {:else if capsLoaded && managingViaOwnerSafe}
     <div class="text-xs opacity-70 rounded border border-base-300/60 bg-base-200/40 px-2 py-1">
       Managing as
-      <span class="font-mono">{shortenAddress(managingViaOwnerSafe)}</span>
+      <AddressView address={managingViaOwnerSafe} full explorer />
       (the Safe that owns this group). Trust changes are routed through it.
     </div>
   {/if}

--- a/circles-app/src/lib/areas/groups/ui/components/GroupMembersManager.svelte
+++ b/circles-app/src/lib/areas/groups/ui/components/GroupMembersManager.svelte
@@ -12,7 +12,12 @@
   import { createAvatarDataSource } from '$lib/shared/data/circles/avatarDataSource';
   import { createGroupDataSource } from '$lib/shared/data/circles/groupDataSource';
   import { removeGroupMembers } from '$lib/shared/utils/trustActions';
-  import { probeGroupCapabilities } from '$lib/areas/groups/utils/groupKind';
+  import {
+    assessManagePermission,
+    probeGroupCapabilities,
+    type ManagePermission,
+  } from '$lib/areas/groups/utils/groupKind';
+  import { signer, wallet } from '$lib/shared/state/wallet.svelte';
   import ActionButton from '$lib/shared/ui/primitives/ActionButton.svelte';
   import SearchablePaginatedList from '$lib/shared/ui/lists/SearchablePaginatedList.svelte';
   import AvatarRowPlaceholder from '$lib/shared/ui/lists/placeholders/AvatarRowPlaceholder.svelte';
@@ -48,6 +53,22 @@
     ownerRemoveSupported = v;
   });
   let capsLoaded: boolean = $state(false);
+
+  // Does the currently-connected wallet have permission to manage this group?
+  // `canManage` is derived from on-chain caps (owner, ownerSafeOwners) + the
+  // wallet runner's address. The row context exposes a parallel readable so
+  // each row can hide the trash icon without prop drilling.
+  // Declaration order matters: the $state mirror must exist BEFORE subscribe,
+  // because subscribe fires synchronously with the current store value and
+  // would otherwise hit a TDZ on the let binding.
+  let canManageEnabled: boolean = $state(false);
+  let manageReason: ManagePermission['reason'] = $state('unknown');
+  let managingViaOwnerSafe: Address | null = $state(null);
+  let groupOwner: Address | null = $state(null);
+  const canManageStore = writable<boolean>(false);
+  canManageStore.subscribe((v) => {
+    canManageEnabled = v;
+  });
 
   // Selection state lives outside the virtualized rows so toggling a checkbox
   // doesn't rebuild item identities (which would cost re-render on every row).
@@ -264,15 +285,58 @@
 
     capsLoaded = false;
     ownerRemoveSupportedStore.set(false);
+    canManageStore.set(false);
+    manageReason = 'unknown';
+    managingViaOwnerSafe = null;
+    groupOwner = null;
     void probeGroupCapabilities(group as string)
       .then((caps) => {
         if (probedForGroup !== groupKey) return;
         ownerRemoveSupportedStore.set(caps.ownerRemove);
+        groupOwner = caps.owner;
+        // Re-evaluate manage permission whenever caps land OR the wallet
+        // runner address changes. The wallet store is subscribed to in the
+        // separate $effect below, but assess once here using the current
+        // value to avoid a one-tick "no permission" flash before the
+        // subscription kicks in.
+        const runnerAddr =
+          (get(wallet) as { address?: string } | null)?.address ?? null;
+        const perm = assessManagePermission(caps, runnerAddr, signer.address);
+        canManageStore.set(perm.canManage);
+        manageReason = perm.reason;
+        managingViaOwnerSafe =
+          perm.reason === 'nested-safe' ? perm.ownerProxyChain[0] : null;
         capsLoaded = true;
       })
       .catch((e) => {
         console.warn('[GroupMembersManager] capabilities probe failed', e);
         if (probedForGroup === groupKey) capsLoaded = true;
+      });
+  });
+
+  // Re-evaluate canManage whenever the connected wallet changes. The probed
+  // caps are stable per group; only the runner address moves here.
+  $effect(() => {
+    const runner = $wallet as { address?: string } | null;
+    const groupKey = group ? String(group).toLowerCase() : '';
+    if (!groupKey) return;
+
+    void probeGroupCapabilities(group as string)
+      .then((caps) => {
+        // Only update if still on the same group (avoid stale closure write).
+        if (probedForGroup !== groupKey) return;
+        const perm = assessManagePermission(
+          caps,
+          runner?.address ?? null,
+          signer.address
+        );
+        canManageStore.set(perm.canManage);
+        manageReason = perm.reason;
+        managingViaOwnerSafe =
+          perm.reason === 'nested-safe' ? perm.ownerProxyChain[0] : null;
+      })
+      .catch(() => {
+        // Swallow — original probe already logs.
       });
   });
 
@@ -403,9 +467,16 @@
     });
   }
 
+  // Combined readable for rows: trash icon shows only if BOTH the contract
+  // shape supports owner-remove AND the connected wallet has permission.
+  const rowCanRemove = derived(
+    [ownerRemoveSupportedStore, canManageStore],
+    ([$contractSupports, $hasPermission]) => $contractSupports && $hasPermission
+  );
+
   setContext('groupMemberRowActions', {
     selectedSet: { subscribe: selectedSetStore.subscribe } as Readable<Set<string>>,
-    canRemove: { subscribe: ownerRemoveSupportedStore.subscribe } as Readable<boolean>,
+    canRemove: { subscribe: rowCanRemove.subscribe } as Readable<boolean>,
     onToggleSelected: toggleSelected,
     onUntrust: (address: Address) => void untrustOne(address),
     onActivateRow: activateRow,
@@ -426,14 +497,16 @@
       <div class="text-xs opacity-70">Manage trusted avatars for this group.</div>
     </div>
     <div class="flex items-center gap-2">
-      {#if ownerRemoveSupported && selectedCount > 0}
+      {#if canManageEnabled && ownerRemoveSupported && selectedCount > 0}
         <ActionButton action={removeSelected}>
           Remove {selectedCount} member{selectedCount === 1 ? '' : 's'}
         </ActionButton>
       {/if}
-      <button class="btn btn-sm btn-primary" onclick={openAddPopup}>
-        Add
-      </button>
+      {#if canManageEnabled}
+        <button class="btn btn-sm btn-primary" onclick={openAddPopup}>
+          Add
+        </button>
+      {/if}
     </div>
   </div>
 
@@ -441,7 +514,28 @@
     {totalMemberCount ?? $itemsReadable.length} trusted avatar{(totalMemberCount ?? $itemsReadable.length) === 1 ? '' : 's'}
   </div>
 
-  {#if capsLoaded && !ownerRemoveSupported}
+  {#if capsLoaded && !canManageEnabled && manageReason === 'eoa-must-switch-wallet'}
+    <div class="text-xs rounded border border-warning/40 bg-warning/10 px-2 py-1">
+      Your account can manage this group, but only when connected via the
+      Safe that owns it
+      <span class="font-mono">({groupOwner ? shortenAddress(groupOwner) : 'unknown'})</span>.
+      Disconnect and reconnect using that Safe.
+    </div>
+  {:else if capsLoaded && !canManageEnabled && manageReason === 'not-an-owner'}
+    <div class="text-xs rounded border border-warning/40 bg-warning/10 px-2 py-1">
+      View-only. This group is owned by
+      <span class="font-mono">{groupOwner ? shortenAddress(groupOwner) : 'another account'}</span>
+      — sign in with the Safe that owns this group to add or remove members.
+    </div>
+  {:else if capsLoaded && managingViaOwnerSafe}
+    <div class="text-xs opacity-70 rounded border border-base-300/60 bg-base-200/40 px-2 py-1">
+      Managing as
+      <span class="font-mono">{shortenAddress(managingViaOwnerSafe)}</span>
+      (the Safe that owns this group). Trust changes are routed through it.
+    </div>
+  {/if}
+
+  {#if capsLoaded && canManageEnabled && !ownerRemoveSupported}
     <div class="text-xs opacity-70 rounded border border-base-300/60 bg-base-200/40 px-2 py-1">
       This group's contract has no owner-side remove. Members leave via Opt-out from their Memberships page.
     </div>

--- a/circles-app/src/lib/areas/groups/utils/groupKind.ts
+++ b/circles-app/src/lib/areas/groups/utils/groupKind.ts
@@ -1,4 +1,12 @@
-import { JsonRpcProvider, keccak256, toUtf8Bytes } from 'ethers';
+import {
+  Contract,
+  Interface,
+  JsonRpcProvider,
+  ZeroAddress,
+  keccak256,
+  toUtf8Bytes,
+} from 'ethers';
+import type { Address } from '@aboutcircles/sdk-types';
 import { getActiveConfig } from '$lib/shared/state/settings.svelte';
 
 // Three v2 group contract shapes coexist on Gnosis. The on-chain selectors
@@ -26,6 +34,35 @@ export type GroupCapabilities = {
   ownerRemove: boolean;
   // Member can opt out (optOut()).
   optOut: boolean;
+  // owner() of the group contract. Lowercased. `null` if owner() is not callable.
+  owner: Address | null;
+  // service() of the group contract. Lowercased. `null` if not exposed.
+  service: Address | null;
+  // True if owner is a contract (Safe or otherwise).
+  ownerIsContract: boolean;
+  // If owner is a Safe, its owner set (lowercased). `null` if owner is an EOA
+  // or `getOwners()` is not callable.
+  ownerSafeOwners: Address[] | null;
+};
+
+export type ManagePermissionReason =
+  | 'direct'      // runner === group.owner — call group directly
+  | 'nested-safe' // runner is an owner of group.owner Safe — nest via owner Safe
+  | 'service'     // runner === group.service — call group directly (service path)
+  | 'eoa-must-switch-wallet' // the EOA can sign for the owner Safe but the
+                             // currently-connected runner Safe cannot — user
+                             // must disconnect and reconnect via the owner Safe
+  | 'not-an-owner'
+  | 'unknown';
+
+export type ManagePermission = {
+  canManage: boolean;
+  // Empty when canManage is via direct or service path; [ownerSafe] when
+  // call must be routed via Safe-on-Safe through the owner. For
+  // 'eoa-must-switch-wallet' this lists the Safe the user should reconnect
+  // via.
+  ownerProxyChain: Address[];
+  reason: ManagePermissionReason;
 };
 
 const TRUST_BATCH_WITH_CONDITIONS = '4141f954';
@@ -45,11 +82,28 @@ const EIP1967_IMPL_SLOT =
     .padStart(64, '0');
 const ZERO_SLOT = '0x' + '0'.repeat(64);
 
-const CACHE_KEY_PREFIX = 'circles.groupCaps.';
+// v3 cache key — the shape grew (owner / service / ownerSafeOwners). Old v2
+// entries are missing those fields and would be misclassified as
+// "owner unknown", so we ignore them by changing the prefix.
+const CACHE_KEY_PREFIX = 'circles.groupCaps.v3.';
 const inflight = new Map<string, Promise<GroupCapabilities>>();
+
+const groupReadIface = new Interface([
+  'function owner() view returns (address)',
+  'function service() view returns (address)',
+]);
+const safeIface = new Interface([
+  'function getOwners() view returns (address[])',
+]);
 
 function cacheKey(address: string): string {
   return `${CACHE_KEY_PREFIX}${address.toLowerCase()}`;
+}
+
+function asAddress(value: unknown): Address | null {
+  if (typeof value !== 'string') return null;
+  if (!/^0x[0-9a-fA-F]{40}$/.test(value)) return null;
+  return value.toLowerCase() as Address;
 }
 
 function readCached(address: string): GroupCapabilities | null {
@@ -63,7 +117,11 @@ function readCached(address: string): GroupCapabilities | null {
       typeof parsed === 'object' &&
       typeof parsed.optOut === 'boolean' &&
       typeof parsed.ownerRemove === 'boolean' &&
-      typeof parsed.trustKind === 'string'
+      typeof parsed.trustKind === 'string' &&
+      'owner' in parsed &&
+      'service' in parsed &&
+      typeof parsed.ownerIsContract === 'boolean' &&
+      'ownerSafeOwners' in parsed
     ) {
       return parsed;
     }
@@ -107,7 +165,11 @@ async function readEffectiveBytecode(
   return (code + implCode).toLowerCase();
 }
 
-function classify(bytecode: string): GroupCapabilities {
+function classifyBytecode(bytecode: string): {
+  trustKind: GroupTrustKind;
+  ownerRemove: boolean;
+  optOut: boolean;
+} {
   const hasConditions = bytecode.includes(TRUST_BATCH_WITH_CONDITIONS);
   const hasExpiry = bytecode.includes(TRUST_BATCH_WITH_EXPIRY);
   const hasSimple = bytecode.includes(TRUST_BATCH_NO_EXPIRY);
@@ -129,6 +191,54 @@ function classify(bytecode: string): GroupCapabilities {
   return { trustKind, ownerRemove, optOut: hasOptOut };
 }
 
+async function readGroupOwnerAndService(
+  provider: JsonRpcProvider,
+  address: string
+): Promise<{ owner: Address | null; service: Address | null }> {
+  const group = new Contract(address, groupReadIface, provider);
+  const [ownerSettled, serviceSettled] = await Promise.allSettled([
+    group.owner(),
+    group.service(),
+  ]);
+  return {
+    owner:
+      ownerSettled.status === 'fulfilled'
+        ? asAddress(ownerSettled.value)
+        : null,
+    service:
+      serviceSettled.status === 'fulfilled'
+        ? asAddress(serviceSettled.value)
+        : null,
+  };
+}
+
+async function readSafeOwnersIfContract(
+  provider: JsonRpcProvider,
+  address: Address | null
+): Promise<{ isContract: boolean; safeOwners: Address[] | null }> {
+  if (!address || address === ZeroAddress.toLowerCase()) {
+    return { isContract: false, safeOwners: null };
+  }
+  // RPC failure on getCode is propagated: silently returning isContract=false
+  // would poison the cache and make a Safe-owned group look like an EOA-owned
+  // one, hiding the manage UI forever via the not-an-owner branch.
+  const code = await provider.getCode(address);
+  if (!code || code === '0x') {
+    return { isContract: false, safeOwners: null };
+  }
+  try {
+    const safe = new Contract(address, safeIface, provider);
+    const owners = (await safe.getOwners()) as string[];
+    const normalized = owners
+      .map((o) => asAddress(o))
+      .filter((o): o is Address => o !== null);
+    return { isContract: true, safeOwners: normalized };
+  } catch {
+    // Owner is a contract but not a Safe — still useful to flag isContract.
+    return { isContract: true, safeOwners: null };
+  }
+}
+
 export async function probeGroupCapabilities(
   address: string
 ): Promise<GroupCapabilities> {
@@ -146,20 +256,38 @@ export async function probeGroupCapabilities(
     if (!rpcUrl) {
       // No RPC available — conservative default so the UI doesn't lock up
       // pretending the group has no capabilities at all.
-      return { trustKind: 'unknown', ownerRemove: false, optOut: false };
+      return emptyCaps();
     }
     try {
       const provider = new JsonRpcProvider(rpcUrl);
-      const bytecode = await readEffectiveBytecode(provider, address);
+      const [bytecode, ownerInfo] = await Promise.all([
+        readEffectiveBytecode(provider, address),
+        readGroupOwnerAndService(provider, address),
+      ]);
+
       if (!bytecode) {
-        return { trustKind: 'unknown', ownerRemove: false, optOut: false };
+        return emptyCaps();
       }
-      const caps = classify(bytecode);
+
+      const bytecodeCaps = classifyBytecode(bytecode);
+      const { isContract, safeOwners } = await readSafeOwnersIfContract(
+        provider,
+        ownerInfo.owner
+      );
+
+      const caps: GroupCapabilities = {
+        ...bytecodeCaps,
+        owner: ownerInfo.owner,
+        service: ownerInfo.service,
+        ownerIsContract: isContract,
+        ownerSafeOwners: safeOwners,
+      };
       writeCached(key, caps);
       return caps;
-    } catch {
+    } catch (e) {
       // Network or RPC error: do not cache; next call may succeed.
-      return { trustKind: 'unknown', ownerRemove: false, optOut: false };
+      console.warn('[groupKind] probeGroupCapabilities failed for', address, e);
+      return emptyCaps();
     }
   })();
 
@@ -169,4 +297,88 @@ export async function probeGroupCapabilities(
   } finally {
     inflight.delete(key);
   }
+}
+
+function emptyCaps(): GroupCapabilities {
+  return {
+    trustKind: 'unknown',
+    ownerRemove: false,
+    optOut: false,
+    owner: null,
+    service: null,
+    ownerIsContract: false,
+    ownerSafeOwners: null,
+  };
+}
+
+// Pure derivation: given the on-chain shape and the currently-connected
+// runner + EOA addresses, decide whether the user can manage the group and
+// how. Kept separate from `probeGroupCapabilities` so a wallet swap
+// re-evaluates permission without re-probing the (immutable) on-chain shape.
+//
+// `eoaAddress` is the signer EOA (e.g. wallet.svelte's `signer.address`).
+// It matters because some users have a personal-avatar Safe AND a separate
+// group-owner Safe that share an EOA cosigner but where the personal Safe
+// is NOT itself an owner of the group Safe. In that case the user CAN still
+// manage the group — but only by reconnecting via the group's owner Safe.
+// We detect that and surface it as `eoa-must-switch-wallet` so the UI can
+// guide the user instead of letting them hit OnlyOwnerOrService at submit.
+export function assessManagePermission(
+  caps: GroupCapabilities,
+  runnerAddress: Address | string | null | undefined,
+  eoaAddress: Address | string | null | undefined = null
+): ManagePermission {
+  const runner = asAddress(runnerAddress ?? null);
+  const eoa = asAddress(eoaAddress ?? null);
+  if (!runner) {
+    return { canManage: false, ownerProxyChain: [], reason: 'unknown' };
+  }
+  const owner = caps.owner;
+  const service = caps.service;
+
+  // Direct paths: runner IS the owner, OR runner IS the service.
+  if (owner && runner === owner) {
+    return { canManage: true, ownerProxyChain: [], reason: 'direct' };
+  }
+  if (service && runner === service) {
+    return { canManage: true, ownerProxyChain: [], reason: 'service' };
+  }
+
+  // 1-hop Safe-on-Safe: owner is a Safe and runner is one of its owners.
+  if (owner && caps.ownerSafeOwners && caps.ownerSafeOwners.includes(runner)) {
+    return {
+      canManage: true,
+      ownerProxyChain: [owner],
+      reason: 'nested-safe',
+    };
+  }
+
+  // EOA-can-sign-but-runner-cannot. Runner Safe isn't an owner of the group
+  // Safe, but the user's EOA *is*. The user has signing rights — they just
+  // need to reconnect using the group's owner Safe as their wallet.
+  if (
+    owner &&
+    eoa &&
+    caps.ownerSafeOwners &&
+    caps.ownerSafeOwners.includes(eoa)
+  ) {
+    return {
+      canManage: false,
+      ownerProxyChain: [owner],
+      reason: 'eoa-must-switch-wallet',
+    };
+  }
+
+  // We have full data and neither the runner nor the EOA is on any path.
+  if (owner !== null) {
+    return { canManage: false, ownerProxyChain: [], reason: 'not-an-owner' };
+  }
+
+  // Could not read owner — some group variants (`simple`/ScoreGroup) don't
+  // expose `owner()` at all and use different permission models. Be
+  // OPTIMISTIC here: leave the Add/Remove buttons enabled so the user can
+  // attempt the action. The preflight in `trustActions.ts` runs `eth_call`
+  // from the runner; if the contract rejects the call, the user sees a
+  // decoded error from preflight instead of a button that does nothing.
+  return { canManage: true, ownerProxyChain: [], reason: 'unknown' };
 }

--- a/circles-app/src/lib/areas/groups/utils/groupOwnerProxy.ts
+++ b/circles-app/src/lib/areas/groups/utils/groupOwnerProxy.ts
@@ -1,0 +1,49 @@
+import { Interface, ZeroAddress, concat, zeroPadValue } from 'ethers';
+import type { Address } from '@aboutcircles/sdk-types';
+
+// Safe v1.3 execTransaction ABI. Same shape that produced the failing tx the
+// user reported — the only thing changing is what `to` points at: a wrapped
+// inner Safe call instead of the group contract directly.
+const safeExecIface = new Interface([
+  'function execTransaction(address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, bytes signatures) external payable returns (bool success)',
+]);
+
+// Pre-validated Safe signature payload. When the Safe checks signatures and
+// sees `v == 1`, it treats `r` as the address of an approver. If that address
+// equals msg.sender, the call is considered authorized without a stored
+// approveHash. We rely on this here: the OUTER call is sent by the runner
+// Safe (= our msg.sender on the inner Safe's execTransaction), so passing the
+// runner Safe address in `r` satisfies the inner Safe's signature check.
+//
+// Layout (65 bytes / one signature):
+//   r (32 bytes) = address, left-padded
+//   s (32 bytes) = 0
+//   v (1 byte)   = 0x01 — pre-validated marker
+function buildPreValidatedSignature(approver: Address): string {
+  return concat([zeroPadValue(approver, 32), zeroPadValue('0x', 32), '0x01']);
+}
+
+// Wrap an inner contract call in the calldata of a single
+// `ownerSafe.execTransaction(...)`. The OUTER wrapper (= the runner Safe's
+// own execTransaction) is built by the SDK runner; we just supply this as
+// `data` to `runner.sendTransaction(...)`.
+export function buildNestedSafeCalldata(params: {
+  innerTo: Address;
+  innerData: string;
+  innerValue?: bigint;
+  runnerSafeAddress: Address;
+}): string {
+  const signatures = buildPreValidatedSignature(params.runnerSafeAddress);
+  return safeExecIface.encodeFunctionData('execTransaction', [
+    params.innerTo,
+    params.innerValue ?? 0n,
+    params.innerData,
+    0, // operation = Call (1 would be DelegateCall — we never want that here)
+    0, // safeTxGas
+    0, // baseGas
+    0, // gasPrice
+    ZeroAddress,
+    ZeroAddress,
+    signatures,
+  ]);
+}

--- a/circles-app/src/lib/areas/wallet/ui/components/BalanceRow.svelte
+++ b/circles-app/src/lib/areas/wallet/ui/components/BalanceRow.svelte
@@ -4,7 +4,7 @@
     import Avatar from '$lib/shared/ui/avatar/Avatar.svelte';
     import { avatarState } from '$lib/shared/state/avatar.svelte';
     import { tokenTypeToString } from '$lib/areas/wallet/ui/pages/SelectAsset.svelte';
-    import { crcTypes, roundToDecimals, staticTypes } from '$lib/shared/utils/shared';
+    import { crcTypes, roundToDecimals } from '$lib/shared/utils/shared';
     import { formatCompactCurrency } from '$lib/shared/utils/money';
     import type { TokenBalance } from '@aboutcircles/sdk-types';
     import { createKeyboardListNavigator } from '$lib/shared/ui/lists/utils/keyboardListNavigator';
@@ -123,7 +123,7 @@
                 <div class="text-right tabular-nums">
                     <div class="font-medium">{formatCompactCurrency(item.circles ?? 0, 'CRC')}</div>
                     <p class="text-xs text-base-content/70">
-                        {#if staticTypes.has(item.tokenType ?? '')}
+                        {#if isWrappedStaticToken(item)}
                             {roundToDecimals(item.staticCircles ?? 0)} Static Circles
                         {/if}
                         {#if crcTypes.has(item.tokenType ?? '')}

--- a/circles-app/src/lib/areas/wallet/ui/components/BalanceRowActions.svelte
+++ b/circles-app/src/lib/areas/wallet/ui/components/BalanceRowActions.svelte
@@ -2,7 +2,8 @@
     import Avatar from '$lib/shared/ui/avatar/Avatar.svelte';
     import { avatarState } from '$lib/shared/state/avatar.svelte';
     import { tokenTypeToString } from '$lib/areas/wallet/ui/pages/SelectAsset.svelte';
-    import { crcTypes, roundToDecimals, staticTypes } from '$lib/shared/utils/shared';
+    import { crcTypes, roundToDecimals } from '$lib/shared/utils/shared';
+    import { isWrappedStaticToken } from '$lib/shared/pricing/wrappedStaticPricing';
     import { formatCompactCurrency } from '$lib/shared/utils/money';
     import WrapTokens from '$lib/areas/wallet/ui/pages/WrapTokens.svelte';
 
@@ -45,11 +46,16 @@
         },
 
         {
-            condition: (b) => (b.tokenType ?? '') === 'CrcV2_ERC20WrapperDeployed_Demurraged',
+            // Demurraged wrapper. Flag-based detection — group wrappers
+            // (gCRC) report a tokenType string the previous exact-match
+            // missed, but `isWrapped` + `isInflationary` flags are stable
+            // across personal AND group wrappers.
+            condition: (b) => b.isWrapped === true && b.isInflationary === false,
             title: 'Unwrap', icon: '/banknotes.svg', component: UnwrapTokens
         },
         {
-            condition: (b) => (b.tokenType ?? '') === 'CrcV2_ERC20WrapperDeployed_Inflationary',
+            // Inflationary / static wrapper. Same flag-based treatment.
+            condition: (b) => b.isWrapped === true && b.isInflationary === true,
             title: 'Unwrap Static Circles', icon: '/banknotes.svg', component: UnwrapTokens
         },
     ];
@@ -181,7 +187,7 @@
     <div class="text-right tabular-nums shrink-0">
         <div class="font-bold">{formatCompactCurrency(item.circles ?? 0, 'CRC')}</div>
         <p class="text-xs text-base-content/70">
-            {#if staticTypes.has(item.tokenType ?? '')}
+            {#if isWrappedStaticToken(item)}
                 {roundToDecimals(item.staticCircles ?? 0)} Static Circles
             {/if}
             {#if crcTypes.has(item.tokenType ?? '')}

--- a/circles-app/src/lib/areas/wallet/ui/pages/UnwrapTokens.svelte
+++ b/circles-app/src/lib/areas/wallet/ui/pages/UnwrapTokens.svelte
@@ -43,15 +43,18 @@
 
     const amountWei = BigInt(ethers.parseEther(amount.toString()));
 
-    // asset.tokenType is the same field the row-action button gates on
-    // (BalanceRowActions.svelte) — by the time we're here it must be a wrapper.
-    const isInflationary =
-      asset.tokenType === 'CrcV2_ERC20WrapperDeployed_Inflationary';
-    const isDemurraged =
-      asset.tokenType === 'CrcV2_ERC20WrapperDeployed_Demurraged';
+    // Flag-based detection beats the brittle tokenType string match: the
+    // indexer reports group-wrapper variants (gCRC) with tokenType strings
+    // that don't carry the `_Inflationary` / `_Demurraged` suffix, but the
+    // SDK always sets `isWrapped` + `isInflationary` consistently. Branching
+    // on flags makes this popup work for personal AND group wrappers.
+    const isInflationary = asset.isWrapped === true && asset.isInflationary === true;
+    const isDemurraged = asset.isWrapped === true && asset.isInflationary === false;
 
     if (!isInflationary && !isDemurraged) {
-      throw new Error(`Unsupported token type: ${asset.tokenType ?? 'unknown'}`);
+      throw new Error(
+        `Unsupported token type: ${asset.tokenType ?? 'unknown'} (isWrapped=${asset.isWrapped}, isInflationary=${asset.isInflationary})`
+      );
     }
 
     void executeTxSubmitFirst({

--- a/circles-app/src/lib/shared/pricing/wrappedStaticPricing.ts
+++ b/circles-app/src/lib/shared/pricing/wrappedStaticPricing.ts
@@ -9,8 +9,16 @@ export type WrappedStaticPriceResult = {
 
 export type WrappedStaticPriceMap = Record<string, WrappedStaticPriceResult>;
 
+// Flag-based detection so group wrappers (gCRC) are recognized too — the
+// indexer reports their tokenType under different strings (group-wrapper
+// variants don't always carry the `_Inflationary` suffix), but the SDK
+// always sets the boolean flags consistently.
 export function isWrappedStaticToken(balance: TokenBalance): boolean {
-  return balance.tokenType === WRAPPED_STATIC_TOKEN_TYPE && balance.isErc20 === true;
+  return (
+    balance.isWrapped === true &&
+    balance.isInflationary === true &&
+    balance.isErc20 === true
+  );
 }
 
 export function normalizeAddress(address: string): string {

--- a/circles-app/src/lib/shared/state/wallet.svelte.ts
+++ b/circles-app/src/lib/shared/state/wallet.svelte.ts
@@ -356,16 +356,13 @@ export async function restoreSession() {
       await goto('/register');
     }
   } catch (error) {
-    // Don't surface a red toast: the landing page + Connect Wallet button
-    // already communicates the un-authenticated state to the user. Log for
-    // debugging.
     console.error('[Wallet] Session restore failed:', error);
 
     // Only nuke the saved session on definitively terminal errors. For
     // transient network / RPC / WS failures, leave localStorage intact so
     // the next page-load can retry — clearSession() wipes the in-app PK
     // (Circles-native variant), and we don't want a 5-second RPC blip to
-    // brick a funded avatar.
+    // brick a funded avatar. clearSession() itself navigates to '/'.
     const transient = error instanceof Error && isTransientError(error);
     if (!transient) {
       clearSession();

--- a/circles-app/src/lib/shared/state/wallet.svelte.ts
+++ b/circles-app/src/lib/shared/state/wallet.svelte.ts
@@ -215,14 +215,37 @@ export async function initNewEoaBrowserRunner(eoaAddress: Address) {
   return runner;
 }
 
+// Mirrors shouldBypassWalletRestore in +layout.svelte; the two lists must
+// stay in sync. Uses raw pathname instead of SvelteKit's parameterized
+// route id so it can run anywhere (incl. outside a SvelteKit context).
+export function isPublicRoute(pathname: string): boolean {
+  return (
+    pathname === '/' ||
+    pathname === '/util' ||
+    pathname.startsWith('/connect-wallet') ||
+    pathname.startsWith('/register') ||
+    pathname.startsWith('/privacy-policy') ||
+    pathname.startsWith('/terms') ||
+    pathname.startsWith('/kitchen-sink')
+  );
+}
+
 export async function restoreSession() {
   const privateKey = CirclesStorage.getInstance().privateKey;
   const savedAvatar = CirclesStorage.getInstance().avatar;
 
   // Fresh visit / signed-out state — nothing to restore. Skip silently instead
   // of throwing, otherwise every first-time landing fires a red "Session Restore
-  // Failed" error toast.
+  // Failed" error toast. If the user is on an auth-gated route (deep-linked
+  // /dashboard, or wagmi lost the connector between sessions), redirect to /
+  // so the landing-page Connect Wallet button is the obvious next step.
+  // Without this redirect the dashboard renders "0 Circles" with no recovery
+  // UI — the mid-session disconnect path is covered by clearSession()'s own
+  // goto('/'), this branch covers the no-storage-on-load path.
   if (!privateKey && !savedAvatar) {
+    if (typeof window !== 'undefined' && !isPublicRoute(window.location.pathname)) {
+      await goto('/');
+    }
     return;
   }
 

--- a/circles-app/src/lib/shared/state/wallet.svelte.ts
+++ b/circles-app/src/lib/shared/state/wallet.svelte.ts
@@ -293,26 +293,41 @@ export async function restoreSession() {
       savedAvatar ??
       (newRunner?.address || sdk.contractRunner?.address)) as Address;
 
-    // Get avatar from SDK - returns HumanAvatar, OrganisationAvatar, or BaseGroupAvatar
-    // Enable auto event subscription for reactive updates
-    // Use retry logic for WebSocket subscription resilience
-    let avatar = await withRetry(
-      () => sdk.getAvatar(avatarToRestore, true),
-      {
-        maxAttempts: 5,
-        initialDelayMs: 1000,
-        maxDelayMs: 15000,
-        isRetryable: isTransientError,
-        updateConnectionStatus: true,
-        statusLabel: 'Wallet',
-        onRetry: (attempt, error, delayMs) => {
-          console.warn(
-            `[Wallet] Avatar subscription failed (attempt ${attempt}/5), retrying in ${Math.round(delayMs / 1000)}s:`,
-            error.message
-          );
-        },
-      }
-    );
+    // Restore the avatar with event subscription. If subscribe fails (the
+    // WS-bug captured in memory/sdk_websocket_bug.md occasionally never
+    // resolves), the user must NOT be bounced to /register — that's a UX
+    // regression where a transient WS hiccup looks like a logged-out state
+    // and forces re-login. Fall back to a non-subscribed avatar; the user
+    // keeps a working session in read/sign mode, just without live event
+    // pushes (a refresh later reconnects).
+    let avatar;
+    try {
+      avatar = await withRetry(
+        () => sdk.getAvatar(avatarToRestore, true),
+        {
+          maxAttempts: 5,
+          initialDelayMs: 1000,
+          maxDelayMs: 15000,
+          isRetryable: isTransientError,
+          updateConnectionStatus: true,
+          statusLabel: 'Wallet',
+          onRetry: (attempt, error, delayMs) => {
+            console.warn(
+              `[Wallet] Avatar subscription failed (attempt ${attempt}/5), retrying in ${Math.round(delayMs / 1000)}s:`,
+              error.message
+            );
+          },
+        }
+      );
+    } catch (subscribeError) {
+      console.warn(
+        '[Wallet] Avatar subscription retries exhausted, falling back to non-subscribed restore:',
+        subscribeError
+      );
+      // Non-subscribed restore — pure data read, no WS. If THIS fails, the
+      // outer catch handles it as the original code did.
+      avatar = await sdk.getAvatar(avatarToRestore, false);
+    }
 
     if (avatar) {
       avatarState.avatar = avatar;

--- a/circles-app/src/lib/shared/ui/primitives/Address.svelte
+++ b/circles-app/src/lib/shared/ui/primitives/Address.svelte
@@ -5,21 +5,82 @@
   let copyIcon = $state('/copy.svg');
   interface Props {
     address: Address;
+    // When true, render the full 0x… address (no shortening). Inline variant
+    // — no button chrome — so it composes inside flowing banner text.
+    full?: boolean;
+    // When true, render a small explorer-link icon next to the address.
+    explorer?: boolean;
   }
 
-  let { address }: Props = $props();
+  let { address, full = false, explorer = false }: Props = $props();
+  let copyFailed = $state(false);
 
-  function handleCopy() {
-    navigator.clipboard.writeText(address);
-    copyIcon = '/check.svg';
+  async function handleCopy() {
+    // Clipboard write can fail or be unavailable:
+    //  - navigator.clipboard undefined (older mobile, http:// dev mirrors)
+    //  - permission denied (iOS Safari without user gesture, some iframes)
+    //  - document not focused (Firefox in some embeds)
+    // Only flip to the success icon when the write actually resolved; on
+    // failure surface a small visual signal so the user doesn't silently
+    // paste nothing.
+    try {
+      if (!navigator?.clipboard?.writeText) {
+        throw new Error('Clipboard API unavailable in this browser context');
+      }
+      await navigator.clipboard.writeText(address);
+      copyIcon = '/check.svg';
+      copyFailed = false;
+    } catch (e) {
+      console.warn('[Address] Clipboard write failed:', e);
+      copyFailed = true;
+    }
 
     setTimeout(() => {
       copyIcon = '/copy.svg';
-    }, 1000);
+      copyFailed = false;
+    }, 1500);
   }
 </script>
 
-<button onclick={handleCopy} class="btn btn-sm">
-  {shortenAddress(address)}
-  <img src={copyIcon} alt="Copy" class="w-4 h-4 inline" />
-</button>
+{#if full}
+  <span class="inline-flex items-center gap-1 align-baseline">
+    <button
+      type="button"
+      onclick={handleCopy}
+      title={copyFailed ? 'Copy failed — select and copy manually' : 'Copy address'}
+      class="font-mono break-all underline decoration-dotted hover:opacity-70 cursor-pointer"
+    >
+      {address}
+    </button>
+    {#if copyFailed}
+      <span class="text-error text-xs shrink-0" title="Clipboard blocked by browser">!</span>
+    {:else}
+      <img src={copyIcon} alt="Copy" class="w-3 h-3 inline shrink-0" />
+    {/if}
+    {#if explorer}
+      <a
+        href="https://gnosisscan.io/address/{address}"
+        target="_blank"
+        rel="noopener noreferrer"
+        title="View on Gnosisscan"
+        class="opacity-60 hover:opacity-100 shrink-0"
+        aria-label="View on Gnosisscan"
+      >
+        ↗
+      </a>
+    {/if}
+  </span>
+{:else}
+  <button
+    onclick={handleCopy}
+    class="btn btn-sm"
+    title={copyFailed ? 'Copy failed — select and copy manually' : 'Copy address'}
+  >
+    {shortenAddress(address)}
+    {#if copyFailed}
+      <span class="text-error text-xs">!</span>
+    {:else}
+      <img src={copyIcon} alt="Copy" class="w-4 h-4 inline" />
+    {/if}
+  </button>
+{/if}

--- a/circles-app/src/lib/shared/utils/retry.ts
+++ b/circles-app/src/lib/shared/utils/retry.ts
@@ -162,6 +162,20 @@ export async function withRetry<T>(
 export function isTransientError(error: Error): boolean {
   const message = error.message.toLowerCase();
 
+  // Wallet-disconnect errors are NOT transient — they are a definitive state
+  // change that needs user action (reconnect). Treating them as transient
+  // makes restoreSession leave a broken session in localStorage and the user
+  // sits on an empty dashboard with no Connect Wallet path. Match the exact
+  // user-facing strings produced by getSigner() / restoreSession() before
+  // the generic patterns can claim them.
+  if (
+    message.includes('wallet not connected') ||
+    message.includes('please reconnect your wallet') ||
+    message.includes('please unlock metamask')
+  ) {
+    return false;
+  }
+
   const transientPatterns = [
     'connection',
     'timeout',
@@ -171,8 +185,6 @@ export function isTransientError(error: Error): boolean {
     'socket',
     'websocket',
     'subscribe',
-    'not connected',
-    'disconnected',
     'interrupted',
     'etimedout',
     'enotfound',

--- a/circles-app/src/lib/shared/utils/trustActions.ts
+++ b/circles-app/src/lib/shared/utils/trustActions.ts
@@ -214,11 +214,14 @@ async function sendGroupTrustTx(params: {
   // Preflight failed and we can't route. Surface a meaningful, address-bearing
   // error instead of letting the user hit the opaque execTransaction revert.
   if (isOwnerCheckFailure) {
+    // Full addresses, not shortened — error toasts surface to the user when
+    // they need to take action (switch Safe, copy an address, look it up on
+    // an explorer). Shortened addresses force a tedious back-and-forth.
     const ownerHint = params.caps.owner
-      ? ` Manage this group from the Safe that owns it (${shortenAddress(params.caps.owner)}).`
+      ? ` Manage this group from the Safe that owns it (${params.caps.owner}).`
       : '';
     throw new Error(
-      `You don't have permission to update trust on this group from ${shortenAddress(from)}.${ownerHint}`
+      `You don't have permission to update trust on this group from ${from}.${ownerHint}`
     );
   }
   throw new Error(`Group trust call would revert: ${preflight.reason}`);

--- a/circles-app/src/lib/shared/utils/trustActions.ts
+++ b/circles-app/src/lib/shared/utils/trustActions.ts
@@ -1,7 +1,6 @@
 import { get } from 'svelte/store';
-import { ethers } from 'ethers';
+import { ethers, JsonRpcProvider } from 'ethers';
 import type { Address } from '@aboutcircles/sdk-types';
-import type { BaseGroupAvatar } from '@aboutcircles/sdk';
 
 import { avatarState } from '$lib/shared/state/avatar.svelte';
 import { circles } from '$lib/shared/state/circles';
@@ -10,12 +9,24 @@ import { runTask } from '$lib/shared/utils/tasks';
 import { shortenAddress } from '$lib/shared/utils/shared';
 import { sendRunnerTransactionAndWait } from '$lib/shared/utils/tx';
 import {
+  assessManagePermission,
   probeGroupCapabilities,
+  type GroupCapabilities,
   type GroupTrustKind,
+  type ManagePermission,
 } from '$lib/areas/groups/utils/groupKind';
+import { buildNestedSafeCalldata } from '$lib/areas/groups/utils/groupOwnerProxy';
+import { getActiveConfig } from '$lib/shared/state/settings.svelte';
 
 // 96-bit max — what `BaseGroup.trust(...)` and friends interpret as "no expiry".
 const TRUST_EXPIRY_MAX = BigInt('0xFFFFFFFFFFFFFFFFFFFFFFFF');
+
+// Selector of `OnlyOwnerOrService()` custom error.
+// `cast 4byte 0xf1427430` → OnlyOwnerOrService(). This is what the v2
+// BaseGroup family reverts with when msg.sender is neither owner nor service.
+// We watch for this byte signature in preflight to know we should attempt
+// to nest the call through the group-owner Safe.
+const ONLY_OWNER_OR_SERVICE_SELECTOR = '0xf1427430';
 
 const trustBatchWithConditionsIface = new ethers.Interface([
   'function trustBatchWithConditions(address[] _members, uint96 _expiry) external',
@@ -53,13 +64,85 @@ function encodeGroupTrustCall(
   }
 }
 
-// Submit a group trust mutation directly through the wallet runner. The SDK's
-// BaseGroupAvatar.trust.* methods only model one of the three live group
-// shapes, so we build calldata ourselves once `probeGroupCapabilities` has
-// told us which selector the contract actually exposes.
+function getRpcProvider(): JsonRpcProvider | null {
+  const config = getActiveConfig();
+  const rpcUrl = config.chainRpcUrl ?? config.circlesRpcUrl;
+  return rpcUrl ? new JsonRpcProvider(rpcUrl) : null;
+}
+
+// Pull a revert selector / reason string out of the various error shapes
+// ethers / RPC providers may throw. Returns the lowercased 0x-prefixed
+// 4-byte selector if found, else null.
+function extractRevertSelector(error: unknown): string | null {
+  if (!error || typeof error !== 'object') return null;
+  const candidates: unknown[] = [
+    (error as any).data,
+    (error as any).info?.error?.data,
+    (error as any).error?.data,
+    (error as any).cause?.data,
+    (error as any).cause?.info?.error?.data,
+  ];
+  for (const c of candidates) {
+    if (typeof c === 'string' && /^0x[0-9a-fA-F]{8,}$/.test(c)) {
+      return c.slice(0, 10).toLowerCase();
+    }
+  }
+  return null;
+}
+
+// Best-effort decoded revert reason for surfacing to the user. Falls back to
+// raw selector or generic message.
+function describeRevert(error: unknown): string {
+  const sel = extractRevertSelector(error);
+  if (sel === ONLY_OWNER_OR_SERVICE_SELECTOR) {
+    return 'OnlyOwnerOrService — the group rejected the call from this account';
+  }
+  const msg = error instanceof Error ? error.message : String(error ?? '');
+  if (msg) return msg;
+  return sel ? `revert ${sel}` : 'execution reverted';
+}
+
+// Preflight: simulate the trust call from the current runner's address. We
+// don't *care* about a successful return value — we only need to know whether
+// the on-chain modifier would reject this msg.sender, and decide between
+// (direct submit) | (nested-Safe route) | (surface clear error).
+async function preflightTrustCall(
+  from: Address,
+  to: Address,
+  data: string
+): Promise<{ ok: true } | { ok: false; selector: string | null; reason: string }> {
+  const provider = getRpcProvider();
+  if (!provider) {
+    // No RPC available — skip preflight and let the real submit decide.
+    return { ok: true };
+  }
+  try {
+    await provider.call({ from, to, data });
+    return { ok: true };
+  } catch (error) {
+    return {
+      ok: false,
+      selector: extractRevertSelector(error),
+      reason: describeRevert(error),
+    };
+  }
+}
+
+function runnerAddress(): Address | null {
+  const r = get(wallet) as { address?: string } | null;
+  if (!r?.address) return null;
+  return r.address.toLowerCase() as Address;
+}
+
+// Single entry point for submitting a group-trust mutation. Builds the
+// calldata, preflights it from the connected runner, and either submits
+// direct, nests via the group-owner Safe, or surfaces a clear error.
+//
+// Both addTrustRelations (group branch) and removeGroupMembers funnel through
+// here so the same preflight + nesting logic covers add and remove.
 async function sendGroupTrustTx(params: {
   groupAddress: Address;
-  kind: GroupTrustKind;
+  caps: GroupCapabilities;
   members: Address[];
   expiry: bigint;
   taskName: string;
@@ -68,15 +151,77 @@ async function sendGroupTrustTx(params: {
   if (!runner?.sendTransaction) {
     throw new Error('Wallet not connected.');
   }
-  const data = encodeGroupTrustCall(params.kind, params.members, params.expiry);
-  await runTask({
-    name: params.taskName,
-    promise: sendRunnerTransactionAndWait(
-      runner,
-      { to: params.groupAddress, value: 0n, data },
-      { label: 'Group trust update' }
-    ),
-  });
+
+  const innerData = encodeGroupTrustCall(
+    params.caps.trustKind,
+    params.members,
+    params.expiry
+  );
+  const from = runnerAddress();
+  if (!from) {
+    throw new Error('Wallet runner has no address — reconnect and try again.');
+  }
+
+  const preflight = await preflightTrustCall(
+    from,
+    params.groupAddress,
+    innerData
+  );
+
+  if (preflight.ok) {
+    await runTask({
+      name: params.taskName,
+      promise: sendRunnerTransactionAndWait(
+        runner,
+        { to: params.groupAddress, value: 0n, data: innerData },
+        { label: 'Group trust update' }
+      ),
+    });
+    return;
+  }
+
+  // Preflight says the call won't succeed as msg.sender = currentRunner.
+  // If it's specifically the "only owner / service" rejection AND the runner
+  // is a co-signer of the group-owner Safe, nest the call through the owner
+  // Safe and retry from there.
+  const perm = assessManagePermission(params.caps, from);
+  const isOwnerCheckFailure =
+    preflight.selector === ONLY_OWNER_OR_SERVICE_SELECTOR;
+
+  if (
+    isOwnerCheckFailure &&
+    perm.canManage &&
+    perm.reason === 'nested-safe' &&
+    perm.ownerProxyChain.length === 1
+  ) {
+    const ownerSafe = perm.ownerProxyChain[0];
+    const nestedCalldata = buildNestedSafeCalldata({
+      innerTo: params.groupAddress,
+      innerData,
+      runnerSafeAddress: from,
+    });
+    await runTask({
+      name: params.taskName,
+      promise: sendRunnerTransactionAndWait(
+        runner,
+        { to: ownerSafe, value: 0n, data: nestedCalldata },
+        { label: 'Group trust update (routed via owner Safe)' }
+      ),
+    });
+    return;
+  }
+
+  // Preflight failed and we can't route. Surface a meaningful, address-bearing
+  // error instead of letting the user hit the opaque execTransaction revert.
+  if (isOwnerCheckFailure) {
+    const ownerHint = params.caps.owner
+      ? ` Manage this group from the Safe that owns it (${shortenAddress(params.caps.owner)}).`
+      : '';
+    throw new Error(
+      `You don't have permission to update trust on this group from ${shortenAddress(from)}.${ownerHint}`
+    );
+  }
+  throw new Error(`Group trust call would revert: ${preflight.reason}`);
 }
 
 // Public helper: submit a group untrust (expiry=0). Throws if the group's
@@ -94,7 +239,7 @@ export async function removeGroupMembers(
   }
   await sendGroupTrustTx({
     groupAddress,
-    kind: caps.trustKind,
+    caps,
     members,
     expiry: 0n,
     taskName: `Removing ${members.length} trusted avatar${members.length === 1 ? '' : 's'} from ${shortenAddress(groupAddress)} ...`,
@@ -129,44 +274,24 @@ export async function addTrustRelations(params: {
     }
 
     const caps = await probeGroupCapabilities(params.actorAddress);
-    const taskName = `${shortenAddress(params.actorAddress)} trusts ${trustTargets.length} avatar${trustTargets.length === 1 ? '' : 's'} ...`;
-
-    // SDK fast path: the `conditions` variant is the only one the SDK
-    // properly models. Keep using it so the SDK's own contract-runner
-    // observability stays in the loop for this shape. The other two we
-    // dispatch directly via the wallet runner because the SDK builds
-    // selectors that don't exist on those contracts.
-    if (caps.trustKind === 'conditions') {
-      const groupAvatar = await sdk.getAvatar(params.actorAddress, false);
-      await runTask({
-        name: taskName,
-        promise: (groupAvatar as BaseGroupAvatar).trust.addBatchWithConditions(
-          trustTargets,
-          TRUST_EXPIRY_MAX
-        ),
-      });
-      return;
+    if (caps.trustKind === 'unknown') {
+      // No recognizable trust selector at all — refuse fast instead of
+      // submitting calldata to a contract that won't dispatch it.
+      throw new Error(
+        'Unsupported group contract type at ' +
+          params.actorAddress +
+          '. Could not detect a known trustBatch* selector in its bytecode.'
+      );
     }
 
-    if (caps.trustKind === 'expiry' || caps.trustKind === 'simple') {
-      await sendGroupTrustTx({
-        groupAddress: params.actorAddress,
-        kind: caps.trustKind,
-        members: trustTargets,
-        expiry: TRUST_EXPIRY_MAX,
-        taskName,
-      });
-      return;
-    }
-
-    // `unknown` shape — surface a clear error instead of sending a
-    // selector that the contract doesn't have (which is what produced the
-    // silent "execTransaction reverted" empty-data revert before this fix).
-    throw new Error(
-      'Unsupported group contract type at ' +
-        params.actorAddress +
-        '. Could not detect a known trustBatch* selector in its bytecode.'
-    );
+    await sendGroupTrustTx({
+      groupAddress: params.actorAddress,
+      caps,
+      members: trustTargets,
+      expiry: TRUST_EXPIRY_MAX,
+      taskName: `${shortenAddress(params.actorAddress)} trusts ${trustTargets.length} avatar${trustTargets.length === 1 ? '' : 's'} ...`,
+    });
+    return;
   }
 
   // gateway
@@ -194,3 +319,8 @@ export async function addTrustRelations(params: {
     });
   }
 }
+
+// Re-export so UI components can derive permission state without importing
+// from groupKind directly (smaller import surface).
+export { assessManagePermission };
+export type { ManagePermission };

--- a/circles-app/src/routes/+layout.svelte
+++ b/circles-app/src/routes/+layout.svelte
@@ -127,6 +127,25 @@
   onMount(() => {
     disposePopupHistorySync = initPopupHistorySync();
 
+    // Legacy service-worker / cache cleanup. An old `static/service-worker.js`
+    // shipped in earlier builds; it's a no-op on prod (intercepts a chiado-rpc
+    // URL only) but if a user has it registered + has stale Cache API entries
+    // they can serve stale chunks across deploys. Unregister + drop caches so
+    // subsequent navigations always pull fresh `_app/immutable/*` from origin.
+    // Fire-and-forget; never block first paint.
+    if (browser && 'serviceWorker' in navigator) {
+      void navigator.serviceWorker
+        .getRegistrations()
+        .then((regs) => regs.forEach((r) => void r.unregister()))
+        .catch(() => {});
+    }
+    if (browser && 'caches' in window) {
+      void caches
+        .keys()
+        .then((keys) => Promise.all(keys.map((k) => caches.delete(k))))
+        .catch(() => {});
+    }
+
     // Global handler for uncaught promise rejections (e.g., SDK WebSocket errors)
     const handleUnhandledRejection = (event: PromiseRejectionEvent) => {
       const error = event.reason;

--- a/circles-app/src/routes/groups/members/[group]/+page.svelte
+++ b/circles-app/src/routes/groups/members/[group]/+page.svelte
@@ -9,6 +9,7 @@
   import type { Action } from '$lib/shared/ui/shell/actions';
   import { getProfileDisplayName } from '$lib/areas/groups/ui/utils/profileDisplayName';
   import GroupMembersManager from '$lib/areas/groups/ui/components/GroupMembersManager.svelte';
+  import AddressView from '$lib/shared/ui/primitives/Address.svelte';
 
   const group = $derived(($page.params.group ?? '').toLowerCase() as Address | '');
   const shortAddr = (a?: string) => (a ? `${a.slice(0, 6)}…${a.slice(-4)}` : '');
@@ -87,7 +88,9 @@
 
   {#snippet meta()}
     {#if group}
-      <span class="text-xs opacity-70">{shortAddr(group)}</span>
+      <span class="text-xs opacity-70">
+        <AddressView address={group} full explorer />
+      </span>
     {:else}
       <span class="text-xs opacity-70">Missing group address.</span>
     {/if}

--- a/circles-app/static/service-worker.js
+++ b/circles-app/static/service-worker.js
@@ -1,92 +1,38 @@
-const CACHE_NAME = 'profile-cache-v1';
-const MAX_CACHE_SIZE = 50; // Max number of items in the cache
+// Self-destruct service worker. Replaces an earlier profile-cache SW that
+// could pin stale Cache API entries across deploys for users who had it
+// registered. Activating this SW clears all caches and unregisters itself,
+// so the next page load uses the standard browser network stack only.
+//
+// Bumped name + simple body forces the browser update path to pick this up:
+// previous SW called skipWaiting/clients.claim, so as soon as the browser
+// fetches /service-worker.js (which it does on every navigation by spec),
+// it installs this one, runs the install/activate handlers, and the old SW
+// is gone.
 
-self.addEventListener('install', (event) => {
+const CACHE_NAME = 'circles-sw-killswitch-v1';
+
+self.addEventListener('install', () => {
+  // Take over immediately — don't wait for old tabs to close.
   self.skipWaiting();
 });
 
 self.addEventListener('activate', (event) => {
-  event.waitUntil(clients.claim());
+  event.waitUntil(
+    (async () => {
+      // 1. Drop every Cache API store this origin has accumulated.
+      const keys = await caches.keys();
+      await Promise.all(keys.map((k) => caches.delete(k)));
+
+      // 2. Claim open clients so the unregister below also affects this tab.
+      await self.clients.claim();
+
+      // 3. Unregister this SW. Subsequent navigations have no SW at all
+      //    until/unless the app re-registers (which it doesn't).
+      await self.registration.unregister();
+    })()
+  );
 });
 
-self.addEventListener('fetch', (event) => {
-  const url = new URL(event.request.url);
-  if (url.hostname === 'chiado-rpc.aboutcircles.com' && url.port === '3000') {
-    if (url.pathname === '/get') {
-      console.log('Handling single profile request for: ' + event.request.url);
-      event.respondWith(handleProfileRequest(event.request));
-    }
-  }
-});
-
-async function handleProfileRequest(request) {
-  const cache = await caches.open(CACHE_NAME);
-  const now = Date.now();
-
-  const cachedResponse = await cache.match(request);
-  if (cachedResponse) {
-    console.log('Found cached response for: ' + request.url);
-    const cachedData = await cachedResponse.json();
-    // Update usage timestamp
-    await updateCacheTimestamp(cache, request, cachedData.profile, now);
-    return new Response(JSON.stringify(cachedData.profile), {
-      headers: { 'Content-Type': 'application/json' },
-    });
-  }
-
-  console.log('No valid cached response found for: ' + request.url);
-  const networkResponse = await fetch(request);
-  if (networkResponse.ok) {
-    const profile = await networkResponse.clone().json();
-    // Add new data to cache
-    await addToCache(cache, request, profile, now);
-    return networkResponse;
-  }
-
-  return cachedResponse || networkResponse;
-}
-
-async function addToCache(cache, request, profile, timestamp) {
-  const cacheItems = await cache.keys();
-  if (cacheItems.length >= MAX_CACHE_SIZE) {
-    // Clean up least recently used cache items
-    await cleanupCache(cache, cacheItems);
-  }
-  const cacheData = { profile, timestamp };
-  await cache.put(
-    request,
-    new Response(JSON.stringify(cacheData), {
-      headers: { 'Content-Type': 'application/json' },
-    })
-  );
-}
-
-async function updateCacheTimestamp(cache, request, profile, timestamp) {
-  const cacheData = { profile, timestamp };
-  await cache.put(
-    request,
-    new Response(JSON.stringify(cacheData), {
-      headers: { 'Content-Type': 'application/json' },
-    })
-  );
-}
-
-async function cleanupCache(cache, cacheItems) {
-  let oldestRequest = null;
-  let oldestTimestamp = Date.now();
-
-  for (const request of cacheItems) {
-    const response = await cache.match(request);
-    if (response) {
-      const cachedData = await response.json();
-      if (cachedData.timestamp < oldestTimestamp) {
-        oldestTimestamp = cachedData.timestamp;
-        oldestRequest = request;
-      }
-    }
-  }
-
-  if (oldestRequest) {
-    await cache.delete(oldestRequest);
-  }
-}
+// No fetch handler on purpose — anything served from this SW would just be
+// pass-through to the network; while activate is running we don't want to
+// short-circuit any request paths.

--- a/circles-app/tests/isPublicRoute.test.ts
+++ b/circles-app/tests/isPublicRoute.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { isPublicRoute } from '$lib/shared/state/wallet.svelte';
+
+describe('isPublicRoute', () => {
+  describe('public routes (no wallet required)', () => {
+    const publicPaths = [
+      '/',
+      '/util',
+      '/connect-wallet',
+      '/connect-wallet/connect-safe',
+      '/connect-wallet/import-circles-garden',
+      '/register',
+      '/register/some/nested/step',
+      '/privacy-policy',
+      '/terms',
+      '/kitchen-sink',
+      '/kitchen-sink/identity',
+    ];
+
+    for (const path of publicPaths) {
+      it(`treats ${JSON.stringify(path)} as public`, () => {
+        expect(isPublicRoute(path)).toBe(true);
+      });
+    }
+  });
+
+  describe('auth-gated routes (wallet required)', () => {
+    const authGatedPaths = [
+      '/dashboard',
+      '/groups',
+      '/groups/members/0xabc',
+      '/groups/metrics/0xdef',
+      '/contacts',
+      '/contacts/0xabc',
+      '/market',
+      '/admin',
+      '/avatar-search',
+      '/back-circles',
+      '/jump',
+      '/sales',
+      '/settings',
+    ];
+
+    for (const path of authGatedPaths) {
+      it(`treats ${JSON.stringify(path)} as auth-gated`, () => {
+        expect(isPublicRoute(path)).toBe(false);
+      });
+    }
+  });
+
+  describe('edge cases', () => {
+    it('rejects paths that contain but do not start with a public prefix', () => {
+      // `/dashboard/register` is NOT the register flow; it's a dashboard child.
+      // The startsWith check is intentional and only triggers on prefix match.
+      expect(isPublicRoute('/dashboard/register')).toBe(false);
+      expect(isPublicRoute('/groups/terms')).toBe(false);
+    });
+
+    it('treats empty string as auth-gated (defensive default)', () => {
+      expect(isPublicRoute('')).toBe(false);
+    });
+  });
+});

--- a/circles-app/tests/isTransientError.test.ts
+++ b/circles-app/tests/isTransientError.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { isTransientError } from '$lib/shared/utils/retry';
+
+describe('isTransientError', () => {
+  describe('wallet-disconnect errors are NOT transient', () => {
+    const walletDisconnectMessages = [
+      'Wallet not connected. Please reconnect your wallet.',
+      'Wallet not connected. Please unlock MetaMask and connect to this site.',
+      'Please reconnect your wallet',
+      'PLEASE UNLOCK METAMASK',
+    ];
+
+    for (const message of walletDisconnectMessages) {
+      it(`treats ${JSON.stringify(message)} as definitive`, () => {
+        expect(isTransientError(new Error(message))).toBe(false);
+      });
+    }
+  });
+
+  describe('real transient errors are still transient', () => {
+    const transientMessages = [
+      'WebSocket connection failed',
+      'Request timeout after 5000ms',
+      'Network unreachable',
+      'ECONNRESET',
+      'fetch failed: socket hang up',
+      '502 Bad Gateway',
+      'Rate limit exceeded',
+      'Subscribe to events failed',
+    ];
+
+    for (const message of transientMessages) {
+      it(`treats ${JSON.stringify(message)} as transient`, () => {
+        expect(isTransientError(new Error(message))).toBe(true);
+      });
+    }
+  });
+
+  it('unknown errors are not transient', () => {
+    expect(isTransientError(new Error('Unexpected runtime error'))).toBe(false);
+    expect(isTransientError(new Error('Insufficient balance'))).toBe(false);
+  });
+});

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,5 @@
 [build]
+  base = "circles-app"
   command = "cd .. && npm install && npm run build:packages && cd circles-app && npm run build"
   publish = "build"
 


### PR DESCRIPTION
## Summary

Brings four bug-fix PRs from `dev` to `main` for the next prod deploy. All four were merged to `dev` between 2026-05-22 and 2026-06-05 and have been live on staging.

| PR | Title | Surface |
|----|------|------|
| #208 | groups,wallet: route group-trust via owner Safe; widen unwrap branching; SW kill-switch | Nested-Safe group trust routing via owner-Safe execTransaction with pre-validated signature; gCRC group-wrapper Unwrap button surfaces via flag-based detection; non-subscribed `getAvatar()` fallback when WS subscribe retries exhaust; self-destruct service worker to drop stale Cache API entries across deploys. |
| #209 | wallet: treat wallet-disconnect as definitive; redirect off-route to landing | `isTransientError` carve-out for wallet-disconnect strings; `restoreSession` catch handler routes non-transient failures through `clearSession()` → landing page. Closes the silent-zombie-session UX bug where the dashboard rendered with empty state and no Connect Wallet button. |
| #210 | groups: show full + interactive addresses in GroupMembersManager | `Address.svelte` gains `full` + `explorer` props; banners on `/groups/members/<group>` now show full owner-Safe address with one-click copy + gnosisscan link instead of truncated `0x12…ab`. |
| #211 | wallet: redirect from auth-gated routes on empty session state | `restoreSession` early-return now redirects to `/` when on an auth-gated route. Covers the no-storage-on-load path that PR #209's catch-handler fix doesn't reach (e.g., wagmi lost the connector between sessions, browser cleared site data). |

Sync via single release-branch PR (avoids "too many files" review fan-out).

## Verification

- Code-side: all four PRs merged with green CI on `dev`; `npm run check` clean, `npm run test:run` 19 files / 142 cases pass at `5e8b6886`.
- Live on staging (`app.circlesubi.network`): items 3, 10, 13, 14, 15, 17–19, owner-mode UI on owned group, and code-path of #209 wallet-disconnect verified during recent sessions.
- Pending live verification on prod after deploy.

## Test plan (post-merge)

- [ ] Confirm DigitalOcean auto-deploy completes on `app.aboutcircles.com`.
- [ ] Re-run on prod: hard-refresh `/dashboard` while connected → session restores (no `/register` bounce).
- [ ] Re-run on prod: deep-link `/dashboard` from a private window → lands on `/` with Connect Wallet visible (#211).
- [ ] Re-run on prod: open a known unowned group `/groups/members/<addr>` → view-only banner with full owner-Safe address (#208 + #210).
- [ ] Re-run on prod: returning user visits the app → legacy service worker unregisters, Cache API stores empty (#208 SW kill-switch).