### PR TITLE
feat(wallet): show transfer-data annotations on transactions

### DIFF
--- a/circles-app/src/lib/__tests__/transferAnnotations.test.ts
+++ b/circles-app/src/lib/__tests__/transferAnnotations.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { get } from 'svelte/store';
+import type { Avatar } from '@aboutcircles/sdk';
+import { encodeCrcV2TransferData } from '@aboutcircles/sdk-utils';
+import { circles } from '$lib/shared/state/circles';
+import {
+  loadTransferAnnotations,
+  resetTransferAnnotations,
+  annotationsByTx,
+} from '$lib/shared/state/transferAnnotations';
+
+const AVATAR = { address: '0xaAaA000000000000000000000000000000000001' } as unknown as Avatar;
+const TX = '0x' + 'a'.repeat(64);
+const TO = '0xbBbB000000000000000000000000000000000002';
+
+/**
+ * Replace the global `circles` SDK store with a stub whose `rpc.client.call`
+ * returns the given transfer-data rows, and record the calls made.
+ */
+function mockSdkReturning(rows: Array<Record<string, unknown>>, hasMore = false) {
+  const calls: Array<{ method: string; params: unknown }> = [];
+  circles.set({
+    rpc: {
+      client: {
+        call: async (method: string, params: unknown) => {
+          calls.push({ method, params });
+          return { results: rows, hasMore, nextCursor: null };
+        },
+      },
+    },
+  } as never);
+  return calls;
+}
+
+describe('transferAnnotations', () => {
+  beforeEach(() => {
+    resetTransferAnnotations();
+  });
+
+  it('calls circles_getTransferData with the lowercased avatar address and limit', async () => {
+    const calls = mockSdkReturning([]);
+    await loadTransferAnnotations(AVATAR, true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe('circles_getTransferData');
+    const params = calls[0].params as unknown[];
+    expect(params[0]).toBe(AVATAR.address.toLowerCase());
+    expect(params[5]).toBe(1000); // FETCH_LIMIT in the limit slot
+  });
+
+  it('decodes a UTF-8 text annotation (0x0001) and keys it by transaction hash', async () => {
+    const data = encodeCrcV2TransferData(['hello note'], 0x0001);
+    mockSdkReturning([{ transactionHash: TX, from: AVATAR.address, to: TO, data }]);
+    await loadTransferAnnotations(AVATAR, true);
+    const list = get(annotationsByTx).get(TX.toLowerCase());
+    expect(list).toHaveLength(1);
+    expect(list?.[0].text).toBe('hello note');
+  });
+
+  it('does NOT surface machine-reference types (XMTP id 0x0002) as a note', async () => {
+    const xmtp = encodeCrcV2TransferData(['0x' + 'ab'.repeat(32)], 0x0002);
+    mockSdkReturning([{ transactionHash: TX, from: AVATAR.address, to: TO, data: xmtp }]);
+    await loadTransferAnnotations(AVATAR, true);
+    expect(get(annotationsByTx).get(TX.toLowerCase())?.[0].text).toBeNull();
+  });
+
+  it('returns null text for an undecodable blob without throwing', async () => {
+    mockSdkReturning([{ transactionHash: TX, from: AVATAR.address, to: TO, data: '0x00' }]);
+    await loadTransferAnnotations(AVATAR, true);
+    expect(get(annotationsByTx).get(TX.toLowerCase())?.[0].text).toBeNull();
+  });
+
+  it('groups multiple annotations under the same transaction hash, in order', async () => {
+    const d1 = encodeCrcV2TransferData(['first'], 0x0001);
+    const d2 = encodeCrcV2TransferData(['second'], 0x0001);
+    mockSdkReturning([
+      { transactionHash: TX, from: AVATAR.address, to: TO, data: d1 },
+      { transactionHash: TX, from: TO, to: AVATAR.address, data: d2 },
+    ]);
+    await loadTransferAnnotations(AVATAR, true);
+    expect(get(annotationsByTx).get(TX.toLowerCase())?.map((a) => a.text)).toEqual([
+      'first',
+      'second',
+    ]);
+  });
+
+  it('no-ops when the SDK is unavailable', async () => {
+    circles.set(undefined);
+    await loadTransferAnnotations(AVATAR, true);
+    expect(get(annotationsByTx).size).toBe(0);
+  });
+
+  it('swallows RPC errors and leaves the annotation map empty (history must not break)', async () => {
+    circles.set({
+      rpc: { client: { call: async () => { throw new Error('rpc down'); } } },
+    } as never);
+    await loadTransferAnnotations(AVATAR, true);
+    expect(get(annotationsByTx).size).toBe(0);
+  });
+
+  it('resetTransferAnnotations clears the store', async () => {
+    const data = encodeCrcV2TransferData(['x'], 0x0001);
+    mockSdkReturning([{ transactionHash: TX, from: AVATAR.address, to: TO, data }]);
+    await loadTransferAnnotations(AVATAR, true);
+    expect(get(annotationsByTx).size).toBe(1);
+    resetTransferAnnotations();
+    expect(get(annotationsByTx).size).toBe(0);
+  });
+});

--- a/circles-app/src/lib/shared/state/transactionHistory.ts
+++ b/circles-app/src/lib/shared/state/transactionHistory.ts
@@ -848,6 +848,10 @@ export async function refreshTransactionHistory(): Promise<void> {
     isLoading: true,
   });
 
