### PR TITLE
Refresh wallet balances after confirmed transactions

### DIFF
--- a/_context/README.md
+++ b/_context/README.md
@@ -1,0 +1,10 @@
+# Company context
+
+Drop company-wide documents here (markdown, text, ADRs, API conventions,
+style guides…). Every file in this directory is mounted read-only into the
+agent's workspace at `_context/` for every task, and the agent is told to
+consult them.
+
+Per-repository docs (architecture notes, CONTRIBUTING, etc.) are configured
+separately on each codebase entry in `config/repos.yaml` (or via the UI), and
+repos' own `AGENTS.md` / `CLAUDE.md` files are always picked up automatically.

--- a/circles-app/src/lib/__tests__/circlesBalances.test.ts
+++ b/circles-app/src/lib/__tests__/circlesBalances.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { get } from 'svelte/store';
+import type { Avatar } from '@aboutcircles/sdk';
+import type { TokenBalance } from '@aboutcircles/sdk-types';
+
+vi.mock('$lib/shared/cache', () => ({
+  writeBalances: vi.fn().mockResolvedValue(undefined),
+  makeScopeId: (address: string) => `gnosis:${address.toLowerCase()}`,
+}));
+
+function createMockBalance(
+  overrides: Partial<TokenBalance> = {}
+): TokenBalance {
+  return {
+    tokenId: 'token-1',
+    tokenAddress: '0x1111111111111111111111111111111111111111',
+    tokenOwner: '0x2222222222222222222222222222222222222222',
+    tokenType: 'CrcV2_RegisterHuman',
+    circles: 1,
+    staticCircles: 1,
+    attoCircles: 1000000000000000000n,
+    isWrapped: false,
+    isInflationary: false,
+    ...overrides,
+  } as TokenBalance;
+}
+
+function createMockAvatar(options: {
+  address?: string;
+  getTokenBalances: () => Promise<TokenBalance[]>;
+  subscribe?: () => () => void;
+}): Avatar {
+  return {
+    address: options.address ?? '0x1234567890123456789012345678901234567890',
+    balances: {
+      getTokenBalances: options.getTokenBalances,
+    },
+    events: {
+      subscribe: options.subscribe ?? (() => () => {}),
+    },
+  } as unknown as Avatar;
+}
+
+async function waitFor(assertion: () => void, timeoutMs = 1000): Promise<void> {
+  const start = Date.now();
+
+  while (Date.now() - start < timeoutMs) {
+    try {
+      assertion();
+      return;
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+  }
+
+  assertion();
+}
+
+describe('circlesBalances', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('refreshBalanceStore reloads and re-sorts balances for the current avatar after a confirmed tx', async () => {
+    const initialBalances = [createMockBalance()];
+    const higherBalance = createMockBalance({
+      tokenId: 'token-2',
+      tokenAddress: '0x3333333333333333333333333333333333333333',
+      tokenOwner: '0x4444444444444444444444444444444444444444',
+      circles: 3,
+      staticCircles: 3,
+      attoCircles: 3000000000000000000n,
+    });
+    const lowerBalance = createMockBalance();
+    const refreshedBalances = [lowerBalance, higherBalance];
+
+    const getTokenBalances = vi
+      .fn<() => Promise<TokenBalance[]>>()
+      .mockResolvedValueOnce(initialBalances)
+      .mockResolvedValueOnce(refreshedBalances);
+
+    const avatar = createMockAvatar({
+      getTokenBalances,
+      subscribe: vi.fn(() => vi.fn()),
+    });
+
+    const { circlesBalances, initBalanceStore, refreshBalanceStore } =
+      await import('$lib/shared/state/circlesBalances');
+
+    initBalanceStore(avatar);
+
+    await waitFor(() => {
+      expect(get(circlesBalances).data).toEqual(initialBalances);
+    });
+
+    expect(getTokenBalances).toHaveBeenCalledTimes(1);
+
+    // Re-initializing the same avatar is deduped, so a manual refresh is required.
+    initBalanceStore(avatar);
+    expect(getTokenBalances).toHaveBeenCalledTimes(1);
+
+    await refreshBalanceStore(avatar);
+
+    expect(get(circlesBalances).data).toEqual([higherBalance, lowerBalance]);
+    expect(getTokenBalances).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not overwrite the active store when an older avatar tx finishes after an account switch', async () => {
+    const firstAvatarBalances = vi
+      .fn<() => Promise<TokenBalance[]>>()
+      .mockResolvedValueOnce([createMockBalance({ circles: 1 })])
+      .mockResolvedValueOnce([createMockBalance({ circles: 5 })]);
+    const secondAvatarSnapshot = [
+      createMockBalance({
+        tokenId: 'token-9',
+        tokenAddress: '0x9999999999999999999999999999999999999999',
+        circles: 9,
+        staticCircles: 9,
+        attoCircles: 9000000000000000000n,
+      }),
+    ];
+    const secondAvatarBalances = vi
+      .fn<() => Promise<TokenBalance[]>>()
+      .mockResolvedValueOnce(secondAvatarSnapshot);
+
+    const firstAvatar = createMockAvatar({
+      address: '0x1111111111111111111111111111111111111111',
+      getTokenBalances: firstAvatarBalances,
+      subscribe: vi.fn(() => vi.fn()),
+    });
+    const secondAvatar = createMockAvatar({
+      address: '0x2222222222222222222222222222222222222222',
+      getTokenBalances: secondAvatarBalances,
+      subscribe: vi.fn(() => vi.fn()),
+    });
+
+    const { circlesBalances, initBalanceStore, refreshBalanceStore } =
+      await import('$lib/shared/state/circlesBalances');
+
+    initBalanceStore(firstAvatar);
+    await waitFor(() => {
+      expect(get(circlesBalances).data).toEqual([
+        createMockBalance({ circles: 1 }),
+      ]);
+    });
+
+    initBalanceStore(secondAvatar);
+    await waitFor(() => {
+      expect(get(circlesBalances).data).toEqual(secondAvatarSnapshot);
+    });
+
+    await refreshBalanceStore(firstAvatar);
+
+    expect(get(circlesBalances).data).toEqual(secondAvatarSnapshot);
+    expect(firstAvatarBalances).toHaveBeenCalledTimes(2);
+  });
+});

