### PR TITLE
fix(ux): surface silent transaction errors as user-facing toasts

### DIFF
--- a/circles-app/src/lib/areas/groups/flows/createGroup/4_Create.svelte
+++ b/circles-app/src/lib/areas/groups/flows/createGroup/4_Create.svelte
@@ -17,6 +17,7 @@
     import type { Address } from '@aboutcircles/sdk-types';
     import AdvancedDetails from '$lib/shared/ui/flow/AdvancedDetails.svelte';
     import Avatar from '$lib/shared/ui/avatar/Avatar.svelte';
+    import { handleError } from '$lib/shared/utils/errorHandler';
 
     const PROFILE_NAME_MAX_LENGTH = 36;
 
@@ -58,7 +59,6 @@
                 // Kept inside runTask so failures open the global dismissable error popup.
                 await assertWalletCanSignForSafe(String($wallet.address));
 
-                console.log($wallet.address, ctx);
                 const ownerAddress: `0x${string}` = $wallet.address as `0x${string}`;
 
                 // sdk.register.asGroup handles profile CID creation, on-chain registration,
@@ -79,7 +79,7 @@
                 try {
                     setGroup?.(groupAddress);
                 } catch (e) {
-                    console.error('setGroup callback failed', e);
+                    handleError(e, { context: 'transaction', title: 'Group created but navigation failed' });
                 }
 
                 // Reset context so a new flow starts clean next time

--- a/circles-app/src/lib/areas/market/ui/ProductDetailsPopup.svelte
+++ b/circles-app/src/lib/areas/market/ui/ProductDetailsPopup.svelte
@@ -11,6 +11,7 @@
   import { fetchAvailabilityFeed, fetchInventoryFeed, type QuantitativeValue } from '$lib/areas/market/services';
   import { createLoadable } from '$lib/areas/market/utils/loadable';
   import {gnosisConfig} from "$lib/shared/config/circles";
+  import { handleError } from '$lib/shared/utils/errorHandler';
 
   interface Props {
     seller: string; // EVM address
@@ -87,7 +88,7 @@
     try {
       await addToCart(product, currentAvatar);
     } catch (e) {
-      console.error('[cart] addToCart failed:', e);
+      handleError(e, { context: 'transaction', title: 'Could not add to cart' });
     }
   }
 </script>

--- a/circles-app/src/lib/areas/market/ui/product/ProductCard.svelte
+++ b/circles-app/src/lib/areas/market/ui/product/ProductCard.svelte
@@ -40,6 +40,7 @@ import { ProductDetailsPopup } from '$lib/areas/market/ui';
   const isOwner = $derived(isProductOwnedBy(product, currentAvatar));
 
   import { getAddToCartState } from '$lib/areas/market/cart/addToCartUi';
+  import { handleError } from '$lib/shared/utils/errorHandler';
   const effectiveAvailabilityIri = $derived<string | null>(
     product?.availability ?? product?.product?.availability ?? null
   );
@@ -98,7 +99,7 @@ import { ProductDetailsPopup } from '$lib/areas/market/ui';
     try {
       await addToCart(product, currentAvatar);
     } catch (e) {
-      console.error('[cart] addToCart failed:', e);
+      handleError(e, { context: 'transaction', title: 'Could not add to cart' });
     }
   }
 

--- a/circles-app/src/lib/areas/settings/ui/editors/GroupSetting.svelte
+++ b/circles-app/src/lib/areas/settings/ui/editors/GroupSetting.svelte
@@ -5,6 +5,7 @@
   import { BaseGroupAvatar } from '@aboutcircles/sdk';
   import Lucide from '$lib/shared/ui/icons/Lucide.svelte';
   import { Check as LCheck } from 'lucide';
+  import { handleError } from '$lib/shared/utils/errorHandler';
 
   let serviceAddress: Address = $state('0x0' as Address);
   let mintHandlerAddress: Address = $state('0x0' as Address);
@@ -50,7 +51,7 @@
       if (!isBaseGroupAvatar(avatarState.avatar)) return;
       await avatarState.avatar.setProperties.service(serviceAddress);
     } catch (error) {
-      console.error('Failed to set service address:', error);
+      handleError(error, { context: 'transaction', title: 'Failed to update service address' });
     }
   }
 
