### PR TITLE
fix: port trust/dashboard bug fixes from dev to main

### DIFF
--- a/circles-app/src/lib/areas/contacts/flows/manageGroupMembers/1_manageGroupMembers.svelte
+++ b/circles-app/src/lib/areas/contacts/flows/manageGroupMembers/1_manageGroupMembers.svelte
@@ -15,6 +15,7 @@
     addTrustRelations,
     removeGroupMembers,
   } from '$lib/shared/utils/trustActions';
+  import { handleError } from '$lib/shared/utils/errorHandler';
 
   let context: AddContactFlowContext = $state({
     selectedAddress: '',
@@ -54,30 +55,6 @@
     }
   }
 
-  function handleErrors(error: any) {
-    const userRejected =
-      error?.info?.error?.code === 4001 ||
-      error?.message?.includes('user rejected') ||
-      error?.message?.includes('User denied transaction');
-
-    if (userRejected) {
-      errorMessage = 'Transaction was rejected';
-      throw new Error('Transaction was rejected');
-    }
-
-    if (error?.message?.includes('No valid addresses provided')) {
-      errorMessage = 'No valid addresses provided';
-      throw error;
-    }
-
-    if (error?.message?.includes('Contract not initialized')) {
-      errorMessage = 'Contract not initialized';
-      throw error;
-    }
-
-    errorMessage = 'Tx failed, try passing less addresses';
-    throw new Error('Tx failed, try passing less addresses');
-  }
 
   const sanitizeAddresses = (addrStr: string): Address[] => {
     const addresses = addrStr
@@ -92,13 +69,6 @@
     if (addresses.length === 0) {
       throw new Error('No valid addresses provided');
     }
-
-    console.log('handleAddMembers called with:', {
-      addresses,
-      untrust,
-      isGroup: avatarState.isGroup,
-      avatarType: avatarState.avatar?.constructor.name,
-    });
 
     try {
       const actor = avatarState.avatar;
@@ -136,8 +106,9 @@
         refreshContactStore(avatarState.avatar);
       }
     } catch (error: any) {
-      console.error('Error in handleAddMembers:', error);
-      handleErrors(error);
+      const msg = error instanceof Error ? error.message : String(error ?? 'Unknown error');
+      errorMessage = msg;
+      handleError(error, { context: 'transaction', title: 'Could not update group member' });
     }
   }
 

--- a/circles-app/src/lib/areas/trust/flows/addTrust/2_ConfirmTrust.svelte
+++ b/circles-app/src/lib/areas/trust/flows/addTrust/2_ConfirmTrust.svelte
@@ -23,10 +23,12 @@
   const selected = $derived(Array.isArray(context.selectedTrustees) ? context.selectedTrustees : []);
   const canConfirm = $derived(selected.length > 0);
   let submitting = $state(false);
+  let errorMessage = $state('');
 
   async function confirm() {
     if (!canConfirm || submitting) return;
     submitting = true;
+    errorMessage = '';
     try {
       await addTrustRelations({
         actorType: context.actorType,
@@ -37,10 +39,8 @@
       await onCompleted?.(selected);
       popupControls.close();
     } catch (error) {
-      // Preflight in trustActions throws a decoded reason (OnlyOwnerOrService,
-      // OnlyHuman, "Group trust call would revert: ..."). Without this catch
-      // the error was swallowed and the dialog froze on the Confirm button
-      // with no user-facing signal. handleError surfaces a toast.
+      const msg = error instanceof Error ? error.message : String(error ?? 'Unknown error');
+      errorMessage = msg;
       handleError(error, { context: 'transaction', title: 'Could not add trust' });
     } finally {
       submitting = false;
@@ -74,6 +74,12 @@
         </div>
       {/if}
     </StepSection>
+
+    {#if errorMessage}
+      <div class="rounded-lg px-3 py-2 text-sm bg-error/10 text-error border border-error/20">
+        {errorMessage}
+      </div>
+    {/if}
 
     <StepActionBar>
       {#snippet secondary()}

--- a/circles-app/src/routes/dashboard/TransactionRow.svelte
+++ b/circles-app/src/routes/dashboard/TransactionRow.svelte
@@ -39,6 +39,7 @@
     });
 
     function formatNetCircles(amount: number): string {
+        if (!Number.isFinite(amount)) return '—';
         const abs = Math.abs(amount);
         return abs < 0.01 ? '< 0.01' : abs.toFixed(2);
     }


### PR DESCRIPTION
Cherry-picks of #221, #224, #225 onto main. #222 was already on main via #223.

- **#221** GroupMembersManager: show toast when EOA tries to manage a group owned by a different Safe
- **#224** Confirm Trust: show error inline in the form (not just as a dismissible toast)
- **#225** Dashboard: show `—` instead of `+NaN CRC` for transactions with a missing amount