### PR TITLE
fix(config): point staging Netlify builds at the staging backends

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -12,7 +12,14 @@
   [context.deploy-preview.environment]
     NETLIFY_BUILD = "true"
     PUBLIC_ENVIRONMENT = "staging"
-    PUBLIC_CIRCLES_RPC_URL = "https://staging.circlesubi.network"
+    # circles.ts (gnosisConfig) reads these via import.meta.env.VITE_* (Vite env),
+    # NOT the SvelteKit PUBLIC_ namespace — they MUST be VITE_-prefixed to take effect.
+    # Point staging builds at the staging backends so previews exercise staging data
+    # (indexer RPC, chain RPC, and the score-groups backend per circles.ts). Trailing
+    # slash matches the prod defaults' format (SDK resolves endpoints relative to base).
+    VITE_CIRCLES_RPC_URL = "https://rpc.staging.aboutcircles.com/"
+    VITE_CHAIN_RPC_URL = "https://rpc.staging.aboutcircles.com/"
+    VITE_SCORE_GROUPS_BACKEND_URL = "https://rpc.staging.aboutcircles.com/score-groups"
     PUBLIC_PLAUSIBLE_DOMAIN = ""
 
 [context.branch-deploy]
@@ -21,7 +28,14 @@
   [context.branch-deploy.environment]
     NETLIFY_BUILD = "true"
     PUBLIC_ENVIRONMENT = "staging"
-    PUBLIC_CIRCLES_RPC_URL = "https://staging.circlesubi.network"
+    # circles.ts (gnosisConfig) reads these via import.meta.env.VITE_* (Vite env),
+    # NOT the SvelteKit PUBLIC_ namespace — they MUST be VITE_-prefixed to take effect.
+    # Point staging builds at the staging backends so previews exercise staging data
+    # (indexer RPC, chain RPC, and the score-groups backend per circles.ts). Trailing
+    # slash matches the prod defaults' format (SDK resolves endpoints relative to base).
+    VITE_CIRCLES_RPC_URL = "https://rpc.staging.aboutcircles.com/"
+    VITE_CHAIN_RPC_URL = "https://rpc.staging.aboutcircles.com/"
+    VITE_SCORE_GROUPS_BACKEND_URL = "https://rpc.staging.aboutcircles.com/score-groups"
     PUBLIC_PLAUSIBLE_DOMAIN = ""
 
 [context.production]


### PR DESCRIPTION
## What
Staging Netlify build contexts (`deploy-preview`, `branch-deploy`) now point the Circles SDK at the staging backends instead of silently using production.

- Rename `PUBLIC_CIRCLES_RPC_URL` → `VITE_CIRCLES_RPC_URL`. The app reads `import.meta.env.VITE_*` (Vite namespace); the SvelteKit `PUBLIC_` variable was never read, so the override was dead config and staging built against the hardcoded production RPC.
- Repoint indexer RPC, chain RPC, and the score-groups backend to `https://rpc.staging.aboutcircles.com/` (the staging DNS pool). The score-groups backend holds staging-specific state and `circles.ts` documents a per-deployment staging override.
- Add a trailing slash to match the production defaults' format for relative endpoint resolution.
- `production` context unchanged.

## Why
Staging preview builds were exercising the production indexer and score-groups backend, masking staging-only data and behavior.

## Known limitations (follow-up, not in scope)
`pathfinderUrl`, `profileServiceUrl`, `profilePinningServiceUrl`, `marketApiBase`, `referralsServiceUrl` are hardcoded to production in `circles.ts` with no override hook — staging previews still hit production for those. Fixing requires a code change to add overrides.

## Test plan (post-deploy on Netlify)
- [ ] deploy-preview build's network calls hit `rpc.staging.aboutcircles.com`
- [ ] Circles data (balances/trust) reflects the staging indexer
- [ ] Score-groups features resolve against the staging backend
