### PR TITLE
fix(dashboard): show — instead of NaN for transactions with missing amount

### DIFF
--- a/circles-app/src/routes/dashboard/TransactionRow.svelte
+++ b/circles-app/src/routes/dashboard/TransactionRow.svelte
@@ -39,6 +39,7 @@
     });
 
     function formatNetCircles(amount: number): string {
+        if (!Number.isFinite(amount)) return '—';
         const abs = Math.abs(amount);
         return abs < 0.01 ? '< 0.01' : abs.toFixed(2);
     }


### PR DESCRIPTION
Guard against NaN/Infinity in transaction amount formatting. One transaction in the history had a null/undefined circles value, causing the row to display '+NaN CRC'.