### PR TITLE
fix(dashboard): stop periodic resync flicker and sidebar layout shift

### DIFF
--- a/circles-app/src/lib/shared/state/circlesBalances.ts
+++ b/circles-app/src/lib/shared/state/circlesBalances.ts
@@ -2,7 +2,7 @@ import type { CirclesEvent, CirclesEventType } from '@aboutcircles/sdk-rpc';
 import type { TokenBalance } from '@aboutcircles/sdk-types';
 import { createEventStore } from '$lib/shared/state/eventStores/eventStoreFactory.svelte';
 import type { Avatar } from '@aboutcircles/sdk';
-import { writable } from 'svelte/store';
+import { writable, get } from 'svelte/store';
 import { writeBalances, makeScopeId } from '$lib/shared/cache';
 
 const refreshOnEvents: Set<CirclesEventType> = new Set<CirclesEventType>([
@@ -51,7 +51,7 @@ async function _loadBalancesFor(avatar: Avatar): Promise<TokenBalance[]> {
   }
 }
 
-export const initBalanceStore = (avatar: Avatar) => {
+export const initBalanceStore = (avatar: Avatar, opts?: { quiet?: boolean }) => {
   // Early return if already initialized for this avatar
   if (currentAvatarAddress === avatar.address) {
     return;
@@ -63,12 +63,18 @@ export const initBalanceStore = (avatar: Avatar) => {
     currentStoreUnsubscribe = undefined;
   }
 
-  _circlesBalances.set({
-    data: [],
-    next: async () => false,
-    ended: false,
-    initialLoaded: false,
-  });
+  // In quiet mode (realtime resync rebind) keep the current balances visible by
+  // seeding the new event store with them, instead of blanking to [] first — this
+  // prevents the hero balance from flickering on every liveness re-subscribe.
+  const seed = opts?.quiet ? get(_circlesBalances).data : [];
+  if (!opts?.quiet) {
+    _circlesBalances.set({
+      data: [],
+      next: async () => false,
+      ended: false,
+      initialLoaded: false,
+    });
+  }
 
   const _initialLoad = (): Promise<TokenBalance[]> => _loadBalancesFor(avatar);
 
@@ -90,7 +96,7 @@ export const initBalanceStore = (avatar: Avatar) => {
     _initialLoad, // Function to load the initial data
     _handleEvent, // Function to handle event-based updates
     _handleNextPage, // Function to handle loading the next page of data
-    [], // Initial empty data
+    seed, // Initial data (current balances in quiet mode, else empty)
     (a, b) => {
       // Comparator to sort the data by blockNumber, transactionIndex, and logIndex
       // Order by balance desc and return 1,0,-1
@@ -109,7 +115,7 @@ export const circlesBalances = _circlesBalances;
  * Force-refresh the balance store, bypassing the dedup guard.
  * Call this after WS reconnect so stale balances are reloaded.
  */
-export function refreshBalanceStore(avatar: Avatar): void {
+export function refreshBalanceStore(avatar: Avatar, opts?: { quiet?: boolean }): void {
   currentAvatarAddress = '';
-  initBalanceStore(avatar);
+  initBalanceStore(avatar, opts);
 }

--- a/circles-app/src/lib/shared/state/realtimeSync.ts
+++ b/circles-app/src/lib/shared/state/realtimeSync.ts
@@ -29,14 +29,26 @@ export function initAvatarStores(avatar: Avatar): void {
 }
 
 /**
- * Refreshes all stores after a WS reconnect, bypassing the dedup guards so
+ * Refreshes stores after a WS reconnect/liveness tick, bypassing the dedup guards so
  * that stale data is reloaded even though the avatar address hasn't changed.
+ *
+ * Transaction history and balances always refresh *quietly* — they re-subscribe and
+ * refetch page 1 in place without blanking to a skeleton, and no-op when nothing
+ * changed. This is what stops the periodic 15s liveness tick from flickering the UI.
+ *
+ * Contacts also rebind on every tick: re-init is non-destructive (the contact store
+ * keeps its current value until the new query resolves), so it doesn't flicker, and
+ * rebinding keeps live trust updates attached to the fresh event observable after an
+ * interval-detected reconnect.
+ *
+ * Group metrics can blank on re-init, so they only refresh on a `full` resync (tab
+ * refocus / network back online), not on the steady-state liveness interval.
  */
-function refreshAvatarStores(avatar: Avatar): void {
-  void refreshTransactionHistory();
+function refreshAvatarStores(avatar: Avatar, opts?: { full?: boolean }): void {
+  void refreshTransactionHistory({ quiet: true });
+  refreshBalanceStore(avatar, { quiet: true });
   refreshContactStore(avatar);
-  refreshBalanceStore(avatar);
-  if (avatarState.isGroup) {
+  if (opts?.full && avatarState.isGroup) {
     const sdk = get(circles);
     if (sdk) {
       void initGroupMetricsStore(sdk.rpc, avatar.address);
@@ -63,7 +75,7 @@ function isWebsocketConnected(sdk: Sdk | undefined): boolean | undefined {
  * `eth_subscribe` (reconnecting the socket first if needed), then we rebind the
  * stores to it and reload to catch up on anything missed while disconnected.
  */
-async function resync(): Promise<void> {
+async function resync(opts?: { full?: boolean }): Promise<void> {
   const avatar = avatarState.avatar;
   if (!avatar) return;
 
@@ -79,7 +91,7 @@ async function resync(): Promise<void> {
     console.warn('[realtimeSync] subscribeToEvents failed', e);
   }
   try {
-    refreshAvatarStores(avatar);
+    refreshAvatarStores(avatar, opts);
   } catch (e) {
     console.warn('[realtimeSync] refreshAvatarStores failed', e);
   }
@@ -99,20 +111,28 @@ export function initRealtimeSync(): () => void {
   // Start each subscription session unthrottled.
   lastResyncAt = 0;
 
+  // Tab refocus / network back online: do a FULL resync (also rebinds contacts +
+  // group metrics) since the user has just returned and a complete catch-up is wanted.
   const onVisible = () => {
-    if (document.visibilityState === 'visible') void resync();
+    if (document.visibilityState === 'visible') void resync({ full: true });
   };
-  const onOnline = () => void resync();
+  const onOnline = () => void resync({ full: true });
 
   document.addEventListener('visibilitychange', onVisible);
   window.addEventListener('online', onOnline);
 
   // Safety net for a clean idle-close while the tab is foregrounded: only
   // resyncs when the socket actually reports disconnected, so it doesn't leak
-  // subscriptions or reload on every tick.
+  // subscriptions or reload on every tick. This is a QUIET resync — transaction
+  // history and balances refetch in place without blanking, and no-op when nothing
+  // changed — so it never flickers the UI even though it can fire every interval.
   const interval = setInterval(() => {
     if (document.visibilityState !== 'visible') return;
-    if (isWebsocketConnected(get(circles)) === false) void resync();
+    // Fail safe: resync when the socket reports disconnected OR when the connection
+    // state is unknown (the SDK field is private/undocumented and may return undefined
+    // after an SDK change). `!== true` means an SDK shape change degrades to a harmless
+    // quiet resync rather than silently freezing the only background refresh path.
+    if (isWebsocketConnected(get(circles)) !== true) void resync();
   }, LIVENESS_CHECK_INTERVAL_MS);
 
   return () => {

--- a/circles-app/src/lib/shared/state/transactionHistory.ts
+++ b/circles-app/src/lib/shared/state/transactionHistory.ts
@@ -35,6 +35,29 @@ function parseNumericValue(raw: unknown): number {
 }
 
 /**
+ * Cheap equality check for the first page of transaction events. Used by the quiet
+ * background refresh to decide whether a refetch actually changed anything — if the
+ * leading `incoming.length` rows match (same tx hash, log index AND amount), nothing
+ * has changed and the refresh is a no-op (so the UI is never disturbed). Comparing the
+ * amount as well as the identity means an in-place correction to an existing top row
+ * (e.g. an indexer backfilling a previously-missing amount) still heals on resync.
+ * A `current` longer than `incoming` (user scrolled past page 1) still counts as
+ * unchanged as long as the leading rows match, preserving their loaded pages.
+ */
+function firstPageUnchanged(
+  current: ExtendedTransactionRow[],
+  incoming: ExtendedTransactionRow[]
+): boolean {
+  if (current.length < incoming.length) return false;
+  for (let i = 0; i < incoming.length; i++) {
+    if (current[i]?.transactionHash !== incoming[i]?.transactionHash) return false;
+    if (current[i]?.logIndex !== incoming[i]?.logIndex) return false;
+    if (current[i]?.circles !== incoming[i]?.circles) return false;
+  }
+  return true;
+}
+
+/**
  * Extended transaction row with event type and operator
  */
 export type ExtendedTransactionRow = TransactionHistoryRow & {
@@ -471,13 +494,18 @@ const _transactionHistory = writable<{
  * Load the next page of transactions using enriched endpoint
  * Profiles are pre-loaded and cached for efficiency
  */
-async function loadNextPage(): Promise<boolean> {
-  if (!currentAvatar || isLoading || !hasMore) {
+async function loadNextPage(opts?: { replace?: boolean }): Promise<boolean> {
+  // `replace` mode = quiet background refresh: refetch page 1 and swap it in place
+  // without first blanking the list to a skeleton (used by the realtime resync).
+  const replace = opts?.replace === true;
+  if (!currentAvatar || isLoading || (!hasMore && !replace)) {
     return false;
   }
 
   isLoading = true;
-  _transactionHistory.update((state) => ({ ...state, isLoading: true }));
+  if (!replace) {
+    _transactionHistory.update((state) => ({ ...state, isLoading: true }));
+  }
 
   try {
     // Use global circles store - more reliable than extracting from avatar
@@ -491,7 +519,7 @@ async function loadNextPage(): Promise<boolean> {
     const response = await sdk.rpc.transaction.getTransactionHistory(
       currentAvatar.address,
       PAGE_SIZE,
-      nextCursor ?? null
+      replace ? null : (nextCursor ?? null)
     ) as unknown as PagedResponse<EnrichedTransaction>;
 
     if (response.results.length > 0) {
@@ -625,12 +653,25 @@ async function loadNextPage(): Promise<boolean> {
         };
       });
 
+      // Quiet replace: if page 1 is unchanged, skip the update entirely so a periodic
+      // resync never disturbs the UI when nothing actually changed. (nextCursor/hasMore
+      // were already updated above.)
+      if (replace && firstPageUnchanged(get(_transactionHistory).data, rows)) {
+        return true;
+      }
+
       // Pre-fetch profiles for all transaction participants
       // This populates enrichedProfileCache for getDisplayName() to use synchronously
       await prefetchProfilesForTransactions(rows);
 
+      // Replacing page 1 (quiet refresh) changes content without necessarily changing
+      // row count, so invalidate the length-keyed grouping memo to force a regroup.
+      if (replace) {
+        resetGroupedCache();
+      }
+
       _transactionHistory.update((state) => {
-        const newData = [...state.data, ...rows];
+        const newData = replace ? rows : [...state.data, ...rows];
         // Write-through to IDB cache
         if (currentAvatarAddress) {
           void writeTransactions(makeScopeId(currentAvatarAddress), newData);
@@ -827,7 +868,7 @@ export const groupedTransactionHistory = derived(
  * Unlike initTransactionHistoryStore(), this bypasses the "already initialized" guard
  * so new transactions (from WebSocket events) actually appear.
  */
-export async function refreshTransactionHistory(): Promise<void> {
+export async function refreshTransactionHistory(opts?: { quiet?: boolean }): Promise<void> {
   if (!currentAvatar || !currentAvatarAddress) {
     return;
   }
@@ -836,6 +877,15 @@ export async function refreshTransactionHistory(): Promise<void> {
   nextCursor = null;
   hasMore = true;
   isLoading = false;
+
+  // Quiet refresh (e.g. realtime liveness resync): refetch page 1 and swap it in place
+  // without tearing the list down to a skeleton, and skip the update entirely when
+  // page 1 is unchanged. Avoids a periodic flicker when nothing actually changed.
+  if (opts?.quiet) {
+    void loadTransferAnnotations(currentAvatar, true);
+    await loadNextPage({ replace: true });
+    return;
+  }
 
   // Clear memoization cache for fresh grouping
   resetGroupedCache();

--- a/circles-app/src/routes/+layout.svelte
+++ b/circles-app/src/routes/+layout.svelte
@@ -26,6 +26,7 @@
   import Popup from '$lib/shared/ui/shell/PopupHost.svelte';
   import { initAvatarStores, initRealtimeSync } from '$lib/shared/state/realtimeSync';
   import { browser } from '$app/environment';
+  import { CirclesStorage } from '$lib/shared/utils/storage';
   import { makeScopeId, writeMeta } from '$lib/shared/cache';
   import { env } from '$env/dynamic/public';
 
@@ -124,6 +125,19 @@
   let lastForwardNoopTick = 0;
   let historyForwardNoopToastTimer: ReturnType<typeof setTimeout> | null = null;
   const avatarInfo = $derived(avatarState.avatar?.avatarInfo ?? null);
+
+  // Reserve the sidebar's width as soon as we know a session will restore, not only once
+  // the avatar resolves — otherwise the sidebar mounts late and shoves page content ~248px
+  // to the right (a visible layout jump on load). "Will restore" = a stored avatar exists
+  // (the same signal restoreSession() checks) AND we're not on a bypass route (landing /
+  // connect / kitchen-sink). Gating on the stored session — rather than the route alone —
+  // avoids showing a dead half-sidebar to signed-out visitors on public routes
+  // (/register, /terms, …). AppSidebar renders safely without an avatar (logo + nav show;
+  // account/Send fill in when it resolves), so reserving the column early causes no error.
+  const showSidebar = $derived(
+    !!avatarState.avatar ||
+    (!shouldBypassWalletRestore($page.route.id) && !!CirclesStorage.getInstance().avatar)
+  );
 
   onMount(() => {
     disposePopupHistorySync = initPopupHistorySync();
@@ -324,8 +338,9 @@
 <!-- Full-height responsive shell -->
 <div class="flex h-dvh overflow-hidden" style="background:#EFEDE7;">
 
-  <!-- Desktop sidebar (md+) -->
-  {#if avatarState.avatar}
+  <!-- Desktop sidebar (md+). Rendered as soon as a session restore is expected so the
+       content column doesn't jump right when the avatar resolves. -->
+  {#if showSidebar}
     <AppSidebar />
   {/if}
 


### PR DESCRIPTION
## Summary

Two dashboard UX regressions, both confirmed with instrumentation:

1. **Periodic flicker (~15s).** The realtime "liveness" resync (a `setInterval` that re-subscribes to events whenever the SDK reports the websocket disconnected) reset transaction history and balances to empty+loading on every tick, tearing the list down to a skeleton and re-rendering even when nothing had changed (measured: a ~140-mutation re-render burst every 15s).
2. **Layout shift on load.** The desktop sidebar was rendered only after the avatar resolved, so the page first painted full-width (fullscreen skeleton) and then jumped ~248px to the right when the sidebar mounted.

## Changes

- **state/realtimeSync.ts** — split the resync into a quiet steady-state path (the 15s liveness interval) and a full path (tab refocus / network online). The quiet path refreshes transaction history and balances **non-destructively**, rebinds contacts non-destructively, and reloads group metrics only on the full path. The liveness gate now fails safe (resync unless the socket reports *connected*) so an SDK field change can't silently freeze background refresh.
- **state/transactionHistory.ts** — `refreshTransactionHistory({ quiet })` refetches page 1 and swaps it in place without blanking; a `firstPageUnchanged` check (hash + log index + amount) makes an unchanged refetch a complete no-op, so a genuine new transaction still renders while an identical refetch never touches the UI.
- **state/circlesBalances.ts** — quiet re-init seeds the rebound event store with the current balances instead of blanking to `[]`, so the hero balance no longer flickers on each liveness re-subscribe.
- **routes/+layout.svelte** — reserve the desktop sidebar column as soon as a session restore is expected (a stored avatar exists and the route isn't a bypass/landing route), eliminating the content jump. Gating on the stored session (not the route alone) avoids showing a dead half-sidebar to signed-out visitors on public routes.

## Test plan

- [x] `npm run check` — 0 errors
- [x] `npm run build` — passes
- [x] `npm run test:run` — 205 unit tests pass
- [x] `npm run test:e2e` — 12 Playwright tests pass
- [x] Manual (instrumented): sidebar column reserved from first paint (no content jump); no re-render bursts at 15s/30s; transaction list + balances + "people" count stable when nothing changed; list still paginates; new transactions still surface via the in-place refresh
