### PR TITLE
fix(ux): surface silent transaction errors as user-facing toasts

### DIFF
--- a/circles-app/src/lib/areas/groups/flows/createGroup/4_Create.svelte
+++ b/circles-app/src/lib/areas/groups/flows/createGroup/4_Create.svelte
@@ -17,6 +17,7 @@
     import type { Address } from '@aboutcircles/sdk-types';
     import AdvancedDetails from '$lib/shared/ui/flow/AdvancedDetails.svelte';
     import Avatar from '$lib/shared/ui/avatar/Avatar.svelte';
+    import { handleError } from '$lib/shared/utils/errorHandler';
 
     const PROFILE_NAME_MAX_LENGTH = 36;
 
@@ -58,7 +59,6 @@
                 // Kept inside runTask so failures open the global dismissable error popup.
                 await assertWalletCanSignForSafe(String($wallet.address));
 
-                console.log($wallet.address, ctx);
                 const ownerAddress: `0x${string}` = $wallet.address as `0x${string}`;
 
                 // sdk.register.asGroup handles profile CID creation, on-chain registration,
@@ -79,7 +79,7 @@
                 try {
                     setGroup?.(groupAddress);
                 } catch (e) {
-                    console.error('setGroup callback failed', e);
+                    handleError(e, { context: 'transaction', title: 'Group created but navigation failed' });
                 }
 
                 // Reset context so a new flow starts clean next time

--- a/circles-app/src/lib/areas/market/ui/ProductDetailsPopup.svelte
+++ b/circles-app/src/lib/areas/market/ui/ProductDetailsPopup.svelte
@@ -11,6 +11,7 @@
   import { fetchAvailabilityFeed, fetchInventoryFeed, type QuantitativeValue } from '$lib/areas/market/services';
   import { createLoadable } from '$lib/areas/market/utils/loadable';
   import {gnosisConfig} from "$lib/shared/config/circles";
+  import { handleError } from '$lib/shared/utils/errorHandler';
 
   interface Props {
     seller: string; // EVM address
@@ -87,7 +88,7 @@
     try {
       await addToCart(product, currentAvatar);
     } catch (e) {
-      console.error('[cart] addToCart failed:', e);
+      handleError(e, { context: 'transaction', title: 'Could not add to cart' });
     }
   }
 </script>

--- a/circles-app/src/lib/areas/market/ui/product/ProductCard.svelte
+++ b/circles-app/src/lib/areas/market/ui/product/ProductCard.svelte
@@ -40,6 +40,7 @@ import { ProductDetailsPopup } from '$lib/areas/market/ui';
   const isOwner = $derived(isProductOwnedBy(product, currentAvatar));
 
   import { getAddToCartState } from '$lib/areas/market/cart/addToCartUi';
+  import { handleError } from '$lib/shared/utils/errorHandler';
   const effectiveAvailabilityIri = $derived<string | null>(
     product?.availability ?? product?.product?.availability ?? null
   );
@@ -98,7 +99,7 @@ import { ProductDetailsPopup } from '$lib/areas/market/ui';
     try {
       await addToCart(product, currentAvatar);
     } catch (e) {
-      console.error('[cart] addToCart failed:', e);
+      handleError(e, { context: 'transaction', title: 'Could not add to cart' });
     }
   }
 

--- a/circles-app/src/lib/areas/settings/ui/editors/GroupSetting.svelte
+++ b/circles-app/src/lib/areas/settings/ui/editors/GroupSetting.svelte
@@ -5,6 +5,7 @@
   import { BaseGroupAvatar } from '@aboutcircles/sdk';
   import Lucide from '$lib/shared/ui/icons/Lucide.svelte';
   import { Check as LCheck } from 'lucide';
+  import { handleError } from '$lib/shared/utils/errorHandler';
 
   let serviceAddress: Address = $state('0x0' as Address);
   let mintHandlerAddress: Address = $state('0x0' as Address);
