### PR TITLE
fix(lists): key VirtualList rows by virtual index to prevent keyed-each crash

### DIFF
--- a/circles-app/src/lib/shared/ui/lists/VirtualList.svelte
+++ b/circles-app/src/lib/shared/ui/lists/VirtualList.svelte
@@ -433,7 +433,18 @@
         onfocusin={onVirtualSpaceFocusIn}
         onfocusout={onVirtualSpaceFocusOut}
     >
-        {#each virtualRows as vr (vr.kind === 'item' ? getKey(vr.item) : `placeholder-${vr.placeholderIndex}`)}
+        <!--
+            Key by the absolute virtual index, NOT by item/placeholder identity.
+            Rows are positioned by `transform: translateY(index * rowHeight)` and
+            tracked via `data-virtual-index`, so the DOM slot's identity IS its
+            index. Keying by item id mixed with a placeholder key whose base
+            (`loadedItems.length`) shifts on every page load forced Svelte to
+            remove placeholder blocks and move item blocks in the same flush as
+            range/data mutations — corrupting the keyed-each linked list
+            (`i.nodes` null → "reading 'start'"). Index keys keep each slot
+            stable and swap its content in place, eliminating that thrash.
+        -->
+        {#each virtualRows as vr (vr.index)}
             <div
                 class="virtual-row"
                 data-virtual-index={vr.index}


### PR DESCRIPTION
## Summary
Transaction history (and every `VirtualList`-backed list) could fail to load or scroll: rows collapsed to a single entry and, in production builds, scrolling threw a storm of `TypeError: Cannot read properties of null (reading 'start')` from Svelte's keyed-`{#each}` reconciler.

## Root cause
The list keyed each row by a hybrid identity — items by `getKey(item)`, placeholders by `placeholder-${i - loadedItems.length}`. The placeholder key base (`loadedItems.length`) shifts on every page load. When the upstream store consolidates rows (grouped transaction history adds *fewer* rows than the requested page size), that base drifts by a variable amount while the visible range churns, forcing Svelte to remove placeholder blocks and move/insert item blocks in the same flush as range/data mutations. That corrupts the keyed-each internal linked list (`.nodes` becomes null). Duplicate item keys hit the same failure path.

## Fix
Key each row by its absolute virtual index (`vr.index`). Rows are already absolutely positioned via `transform: translateY(index * rowHeight)` and tracked through `data-virtual-index`, so the DOM slot's identity *is* its index. Index keys are always unique and change only by ±1 at the window edges, so content swaps in place instead of blocks moving — eliminating the reconciler thrash. This also matches the component's existing index-based focus/positioning model.

One-line change in the `{#each}` key (plus an explanatory comment). No API or prop changes; callers passing `getKey` are unaffected (it remains the dedup key used by the store).

## Test plan
- [x] `svelte-check`: 0 errors (28 pre-existing warnings, unchanged)
- [x] Production build (`build:packages`): passes
- [x] Unit tests: 205/205
- [x] E2E (Playwright): 12/12
- [x] Local repro: with colliding keys the old code collapses to 1 row; the fix renders the full window (13 → 23 rows) and scrolls cleanly with 0 errors/warnings
- [ ] Authenticated dashboard transaction list loads and scrolls — verify on the dev deploy
