### PR TITLE
fix(review): address deferred L-tier findings from shorn-merge

### DIFF
--- a/circles-app/src/lib/areas/groups/model/groupProfileExtras.ts
+++ b/circles-app/src/lib/areas/groups/model/groupProfileExtras.ts
@@ -23,8 +23,8 @@ export interface NormalisedGroupExtras {
   linkLabel?: string;
   linkUrl?: string;
   groupType?: string;
-  membershipFee?: number;
-  minRepScore?: number;
+  membershipFee?: string | number;
+  minRepScore?: string | number;
   additionalCriteria?: string[];
   contactEmail?: string;
   contactWebsite?: string;
@@ -108,8 +108,8 @@ export function readGroupProfileFields(p: any): NormalisedGroupExtras {
     linkLabel: legacy?.label,
     linkUrl: legacy?.url,
     groupType: pick<string>(p?.groupType),
-    membershipFee: pick<number>(p?.membershipFee, p?.membershipCriteria?.membershipFee),
-    minRepScore: pick<number>(p?.minRepScore, p?.membershipCriteria?.minRepScore),
+    membershipFee: pick<string | number>(p?.membershipFee, p?.membershipCriteria?.membershipFee),
+    minRepScore: pick<string | number>(p?.minRepScore, p?.membershipCriteria?.minRepScore),
     additionalCriteria: Array.isArray(criteria) && criteria.length ? criteria.map(String) : undefined,
     contactEmail: pick<string>(p?.contactEmail, p?.contactInfo?.email),
     contactWebsite: pick<string>(p?.contactWebsite, p?.contactInfo?.website),

--- a/circles-app/src/lib/areas/groups/ui/GroupProfileExtras.svelte
+++ b/circles-app/src/lib/areas/groups/ui/GroupProfileExtras.svelte
@@ -134,7 +134,13 @@
           const cid = await rebaseAndSaveProfile(bindings, resolvedAvatar!, (p: any) => {
             applyGroupProfileExtras(p, form);
           });
-          await bindings.updateAvatarProfileDigest(resolvedAvatar!, cid);
+          try {
+            await bindings.updateAvatarProfileDigest(resolvedAvatar!, cid);
+          } catch (e: any) {
+            throw new Error(
+              `Profile uploaded to IPFS but on-chain update failed — retry to publish. (${e?.message ?? e})`
+            );
+          }
           removeProfileFromCache(resolvedAvatar!);
         })(),
       });
@@ -188,9 +194,12 @@
 
   {#if loadError}
     <div role="alert" style="font-size:12px;color:{T.negative};background:{T.negativeSoft};border:1px solid rgba(196,68,48,0.18);border-radius:10px;padding:10px 14px;">{loadError}</div>
-  {/if}
-
-  {#if loading}
+    <button
+      type="button"
+      style="align-self:flex-start;height:30px;padding:0 14px;border-radius:9999px;border:1px solid {T.hairline};background:transparent;color:{T.inkMuted};cursor:pointer;font-family:{T.fontSans};font-size:12px;"
+      onclick={() => void loadProfile()}
+    >Retry</button>
+  {:else if loading}
     <div style="font-size:12.5px;color:{T.inkMuted};">Loading…</div>
   {:else}
     {#if showReadOnly}

--- a/circles-app/src/lib/shared/state/eventStores/eventStoreFactory.svelte.ts
+++ b/circles-app/src/lib/shared/state/eventStores/eventStoreFactory.svelte.ts
@@ -67,20 +67,22 @@ export function createEventStore<T>(
     ? (a: U, b: U) => number
     : undefined,
   debounceDelay = 50
-): Readable<{ data: T; next: () => Promise<boolean>; ended: boolean; initialLoaded: boolean }> {
+): Readable<{ data: T; next: () => Promise<boolean>; ended: boolean; initialLoaded: boolean; initialLoadError: boolean }> {
   let timeout: any;
   let lastEvent: CirclesEvent | null = null;
   let finished = false;
   let initialLoaded = false;
+  let initialLoadError = false;
   let storeData = initialData;
   let unsubscribeFromEvents: (() => void) | undefined;
 
-  return readable<{ data: T; next: () => Promise<boolean>; ended: boolean; initialLoaded: boolean }>(
+  return readable<{ data: T; next: () => Promise<boolean>; ended: boolean; initialLoaded: boolean; initialLoadError: boolean }>(
     {
       data: storeData,
       next: async () => false,
       ended: finished,
       initialLoaded,
+      initialLoadError,
     },
     (set) => {
       let resolveInitialLoad: (() => void) | undefined;
@@ -96,7 +98,7 @@ export function createEventStore<T>(
           storeData = storeData.sort(dataComparator);
         }
 
-        set({ data: storeData, next: next, ended: finished, initialLoaded });
+        set({ data: storeData, next: next, ended: finished, initialLoaded, initialLoadError });
       }
 
       /**
@@ -165,6 +167,7 @@ export function createEventStore<T>(
         .catch((e) => {
           console.error('[EventStore] Failed to initialize store', e);
           initialLoaded = true;
+          initialLoadError = true;
           finished = true;
           setData(storeData);
           resolveInitialLoad?.();

--- a/circles-app/src/lib/shared/state/query/circlesQueryStore.ts
+++ b/circles-app/src/lib/shared/state/query/circlesQueryStore.ts
@@ -47,6 +47,7 @@ export async function createCirclesQueryStore<T extends EventRow>(
     next: () => Promise<boolean>;
     ended: boolean;
     initialLoaded: boolean;
+    initialLoadError: boolean;
   }>
 > {
   let circlesQuery = await circlesQueryFactory();


### PR DESCRIPTION
## Summary

- `groupProfileExtras.ts`: widen `NormalisedGroupExtras.membershipFee/minRepScore` to `string | number` — matches actual JSON API shape; `pick<>` calls updated accordingly
- `eventStoreFactory.svelte.ts`: add `initialLoadError: boolean` to store shape; catch block sets it so consumers can distinguish load failure from empty-success
- `circlesQueryStore.ts`: mirror `initialLoadError` in declared return type
- `GroupProfileExtras.svelte`: gate form behind `{:else if loading}` — edit UI no longer renders when `loadError` is set; adds Retry button
- `GroupProfileExtras.svelte`: wrap `updateAvatarProfileDigest` in try/catch to emit a differentiated error when IPFS pin succeeded but the on-chain tx failed

## Test plan
- [ ] typecheck passes (`npm run check` → 0 errors)
- [ ] Settings → group avatar → Group profile section: loadError path shows error banner + Retry, not the form
- [ ] Retry clears error and loads form
- [ ] Save with chain-tx rejection shows "uploaded to IPFS but on-chain update failed" message