### PR TITLE
fix(trust): show inline error in Confirm Trust when preflight fails

### DIFF
--- a/circles-app/src/lib/areas/trust/flows/addTrust/2_ConfirmTrust.svelte
+++ b/circles-app/src/lib/areas/trust/flows/addTrust/2_ConfirmTrust.svelte
@@ -23,10 +23,12 @@
   const selected = $derived(Array.isArray(context.selectedTrustees) ? context.selectedTrustees : []);
   const canConfirm = $derived(selected.length > 0);
   let submitting = $state(false);
+  let errorMessage = $state('');
 
   async function confirm() {
     if (!canConfirm || submitting) return;
     submitting = true;
+    errorMessage = '';
     try {
       await addTrustRelations({
         actorType: context.actorType,
@@ -37,10 +39,8 @@
       await onCompleted?.(selected);
       popupControls.close();
     } catch (error) {
-      // Preflight in trustActions throws a decoded reason (OnlyOwnerOrService,
-      // OnlyHuman, "Group trust call would revert: ..."). Without this catch
-      // the error was swallowed and the dialog froze on the Confirm button
-      // with no user-facing signal. handleError surfaces a toast.
+      const msg = error instanceof Error ? error.message : String(error ?? 'Unknown error');
+      errorMessage = msg;
       handleError(error, { context: 'transaction', title: 'Could not add trust' });
     } finally {
       submitting = false;
@@ -74,6 +74,12 @@
         </div>
       {/if}
     </StepSection>
+
+    {#if errorMessage}
+      <div class="rounded-lg px-3 py-2 text-sm bg-error/10 text-error border border-error/20">
+        {errorMessage}
+      </div>
+    {/if}
 
     <StepActionBar>
       {#snippet secondary()}


### PR DESCRIPTION
## Summary

When a user tries to add trust but is connected as the wrong Safe, the permission error was only shown as a toast in the bottom-right corner — easy to miss. The form stayed open silently, users assumed nothing happened.

Now the error is also shown inline directly above the action bar.

**Before:** toast only → user misses it → thinks nothing happened → closes form confused  
**After:** toast + red inline message in the form → impossible to miss

## Test plan

- [ ] `npm run check` — 0 errors
- [ ] Connect as wrong Safe, try to add group trust → red error message appears inline in Confirm Trust step
- [ ] Successful trust → no error message, form closes normally