--- a/circles-app/src/lib/areas/wallet/flows/send/4_Send.svelte
+++ b/circles-app/src/lib/areas/wallet/flows/send/4_Send.svelte
@@ -13,6 +13,7 @@
   import {avatarState} from '$lib/shared/state/avatar.svelte';
   import {tokenTypeToString, TransitiveTransferTokenAddress} from '$lib/areas/wallet/ui/pages/SelectAsset.svelte';
   import {popupControls} from '$lib/shared/state/popup';
+  import { refreshBalanceStore } from '$lib/shared/state/circlesBalances';
   import {refreshTransactionHistory} from '$lib/shared/state/transactionHistory';
   import {MAX_PATH_STEPS} from "$lib/shared/config/circles";
   import {
@@ -102,8 +103,8 @@
             selectedAsset.tokenAddress,
             dataUInt8Arr.length > 0 ? dataUInt8Arr : undefined
           ),
-      onSuccess: () => {
-        refreshTransactionHistory();
+      onSuccess: async () => {
+        await Promise.all([refreshBalanceStore(avatar), refreshTransactionHistory()]);
         popupControls.close();
       },
     });

--- a/circles-app/src/lib/shared/state/circlesBalances.ts
+++ b/circles-app/src/lib/shared/state/circlesBalances.ts
@@ -16,6 +16,7 @@ const refreshOnEvents: Set<CirclesEventType> = new Set<CirclesEventType>([
 ]);
 
 let currentStoreUnsubscribe: (() => void) | undefined;