@@ -64,10 +65,10 @@
       if (setProps.mintHandler) {
         await setProps.mintHandler(mintHandlerAddress);
       } else {
-        console.warn('setMintHandler not available in current SDK');
+        handleError(new Error('setMintHandler not available in current SDK version'), { context: 'transaction', title: 'Not supported' });
       }
     } catch (error) {
-      console.error('Failed to set mint handler address:', error);
+      handleError(error, { context: 'transaction', title: 'Failed to update mint handler' });
     }
   }
 
@@ -81,10 +82,10 @@
       if (setProps.redemptionHandler) {
         await setProps.redemptionHandler(redemptionHandlerAddress);
       } else {
-        console.warn('setRedemptionHandler not available in current SDK');
+        handleError(new Error('setRedemptionHandler not available in current SDK version'), { context: 'transaction', title: 'Not supported' });
       }
     } catch (error) {
-      console.error('Failed to set redemption handler address:', error);
+      handleError(error, { context: 'transaction', title: 'Failed to update redemption handler' });
     }
   }
 </script>

--- a/circles-app/src/lib/areas/wallet/ui/onboarding/ConnectCircles.svelte
+++ b/circles-app/src/lib/areas/wallet/ui/onboarding/ConnectCircles.svelte
@@ -14,6 +14,7 @@
     import {resetCreateGroupContext} from '$lib/areas/groups/flows/createGroup/context';
     import { T } from '$lib/design-system/tokens.js';
     import Icon from '$lib/design-system/Icon.svelte';
+    import { handleError } from '$lib/shared/utils/errorHandler';
 
     function toGroupType(avatarType: string | undefined): GroupType | undefined {
         if (!avatarType || !avatarType.includes('Group')) return undefined;
@@ -68,7 +69,7 @@
 
             goto("/dashboard")
         } catch (e) {
-            console.error('[ConnectCircles] Failed to connect:', e);
+            handleError(e, { context: 'wallet', title: 'Connection failed' });
             connecting = false;
             onConnecting?.(false);
         }

--- a/circles-app/src/routes/market/[seller]/[sku]/+page.svelte
+++ b/circles-app/src/routes/market/[seller]/[sku]/+page.svelte
@@ -14,6 +14,7 @@
   import { getAddToCartState } from '$lib/areas/market/cart/addToCartUi';
   import {gnosisConfig} from "$lib/shared/config/circles";
   import { T } from '$lib/design-system/tokens.js';
+  import { handleError } from '$lib/shared/utils/errorHandler';
 
   // Derive seller and SKU from SvelteKit's $page store
     const params = $derived($page.params as { seller: string; sku: string });
@@ -56,7 +57,7 @@
         try {
             await addToCart(product, currentAvatar);
         } catch (e) {
-            console.error('[cart] addToCart failed:', e);
+            handleError(e, { context: 'transaction', title: 'Could not add to cart' });
         }
     }
 


### PR DESCRIPTION
## Summary

Six user-action catch blocks that previously only called `console.error` now call `handleError()` to show a toast notification alongside the console log.

## Changes

| File | Action | Was |
|---|---|---|
| `GroupSetting.svelte` | set service / mint / redemption handler | `console.error` only |
| `ConnectCircles.svelte` | `connectAvatar` failure | `console.error` only |
| `ProductCard.svelte` | add to cart | `console.error` only |
| `ProductDetailsPopup.svelte` | add to cart | `console.error` only |
| `market/[seller]/[sku]/+page.svelte` | add to cart | `console.error` only |
| `createGroup/4_Create.svelte` | `setGroup` callback after creation | `console.error` only |

Also removes a stale `console.log($wallet.address, ctx)` debug line from `4_Create.svelte`.

`SelectWallet.svelte` was audited but already renders errors inline — no change needed there.

## Test plan

- [ ] `npm run check` — 0 errors
- [ ] Connect wallet → simulate failure → toast appears with "Connection failed"
- [ ] Group settings → bad address → toast appears with "Failed to update …"
- [ ] Market add-to-cart error → toast appears with "Could not add to cart"