+  // Reload annotations too — refresh runs after sends and WebSocket updates, so a
+  // newly-annotated transaction must pick up its note (force past the per-avatar guard).
+  void loadTransferAnnotations(currentAvatar, true);
+
   // Refetch from page 1
   await loadNextPage();
 }

--- a/circles-app/src/lib/shared/state/transactionHistory.ts
+++ b/circles-app/src/lib/shared/state/transactionHistory.ts
@@ -8,6 +8,7 @@ import { circles } from '$lib/shared/state/circles';
 import { getProfile } from '$lib/shared/utils/profile';
 import { circlesBalances } from '$lib/shared/state/circlesBalances';
 import { writeTransactions, makeScopeId } from '$lib/shared/cache';
+import { loadTransferAnnotations, resetTransferAnnotations } from '$lib/shared/state/transferAnnotations';
 
 const PAGE_SIZE = 100; // Fetch 100 events - they get grouped by tx hash
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
@@ -688,6 +689,7 @@ export const initTransactionHistoryStore = async (avatar: Avatar) => {
 
   // Clear memoization cache for fresh grouping
   resetGroupedCache();
+  resetTransferAnnotations();
 
   // Validate avatar is properly initialized
   if (!avatar || typeof avatar !== 'object') {
@@ -728,6 +730,10 @@ export const initTransactionHistoryStore = async (avatar: Avatar) => {
 
   // Build ERC20 wrapper cache from user's balance data (no RPC needed)
   refreshErc20WrapperCache();
+
+  // Load transfer-data annotations for this avatar (one RPC call, fire-and-forget —
+  // supplementary to history, must not block or break the listing).
+  void loadTransferAnnotations(avatar);
 
   // Load initial page
   await loadNextPage();

--- a/circles-app/src/lib/shared/state/transferAnnotations.ts
+++ b/circles-app/src/lib/shared/state/transferAnnotations.ts
@@ -51,6 +51,9 @@ const FETCH_LIMIT = 1000;
 export const annotationsByTx = writable<Map<string, TransferAnnotation[]>>(new Map());
 
 let loadedFor: string | null = null;
+// Address of the most recent load request; used to drop a stale response if the
+// active avatar changed while an earlier fetch was still in flight.
+let latestRequest: string | null = null;
 
 /**
  * Reduce a decoded payload to a single display string, or null when there is nothing
@@ -72,7 +75,15 @@ function payloadToText(payload: unknown): string | null {
 function decodeText(data: string): string | null {
   try {
     const decoded = decodeCrcV2TransferData(data);
-    return payloadToText(decoded.payload);
+    // Only treat genuinely human-readable envelope types as a displayable note:
+    //   0x0001 = UTF-8 text, 0x1001 = text + metadata (the message part).
+    // Other types (0x0002 XMTP message id, 0x0003 IPFS CID, 0x0004 ABI calldata) also
+    // decode to a string/object, but they are machine references — not notes — so they
+    // must not render verbatim in the Note card.
+    if (decoded.type === 0x0001 || decoded.type === 0x1001) {
+      return payloadToText(decoded.payload);
+    }
+    return null;
   } catch {
     // Legacy / non-envelope blobs (e.g. raw bytes or an unrecognized version) — not an error,
     // just nothing to display.
@@ -92,11 +103,17 @@ export async function loadTransferAnnotations(avatar: Avatar, force = false): Pr
   const sdk = get(circles);
   if (!sdk?.rpc) return;
 
+  latestRequest = address;
+
   try {
     const response = await sdk.rpc.client.call<unknown[], TransferDataResponse>(
       'circles_getTransferData',
       [address, null, null, null, null, FETCH_LIMIT, null]
     );
+
+    // A newer load (e.g. an avatar switch) superseded this one while awaiting —
+    // drop the stale result rather than overwriting the current avatar's annotations.
+    if (latestRequest !== address) return;
 
     const byTx = new Map<string, TransferAnnotation[]>();
     for (const row of response.results) {
@@ -130,13 +147,9 @@ export async function loadTransferAnnotations(avatar: Avatar, force = false): Pr
   }
 }
 
-/** Annotations for a transaction hash (empty array if none). */
-export function getAnnotationsForTx(transactionHash: string): TransferAnnotation[] {
-  return get(annotationsByTx).get(transactionHash.toLowerCase()) ?? [];
-}
-
 /** Reset cached state (e.g. on avatar switch) so the next load refetches. */
 export function resetTransferAnnotations(): void {
   loadedFor = null;
+  latestRequest = null;
   annotationsByTx.set(new Map());
 }

--- a/circles-app/src/lib/shared/state/transferAnnotations.ts
+++ b/circles-app/src/lib/shared/state/transferAnnotations.ts
@@ -1,0 +1,142 @@
+import { get, writable } from 'svelte/store';
+import { decodeCrcV2TransferData } from '@aboutcircles/sdk-utils';
+import type { Avatar } from '@aboutcircles/sdk';
+import type { Address } from '@aboutcircles/sdk-types';
+import { circles } from '$lib/shared/state/circles';
+
+/**
+ * Transfer annotations ("transfer data").
+ *
+ * A note/message/CID can be attached to a Circles transfer. For pCRC (ERC-1155) it rides in the
+ * transfer's `data`; for gCRC (ERC-20) it rides a separate 0-value ERC-1155 transfer batched into
+ * the same tx. The indexer extracts both into `CrcV2_TransferData`, exposed by the JSON-RPC method
+ * `circles_getTransferData`. We read it via the generic `rpc.client.call` (no SDK wrapper needed —
+ * mirrors how `circles_query` is already called elsewhere) and decode with `decodeCrcV2TransferData`.
+ *
+ * Annotations are keyed only by `(transactionHash, from, to)` — there is no explicit link to a
+ * specific value-transfer leg — so we group them by transaction hash for lookup against the
+ * grouped transaction-history rows.
+ */
+
+/** One annotation row as returned by `circles_getTransferData`, plus its decoded payload. */
+export interface TransferAnnotation {
+  transactionHash: string;
+  from: Address;
+  to: Address;
+  /** 0x-prefixed hex blob. */
+  data: string;
+  /** Human-readable text if the blob is a recognized annotation envelope; null if undecodable. */
+  text: string | null;
+}
+
+interface RawTransferDataRow {
+  transactionHash: string;
+  from: Address;
+  to: Address;
+  data: string;
+}
+
+interface TransferDataResponse {
+  results: RawTransferDataRow[];
+  hasMore: boolean;
+  nextCursor: string | null;
+}
+
+// Annotations are sparse (most transfers carry none), so a single generous page covers
+// virtually every avatar. If an avatar ever exceeds this, we log and stop rather than
+// silently truncating.
+const FETCH_LIMIT = 1000;
+
+/** transactionHash (lowercase) → annotations attached to that transaction. */
+export const annotationsByTx = writable<Map<string, TransferAnnotation[]>>(new Map());
+
+let loadedFor: string | null = null;
+
+/**
+ * Reduce a decoded payload to a single display string, or null when there is nothing
+ * human-readable to show (e.g. an ABI/calldata payload or an undecodable legacy blob).
+ */
+function payloadToText(payload: unknown): string | null {
+  if (typeof payload === 'string') {
+    return payload.length > 0 ? payload : null;
+  }
+  if (payload && typeof payload === 'object') {
+    const message = (payload as { message?: unknown }).message;
+    if (typeof message === 'string' && message.length > 0) {
+      return message;
+    }
+  }
+  return null;
+}
+
+function decodeText(data: string): string | null {
+  try {
+    const decoded = decodeCrcV2TransferData(data);
+    return payloadToText(decoded.payload);
+  } catch {
+    // Legacy / non-envelope blobs (e.g. raw bytes or an unrecognized version) — not an error,
+    // just nothing to display.
+    return null;
+  }
+}
+
+/**
+ * Fetch and decode all transfer-data annotations for an avatar, populating {@link annotationsByTx}.
+ * One RPC call per history load; safe to call repeatedly (no-ops for the same avatar unless forced).
+ */
+export async function loadTransferAnnotations(avatar: Avatar, force = false): Promise<void> {
+  const address = avatar?.address?.toLowerCase();
+  if (!address) return;
+  if (!force && loadedFor === address) return;
+
+  const sdk = get(circles);
+  if (!sdk?.rpc) return;
+
+  try {
+    const response = await sdk.rpc.client.call<unknown[], TransferDataResponse>(
+      'circles_getTransferData',
+      [address, null, null, null, null, FETCH_LIMIT, null]
+    );
+
+    const byTx = new Map<string, TransferAnnotation[]>();
+    for (const row of response.results) {
+      const annotation: TransferAnnotation = {
+        transactionHash: row.transactionHash,
+        from: row.from,
+        to: row.to,
+        data: row.data,
+        text: decodeText(row.data),
+      };
+      const key = row.transactionHash.toLowerCase();
+      const list = byTx.get(key);
+      if (list) {
+        list.push(annotation);
+      } else {
+        byTx.set(key, [annotation]);
+      }
+    }
+
+    if (response.hasMore) {
+      console.warn(
+        `[transferAnnotations] ${address} has more than ${FETCH_LIMIT} annotations; only the first page is shown.`
+      );
+    }
+
+    annotationsByTx.set(byTx);
+    loadedFor = address;
+  } catch (error) {
+    // Non-fatal: annotations are supplementary. Surface for debugging, leave history intact.
+    console.error('[transferAnnotations] failed to load:', error);
+  }
+}
+
+/** Annotations for a transaction hash (empty array if none). */
+export function getAnnotationsForTx(transactionHash: string): TransferAnnotation[] {
+  return get(annotationsByTx).get(transactionHash.toLowerCase()) ?? [];
+}
+
+/** Reset cached state (e.g. on avatar switch) so the next load refetches. */
+export function resetTransferAnnotations(): void {
+  loadedFor = null;
+  annotationsByTx.set(new Map());
+}

--- a/circles-app/src/routes/dashboard/TransactionDetailsPopup.svelte
+++ b/circles-app/src/routes/dashboard/TransactionDetailsPopup.svelte
@@ -8,6 +8,7 @@
     import { CirclesConverter } from '@aboutcircles/sdk-utils';
     import { isAddress, isZeroAddress, toBigIntMaybe, tokenIdToAddressMaybe } from '$lib/shared/utils/tx';
     import TxEvents from './TxEvents.svelte';
+    import { annotationsByTx } from '$lib/shared/state/transferAnnotations';
     import { popupControls } from '$lib/shared/state/popup';
     import JumpPopup from '$lib/shared/ui/content/jump/JumpPopup.svelte';
     import { T } from '$lib/design-system/tokens.js';
@@ -15,6 +16,13 @@
 
     interface Props { item: TransactionHistoryRow }
     let { item }: Props = $props();
+
+    // Transfer-data annotations attached to this transaction (note/message carried on a transfer).
+    // Keyed by transaction hash; only those that decode to readable text are shown.
+    const txAnnotations = $derived(
+        ($annotationsByTx.get(item.transactionHash?.toLowerCase() ?? '') ?? [])
+            .filter((a) => a.text)
+    );
 
     // Tab control removed (JSON view no longer needed)
 
@@ -717,6 +725,22 @@
             />
         </div>
     </div>
+
+    {#if txAnnotations.length}
+        <!-- Transfer note(s) -->
+        <div style="background:{T.surface};border:1px solid {T.hairlineSoft};border-radius:14px;overflow:hidden;">
+            <div style="padding:10px 14px;border-bottom:1px solid {T.hairlineSoft};">
+                <span style="font-size:11px;color:{T.inkMuted};font-weight:600;letter-spacing:0.06em;text-transform:uppercase;">
+                    {txAnnotations.length > 1 ? 'Notes' : 'Note'}
+                </span>
+            </div>
+            {#each txAnnotations as a, i (i)}
+                <div style="padding:10px 14px;{i > 0 ? `border-top:1px solid ${T.hairlineSoft};` : ''}">
+                    <span style="font-size:13px;color:{T.inkBody};white-space:pre-wrap;word-break:break-word;">{a.text}</span>
+                </div>
+            {/each}
+        </div>
+    {/if}
 
     <!-- Details table -->
     <div style="background:{T.surface};border:1px solid {T.hairlineSoft};border-radius:14px;overflow:hidden;">


### PR DESCRIPTION
## Summary

Reads and displays the note/message ("transfer data") attached to a Circles transfer. Until now these annotations were stored on-chain and indexed but never surfaced in the wallet.

An annotation is a small data blob carried on a transfer: for pCRC (ERC-1155) in the transfer's `data`, and for gCRC (ERC-20) on a separate 0-value ERC-1155 transfer batched into the same tx. The indexer extracts both into `CrcV2_TransferData`, exposed by the JSON-RPC method `circles_getTransferData`.

This PR covers the **read/display** side only.

## What changed

- **`lib/shared/state/transferAnnotations.ts`** (new): fetches the avatar's annotations in one RPC call via `sdk.rpc.client.call('circles_getTransferData', …)` (same pattern as the existing `circles_query` calls), decodes each blob with `decodeCrcV2TransferData`, and exposes a `transactionHash → annotations` store. Non-fatal on error; undecodable legacy blobs are skipped.
- **`lib/shared/state/transactionHistory.ts`**: loads annotations on history init and resets them on avatar switch.
- **`routes/dashboard/TransactionDetailsPopup.svelte`**: renders a **Note** card when a transaction has decodable annotations.

Works against the currently-resolved SDK (`0.1.52`, which already ships `decodeCrcV2TransferData`) — no SDK bump required. Correlation is by `transactionHash` (annotations carry no explicit link to a value-transfer leg).

## Not in this PR

- Write side (surface a note input + batch the gCRC 0-value annotation leg) — follow-up.

## Test plan

- [x] `svelte-check` — 0 errors (3641 files)
- [ ] Open a transaction that has an annotation (e.g. an account with prior notes) → the Note card shows the decoded text
- [ ] Avatar switch resets and reloads annotations