### PR TITLE
fix: chart reactivity and seedphrase stale state

### DIFF
--- a/circles-app/src/lib/areas/groups/ui/components/ModernHistoryChart.svelte
+++ b/circles-app/src/lib/areas/groups/ui/components/ModernHistoryChart.svelte
@@ -16,7 +16,7 @@
   let resolution: 'hour' | 'day' = $state('hour');
 
   let canvas: HTMLCanvasElement;
-  let chart: Chart<'line' | 'bar', { x: number; y: number }[]>;
+  let chart = $state<Chart<'line' | 'bar', { x: number; y: number }[]> | undefined>(undefined);
   $effect(() => {
     if (chart) updateChart();
   });
@@ -41,6 +41,7 @@
   const tooltipBorder = T.hairline;
 
   function updateChart() {
+    if (!chart) return;
     const src = resolution === 'hour' ? dataSet1 : dataSet2;
 
     const keys = src.length
@@ -92,7 +93,7 @@
   }
 
   onMount(() => {
-    chart = new Chart(canvas, {
+    chart = new Chart<'line' | 'bar', { x: number; y: number }[]>(canvas, {
       type: type,
       data: { datasets: [] },
       options: {
@@ -184,9 +185,8 @@
         type="checkbox"
         style="width:32px;height:18px;accent-color:{T.primary};"
         checked={resolution === 'hour'}
-        onclick={({ currentTarget }) => {
+        onchange={({ currentTarget }) => {
           resolution = currentTarget.checked ? 'hour' : 'day';
-          updateChart();
         }}
       />
     </div>

--- a/circles-app/src/lib/areas/groups/ui/components/ModernPieChart.svelte
+++ b/circles-app/src/lib/areas/groups/ui/components/ModernPieChart.svelte
@@ -18,7 +18,7 @@
   }: Props = $props();
 
   let canvas: HTMLCanvasElement;
-  let chart: Chart<'doughnut', number[], string>;
+  let chart = $state<Chart<'doughnut', number[], string> | undefined>(undefined);
   let chartData: any;
 
   const palette = [
@@ -67,7 +67,7 @@
   });
 
   onMount(() => {
-    chart = new Chart(canvas, {
+    chart = new Chart<'doughnut', number[], string>(canvas, {
       type: 'doughnut',
       data: chartData,
       options: {

--- a/circles-app/src/lib/areas/wallet/ui/onboarding/components/SeedphraseInput.svelte
+++ b/circles-app/src/lib/areas/wallet/ui/onboarding/components/SeedphraseInput.svelte
@@ -42,6 +42,8 @@
       privateKey = privateKeyWallet.privateKey;
     } else {
       privateKey = '';
+      address = '';
+      mnemonicPhrase = '';
     }
   }
 </script>

--- a/circles-app/src/lib/shared/ui/forms/SeedphraseInput.svelte
+++ b/circles-app/src/lib/shared/ui/forms/SeedphraseInput.svelte
@@ -41,6 +41,8 @@
       privateKey = privateKeyWallet.privateKey;
     } else {
       privateKey = '';
+      address = '';
+      mnemonicPhrase = '';
     }
   }
 </script>


### PR DESCRIPTION
## Summary

Three pre-existing bugs surfaced during the design-system review.

**ModernHistoryChart / ModernPieChart**: Chart instances were declared as plain `let` variables, so `$effect(() => { if (chart) updateChart(); })` would short-circuit on first run (before mount) without reading any reactive dependencies. After mount, `chart` being assigned didn't trigger the effect because it wasn't reactive. Result: chart data never updated when `dataSet1`/`dataSet2`/`resolution` props changed after mount.

Fix: declare `chart` as `$state(undefined)` so the `onMount` assignment triggers the effect, allowing the reactive dependencies to be captured in that run. Also switches chart checkbox from `onclick` to `onchange` (correct event for checkboxes) and removes the now-redundant manual `updateChart()` call.

**SeedphraseInput** (both `shared/ui/forms/` and `areas/wallet/ui/onboarding/components/`): When the 24-word phrase transitioned from valid back to invalid, only `privateKey` was cleared. `address` and `mnemonicPhrase` retained stale values, which any bound parent component would act on as if still valid.

Fix: clear all three bound outputs when mnemonic is invalid.

## Test plan

- [ ] `npm run check` passes (0 errors)
- [ ] Group metrics charts update when toggling hour/day resolution
- [ ] Entering a valid seed phrase populates address; clearing words clears address