### PR TITLE
fix(trust): surface preflight errors to user in addTrust confirm flow

### DIFF
--- a/circles-app/src/lib/areas/trust/flows/addTrust/2_ConfirmTrust.svelte
+++ b/circles-app/src/lib/areas/trust/flows/addTrust/2_ConfirmTrust.svelte
@@ -8,6 +8,7 @@
   import { popToOrOpen } from '$lib/shared/flow';
   import { popupControls } from '$lib/shared/state/popup';
   import { addTrustRelations } from '$lib/shared/utils/trustActions';
+  import { handleError } from '$lib/shared/utils/errorHandler';
   import { ADD_TRUST_FLOW_SCAFFOLD_BASE } from './constants';
   import PickAccounts from './1_PickAccounts.svelte';
   import type { AddTrustFlowContext } from './context';
@@ -21,17 +22,29 @@
 
   const selected = $derived(Array.isArray(context.selectedTrustees) ? context.selectedTrustees : []);
   const canConfirm = $derived(selected.length > 0);
+  let submitting = $state(false);
 
   async function confirm() {
-    if (!canConfirm) return;
-    await addTrustRelations({
-      actorType: context.actorType,
-      actorAddress: context.actorAddress,
-      trustTargets: selected,
-      gatewayExpiry: context.gatewayExpiry,
-    });
-    await onCompleted?.(selected);
-    popupControls.close();
+    if (!canConfirm || submitting) return;
+    submitting = true;
+    try {
+      await addTrustRelations({
+        actorType: context.actorType,
+        actorAddress: context.actorAddress,
+        trustTargets: selected,
+        gatewayExpiry: context.gatewayExpiry,
+      });
+      await onCompleted?.(selected);
+      popupControls.close();
+    } catch (error) {
+      // Preflight in trustActions throws a decoded reason (OnlyOwnerOrService,
+      // OnlyHuman, "Group trust call would revert: ..."). Without this catch
+      // the error was swallowed and the dialog froze on the Confirm button
+      // with no user-facing signal. handleError surfaces a toast.
+      handleError(error, { context: 'transaction', title: 'Could not add trust' });
+    } finally {
+      submitting = false;
+    }
   }
 
   function changeSelection() {
@@ -72,7 +85,7 @@
       {#snippet primary()}
         <ActionButton
           action={confirm}
-          disabled={!canConfirm}
+          disabled={!canConfirm || submitting}
           title="Confirm trust"
           data-popup-default-action
           data-popup-initial-focus


### PR DESCRIPTION
## Summary

PR #208's preflight in `trustActions.sendGroupTrustTx` does an `eth_call` from the runner address before submitting the real tx. When it reverts, the preflight throws `Group trust call would revert: <decoded reason>` (or `OnlyOwnerOrService`-routed nesting + ownerHint).

The Memberships flow (`1_manageGroupMembers.svelte:103-141`) wraps the call in try/catch + handleErrors and shows a toast. The addTrust flow (`2_ConfirmTrust.svelte:25-35`) did **not** wrap the call — the error bubbled up unhandled, the dialog stayed on the Confirm button, the user got no signal that the tx was refused.

Repro: trust a non-Human (org / group) on a simple ScoreGroup. The contract exposes `OnlyHuman()`; preflight catches it but the user just sees the dialog freeze.

## Changes

- `2_ConfirmTrust.svelte`: wrap `addTrustRelations` in try/catch + `handleError(..., { context: 'transaction', title: 'Could not add trust' })` — same toast pathway the Memberships flow already uses.
- Add `submitting` flag bound to the Confirm button's `disabled` so the button can't be double-clicked during the await window.

## Test plan

- [x] `npm run check` — 0 errors (21 pre-existing warnings unrelated).
- [ ] On staging: trust a registered human on a conditions-shape group → tx submits, dialog closes (regression check).
- [ ] On staging: trust an org / group on a simple ScoreGroup → preflight catches → user sees toast.
- [ ] On staging: trust on a group you do not own → preflight catches → user sees address-bearing hint toast.
