### PR TITLE
fix(dashboard): render grouped transactions and correct activity labels

### DIFF
--- a/circles-app/src/routes/dashboard/+page.svelte
+++ b/circles-app/src/routes/dashboard/+page.svelte
@@ -14,7 +14,7 @@
     import Balances from '$lib/areas/wallet/ui/pages/Balances.svelte';
     import { circlesBalances } from '$lib/shared/state/circlesBalances';
     import { totalCirclesBalance } from '$lib/shared/state/totalCirclesBalance';
-    import { refreshTransactionHistory, transactionHistory } from '$lib/shared/state/transactionHistory';
+    import { refreshTransactionHistory, transactionHistory, groupedTransactionHistory } from '$lib/shared/state/transactionHistory';
     import { buildGroupOwnerSet } from '$lib/shared/utils/tokenClassification';
 
     import { openSendFlowPopup } from '$lib/areas/wallet/flows/send/openSendFlowPopup';
@@ -295,7 +295,7 @@
         >
             <VirtualList
                 row={TransactionRow}
-                store={transactionHistory}
+                store={groupedTransactionHistory}
                 rowHeight={TRANSACTION_ROW_HEIGHT}
                 maxPlaceholderPages={2}
                 expectedPageSize={25}

--- a/circles-app/src/routes/dashboard/TransactionDetailsPopup.svelte
+++ b/circles-app/src/routes/dashboard/TransactionDetailsPopup.svelte
@@ -467,6 +467,17 @@
         return 'Transaction';
     });
 
+    // Direction text must agree with the signed header amount. Deriving "sent" purely from
+    // `item.from === me` contradicts the headline for self-counterparty / synthesized rows
+    // (e.g. a positive "received" headline while the direction said "You sent this").
+    const directionLabel = $derived(
+        headerNetAmount < 0 ? 'You sent this'
+        : headerNetAmount > 0 ? 'You received this'
+        // Net zero can be a true self-transfer OR a pass-through hop (from ≠ to), so avoid
+        // asserting "Self-transfer"; "No net change" is honest for both.
+        : 'No net change'
+    );
+
     const nonBurnTransfers = $derived.by(() =>
         aggregatedTransfers.filter(t => !isZeroAddress(t.to))
     );
@@ -710,7 +721,7 @@
                 </div>
                 <div style="margin-top:10px;padding-top:10px;border-top:1px solid {T.hairlineSoft};display:flex;justify-content:space-between;align-items:center;">
                     <span style="font-size:11px;color:{T.inkMuted};font-weight:600;letter-spacing:0.06em;text-transform:uppercase;">Direction</span>
-                    <span style="font-size:12.5px;color:{T.inkBody};font-weight:540;">{sent ? 'You sent this' : 'You received this'}</span>
+                    <span style="font-size:12.5px;color:{T.inkBody};font-weight:540;">{directionLabel}</span>
                 </div>
             {/if}
 
@@ -788,7 +799,7 @@
                             <Avatar address={t.from} view="small" clickable={true} />
                         {/if}
                     </div>
-                    <span style="flex-shrink:0;font-size:13px;font-weight:580;color:{T.ink};font-variant-numeric:tabular-nums;">
+                    <span style="flex-shrink:0;min-width:88px;text-align:right;font-size:13px;font-weight:580;color:{T.ink};font-variant-numeric:tabular-nums;white-space:nowrap;">
                         {formatAmount(t.amount)}<span style="color:{T.inkMuted};font-weight:540;margin-left:3px;">CRC</span>
                     </span>
                     <div style="flex-shrink:0;display:inline-flex;align-items:center;gap:6px;color:{T.inkMuted};">
@@ -831,7 +842,7 @@
                                     <Avatar address={t.from} view="small" clickable={true} />
                                 {/if}
                             </div>
-                            <span style="flex-shrink:0;font-size:13px;font-weight:580;color:{T.ink};font-variant-numeric:tabular-nums;">
+                            <span style="flex-shrink:0;min-width:88px;text-align:right;font-size:13px;font-weight:580;color:{T.ink};font-variant-numeric:tabular-nums;white-space:nowrap;">
                                 {formatAmount(t.amount)}<span style="color:{T.inkMuted};font-weight:540;margin-left:3px;">CRC</span>
                             </span>
                             <div style="flex-shrink:0;display:inline-flex;align-items:center;gap:6px;color:{T.inkMuted};">

--- a/circles-app/src/routes/dashboard/TransactionRow.svelte
+++ b/circles-app/src/routes/dashboard/TransactionRow.svelte
@@ -21,13 +21,20 @@
 
     const counterpartyAddress = $derived(item.counterparty?.toLowerCase() ?? null);
 
-    const topInfoText = $derived(item.hasMint ? 'Collected CRC' : '');
+    // "Collected CRC" should only show for an actual mint (you collected your own CRC),
+    // where the counterparty resolves to yourself. Keying it off `hasMint` (ANY mint event
+    // anywhere in the bundle) mislabels received path-transfers that merely contain a mint
+    // hop as "Collected CRC · <sender>", which is nonsensical. Use the semantic group type.
+    const topInfoText = $derived(item.type === 'mint' ? 'Collected CRC' : '');
 
     const badgeUrl = $derived.by(() => {
-        if (item.hasMint) return '/badge-mint.svg';
-        if (item.hasBurn) return '/badge-burn.svg';
+        if (item.type === 'mint') return '/badge-mint.svg';
+        if (item.type === 'burn') return '/badge-burn.svg';
         if (item.type === 'send') return '/badge-sent.svg';
         if (item.type === 'receive') return '/badge-received.svg';
+        // hop/complex fallback: hint at a mint/burn if one is present in the bundle
+        if (item.hasMint) return '/badge-mint.svg';
+        if (item.hasBurn) return '/badge-burn.svg';
         return null;
     });
 


### PR DESCRIPTION
## Summary

The dashboard activity list rendered every transaction with a `—` amount and a `null` counterparty (unresolved avatar). Root cause: the list's `VirtualList` was mounted with the raw per-event `transactionHistory` store, but `TransactionRow` expects `GroupedTransaction` items. Raw rows have no `netCircles`/`counterparty`, so `Math.abs(undefined) → NaN` rendered `—` and the counterparty was `null`. Fixed by mounting the grouped store (the same one the dedicated `TransactionHistoryPanel` already uses).

While verifying, two related labeling issues were corrected.

## Changes

- **dashboard/+page.svelte** — mount the activity `VirtualList` with `groupedTransactionHistory` instead of the raw `transactionHistory` store. The raw store import is retained; `todayNet` still uses it for per-event summing.
- **dashboard/TransactionRow.svelte** — derive the "Collected CRC" label and the badge from the semantic group `type` instead of `hasMint`. A received path-transfer that incidentally bundles a mint hop was previously mislabeled "Collected CRC · <sender>"; it now shows the sender with the received badge. Genuine mints (counterparty = self) keep "Collected CRC". hop/complex retain a mint/burn badge hint.
- **dashboard/TransactionDetailsPopup.svelte** — give the aggregated-transfer amount a fixed-width, right-aligned column so the amount / arrow / counterparty columns align across rows (transfers and burns). Derive the "Direction" label from the signed header amount so it can no longer contradict the headline; use a neutral "No net change" label for the net-zero case.

## Test plan

- [x] `npm run check` — 0 errors
- [x] `npm run build` — passes
- [x] `npm run test:run` — 205 unit tests pass
- [x] `npm run test:e2e` — 12 Playwright tests pass
- [x] Manual: dashboard renders real amounts, counterparties, avatars, and badges; list scrolls without errors; detail popup columns align; direction label matches the headline