+let currentAvatar: Avatar | undefined;
 let currentAvatarAddress: string = '';
 
 const _circlesBalances = writable<{
@@ -23,6 +24,12 @@ const _circlesBalances = writable<{
   next: () => Promise<boolean>;
   ended: boolean;
 }>({ data: [], next: async () => false, ended: false });
+
+function compareBalances(a: TokenBalance, b: TokenBalance): number {
+  if (a.circles > b.circles) return -1;
+  if (a.circles < b.circles) return 1;
+  return 0;
+}
 
 async function _loadBalancesFor(avatar: Avatar): Promise<TokenBalance[]> {
   if (!avatar || typeof avatar !== 'object') {
@@ -39,7 +46,8 @@ async function _loadBalancesFor(avatar: Avatar): Promise<TokenBalance[]> {
     return [];
   }
   try {
-    const balances = (await avatar.balances.getTokenBalances()) as unknown as TokenBalance[];
+    const balances =
+      (await avatar.balances.getTokenBalances()) as unknown as TokenBalance[];
     void writeBalances(makeScopeId(avatar.address), balances as any[]);
     return balances;
   } catch (e: unknown) {
@@ -53,8 +61,10 @@ async function _loadBalancesFor(avatar: Avatar): Promise<TokenBalance[]> {
 export const initBalanceStore = (avatar: Avatar) => {
   // Early return if already initialized for this avatar
   if (currentAvatarAddress === avatar.address) {
+    currentAvatar = avatar;
     return;
   }
+  currentAvatar = avatar;
   currentAvatarAddress = avatar.address;
 
   if (currentStoreUnsubscribe) {
@@ -89,16 +99,33 @@ export const initBalanceStore = (avatar: Avatar) => {
     _handleEvent, // Function to handle event-based updates
     _handleNextPage, // Function to handle loading the next page of data
     [], // Initial empty data
-    (a, b) => {
-      // Comparator to sort the data by blockNumber, transactionIndex, and logIndex
-      // Order by balance desc and return 1,0,-1
-      if (a.circles > b.circles) return -1;
-      if (a.circles < b.circles) return 1;
-      return 0;
-    }
+    compareBalances
   );
 
   currentStoreUnsubscribe = store.subscribe(_circlesBalances.set);
 };
+
+/**
+ * Force-refresh balances for the current avatar.
+ * Use this after successful wallet transactions when live events are unavailable.
+ */
+export async function refreshBalanceStore(avatar?: Avatar): Promise<void> {
+  const avatarToRefresh = avatar ?? currentAvatar;
+  if (!avatarToRefresh) {
+    return;
+  }
+
+  const balances = await _loadBalancesFor(avatarToRefresh);
+  const sortedBalances = [...balances].sort(compareBalances);
+
+  if (currentAvatarAddress !== avatarToRefresh.address) {
+    return;
+  }
+
+  _circlesBalances.update((current) => ({
+    ...current,
+    data: sortedBalances,
+  }));
+}
 
 export const circlesBalances = _circlesBalances;

--- a/circles-app/src/routes/dashboard/+page.svelte
+++ b/circles-app/src/routes/dashboard/+page.svelte
@@ -10,7 +10,7 @@
     import { popupControls } from '$lib/shared/state/popup';
     import { ethers } from 'ethers';
     import Balances from '$lib/areas/wallet/ui/pages/Balances.svelte';
-    import { circlesBalances } from '$lib/shared/state/circlesBalances';
+    import { circlesBalances, refreshBalanceStore } from '$lib/shared/state/circlesBalances';
     import { totalCirclesBalance } from '$lib/shared/state/totalCirclesBalance';
     import { refreshTransactionHistory } from '$lib/shared/state/transactionHistory';
     import { buildGroupOwnerSet } from '$lib/shared/utils/tokenClassification';
@@ -69,8 +69,8 @@
 
         mintableAmount = 0;
 
-        // Refresh tx history so the mint appears immediately
-        refreshTransactionHistory();
+        // Refresh balance-backed dashboard state and tx history immediately.
+        await Promise.all([refreshBalanceStore(avatar), refreshTransactionHistory()]);
     }
 
     // Match the dust filter in Balances.svelte so the count matches the breakdown


### PR DESCRIPTION
## What
- add a `refreshBalanceStore()` helper to the wallet balance store so confirmed transactions can deterministically reload balance-backed UI
- refresh balances alongside transaction history after confirmed send success
- refresh balances alongside transaction history after confirmed personal mint success
- add regression tests covering manual balance refresh, preserved sort order, and the stale-avatar/account-switch case

## Why
The wallet/dashboard page is driven by long-lived client stores rather than SvelteKit route invalidation. After a successful wallet transaction, the app refreshed transaction history but not the balance store that powers the visible page totals and balance breakdown. That left the page stale unless live avatar events happened to arrive.

This was especially noticeable when the restored avatar session had no live event pushes available.

## How it was tested
- `run_tests` could not be used because no test command is registered for this repo
- locally ran: `npm -w circles-app run test:run -- src/lib/__tests__/avatarHelpers.test.ts src/lib/__tests__/chainConfig.test.ts src/lib/__tests__/circlesBalances.test.ts`
- locally ran: `npm -w circles-app run check` and confirmed it still fails due pre-existing missing `@circles-market/sdk` / `@circles-profile/core` type resolution and unrelated existing type issues, not from this patch

## Notes
- the balance refresh helper preserves the existing descending balance sort order
- explicit avatar refreshes are ignored if the active wallet has changed before the tx finishes, avoiding stale callbacks overwriting the current account view