@@ -50,7 +51,7 @@
       if (!isBaseGroupAvatar(avatarState.avatar)) return;
       await avatarState.avatar.setProperties.service(serviceAddress);
     } catch (error) {
-      console.error('Failed to set service address:', error);
+      handleError(error, { context: 'transaction', title: 'Failed to update service address' });
     }
   }
 
@@ -64,10 +65,10 @@
       if (setProps.mintHandler) {
         await setProps.mintHandler(mintHandlerAddress);
       } else {
-        console.warn('setMintHandler not available in current SDK');
+        handleError(new Error('setMintHandler not available in current SDK version'), { context: 'transaction', title: 'Not supported' });
       }
     } catch (error) {
-      console.error('Failed to set mint handler address:', error);
+      handleError(error, { context: 'transaction', title: 'Failed to update mint handler' });
     }
   }
 
@@ -81,10 +82,10 @@
       if (setProps.redemptionHandler) {
         await setProps.redemptionHandler(redemptionHandlerAddress);
       } else {
-        console.warn('setRedemptionHandler not available in current SDK');
+        handleError(new Error('setRedemptionHandler not available in current SDK version'), { context: 'transaction', title: 'Not supported' });
       }
     } catch (error) {
-      console.error('Failed to set redemption handler address:', error);
+      handleError(error, { context: 'transaction', title: 'Failed to update redemption handler' });
     }
   }
 </script>

--- a/circles-app/src/lib/areas/wallet/ui/onboarding/ConnectCircles.svelte
+++ b/circles-app/src/lib/areas/wallet/ui/onboarding/ConnectCircles.svelte
@@ -12,6 +12,7 @@
     import { openStep } from '$lib/shared/flow';
     import CreateGroup from "$lib/areas/groups/flows/createGroup/1_CreateGroup.svelte";
     import {resetCreateGroupContext} from '$lib/areas/groups/flows/createGroup/context';
+    import { handleError } from '$lib/shared/utils/errorHandler';
 
     /**
      * Map an AvatarInfo.type string to the GroupType enum.
@@ -74,7 +75,7 @@
 
             goto("/dashboard")
         } catch (e) {
-            console.error('[ConnectCircles] Failed to connect:', e);
+            handleError(e, { context: 'wallet', title: 'Connection failed' });
             connecting = false;
             onConnecting?.(false);
         }

--- a/circles-app/src/routes/market/[seller]/[sku]/+page.svelte
+++ b/circles-app/src/routes/market/[seller]/[sku]/+page.svelte
@@ -13,6 +13,7 @@
   import { createLoadable } from '$lib/areas/market/utils/loadable';
   import { getAddToCartState } from '$lib/areas/market/cart/addToCartUi';
   import {gnosisConfig} from "$lib/shared/config/circles";
+  import { handleError } from '$lib/shared/utils/errorHandler';
 
   // Derive seller and SKU from SvelteKit's $page store
     const params = $derived($page.params as { seller: string; sku: string });
@@ -55,7 +56,7 @@
         try {
             await addToCart(product, currentAvatar);
         } catch (e) {
-            console.error('[cart] addToCart failed:', e);
+            handleError(e, { context: 'transaction', title: 'Could not add to cart' });
         }
     }
 


### PR DESCRIPTION
## Summary

Cherry-pick of #222 onto `main`. Resolves two minor import conflicts (pre-design-system file versions on main lack the `T`/`Icon` imports; kept main's versions, added only `handleError`).

Six user-action catch blocks now call `handleError()` instead of `console.error` only:

- `GroupSetting.svelte` — set service / mint / redemption handler transactions
- `ConnectCircles.svelte` — `connectAvatar` failure
- `ProductCard.svelte`, `ProductDetailsPopup.svelte`, `market/[seller]/[sku]` — add-to-cart
- `createGroup/4_Create.svelte` — `setGroup` callback after successful creation

## Test plan

- [ ] `npm run check` — 0 errors
- [ ] Failing transaction → toast appears with clear message