### PR TITLE
fix(groups): surface trust permission error to user in GroupMembersManager

### DIFF
--- a/circles-app/src/lib/areas/contacts/flows/manageGroupMembers/1_manageGroupMembers.svelte
+++ b/circles-app/src/lib/areas/contacts/flows/manageGroupMembers/1_manageGroupMembers.svelte
@@ -15,6 +15,7 @@
     addTrustRelations,
     removeGroupMembers,
   } from '$lib/shared/utils/trustActions';
+  import { handleError } from '$lib/shared/utils/errorHandler';
 
   let context: AddContactFlowContext = $state({
     selectedAddress: '',
@@ -54,30 +55,6 @@
     }
   }
 
-  function handleErrors(error: any) {
-    const userRejected =
-      error?.info?.error?.code === 4001 ||
-      error?.message?.includes('user rejected') ||
-      error?.message?.includes('User denied transaction');
-
-    if (userRejected) {
-      errorMessage = 'Transaction was rejected';
-      throw new Error('Transaction was rejected');
-    }
-
-    if (error?.message?.includes('No valid addresses provided')) {
-      errorMessage = 'No valid addresses provided';
-      throw error;
-    }
-
-    if (error?.message?.includes('Contract not initialized')) {
-      errorMessage = 'Contract not initialized';
-      throw error;
-    }
-
-    errorMessage = 'Tx failed, try passing less addresses';
-    throw new Error('Tx failed, try passing less addresses');
-  }
 
   const sanitizeAddresses = (addrStr: string): Address[] => {
     const addresses = addrStr
@@ -92,13 +69,6 @@
     if (addresses.length === 0) {
       throw new Error('No valid addresses provided');
     }
-
-    console.log('handleAddMembers called with:', {
-      addresses,
-      untrust,
-      isGroup: avatarState.isGroup,
-      avatarType: avatarState.avatar?.constructor.name,
-    });
 
     try {
       const actor = avatarState.avatar;
@@ -136,8 +106,9 @@
         refreshContactStore(avatarState.avatar);
       }
     } catch (error: any) {
-      console.error('Error in handleAddMembers:', error);
-      handleErrors(error);
+      const msg = error instanceof Error ? error.message : String(error ?? 'Unknown error');
+      errorMessage = msg;
+      handleError(error, { context: 'transaction', title: 'Could not update group member' });
     }
   }
 


### PR DESCRIPTION
## Summary

- Adds proper error surfacing when an EOA attempts to manage a group owned by a different Safe
- Replaces local `handleErrors()` with shared `handleError()` utility (same pattern as `2_ConfirmTrust.svelte` which was fixed for the same issue in #213)
- Removes stale debug `console.log` from `handleAddMembers`

## What was happening

User connected with their EOA tried to add a member to a group. The preflight check correctly detected they don't have permission (the group is owned by a Safe). The error thrown contained the owner Safe address as a hint. But `handleErrors()` didn't recognize it and showed "Tx failed, try passing less addresses" — unhelpful and misleading.

The error message was only visible in DevTools console.

## After this fix

The full message is shown both as an inline error and as a toast notification:
> You don't have permission to update trust on this group from 0x…. Manage this group from the Safe that owns it (0x…).

## Test plan

- [ ] `npm run check` — 0 errors
- [ ] Connect as an EOA, navigate to a group owned by a Safe you don't control, try to add a member → toast + inline error shows the permission message with the owner Safe address
- [ ] Connect as the correct Safe owner → add member succeeds normally
- [ ] User-rejected transactions still show "Transaction was rejected" (handled by `handleError`'s `isSilentError` check on "User denied")