### PR TITLE
fix(dashboard): scope group/people balance stats; drop unused score-group env overrides

### DIFF
--- a/circles-app/src/lib/shared/config/circles.ts
+++ b/circles-app/src/lib/shared/config/circles.ts
@@ -32,13 +32,6 @@ export type CirclesConfig = BaseCirclesConfig & {
    * Undefined → score-group minting is unavailable on this network.
    */
   scoreGatedGroupAddress?: string;
-  /**
-   * Optional override for the Circles RPC used by the score-group migration
-   * pathfinder. The migration path must be routed by an indexer that knows the
-   * score-router/sink, or it reverts at the sink. Left `undefined` here; the
-   * integration falls back to `circlesRpcUrl` when this is not set.
-   */
-  scoreGroupsRpcUrl?: string;
 };
 
 export const chiadoConfig: { production: CirclesConfig; rings: CirclesConfig } =
@@ -135,17 +128,12 @@ export const gnosisConfig: { production: CirclesConfig; rings: CirclesConfig } =
       crcPricingApi:
         import.meta.env.VITE_CRC_PRICING_API ||
         'https://rpc.staging.aboutcircles.com/metrics-api/pricing',
-      // Score-groups (reputation-gated mint). Backend + RPC are overridable per
-      // deployment via env vars (dev/staging → staging backend); defaults are
-      // the production Gnosis-mainnet endpoints. The group avatar + its mint
-      // policy/treasury live on the main Gnosis Hub above.
-      scoreGroupsBackendUrl:
-        import.meta.env.VITE_SCORE_GROUPS_BACKEND_URL ||
-        'https://rpc.aboutcircles.com/score-groups',
-      scoreGatedGroupAddress:
-        import.meta.env.VITE_SCORE_GATED_GROUP_ADDRESS ||
-        '0x93eD5A96347927ff6fF6b790F8Cf5258240c321f',
-      scoreGroupsRpcUrl: import.meta.env.VITE_SCORE_GROUPS_RPC_URL || undefined,
+      // Score-groups (reputation-gated mint): the score group avatar and its
+      // proof backend — both public Gnosis-mainnet endpoints. The mint policy
+      // and treasury are resolved on-chain from the Hub above, and the migration
+      // pathfinder uses circlesRpcUrl, so no extra env wiring is needed.
+      scoreGroupsBackendUrl: 'https://rpc.aboutcircles.com/score-groups',
+      scoreGatedGroupAddress: '0x93eD5A96347927ff6fF6b790F8Cf5258240c321f',
     },
     rings: {
       circlesRpcUrl:

--- a/circles-app/src/lib/shared/integrations/permissionlessGroups/scoreGroup.ts
+++ b/circles-app/src/lib/shared/integrations/permissionlessGroups/scoreGroup.ts
@@ -13,8 +13,7 @@ import { getActiveConfig } from '$lib/shared/state/settings.svelte';
  * (chiado, rings).
  *
  * Reads use the standard chain RPC; the migration pathfinder uses the Circles
- * RPC (optionally overridden via `scoreGroupsRpcUrl`, since the path must be
- * routed by an indexer that knows the score-router/sink).
+ * RPC (the same one the rest of the app uses).
  */
 
 /** Whether the active network has score-group minting configured. */
@@ -40,13 +39,9 @@ export function getScoreGroup(): PermissionlessGroup | undefined {
     return undefined;
 
   // Hub/Lift reads need standard eth_call; the runner uses chainRpcUrl for the
-  // same reason, so mirror that here.
+  // same reason, so mirror that here. The migration pathfinder reads from
+  // circlesRpcUrl — the same RPC the rest of the app uses.
   const rpcUrl = cfg.chainRpcUrl ?? cfg.circlesRpcUrl;
-  // The pathfinder (migration) reads from circlesRpcUrl; allow a dedicated
-  // override for the score-group indexer.
-  const circlesConfig = cfg.scoreGroupsRpcUrl
-    ? { ...cfg, circlesRpcUrl: cfg.scoreGroupsRpcUrl }
-    : cfg;
 
   const key = [
     cfg.scoreGatedGroupAddress,
@@ -54,7 +49,7 @@ export function getScoreGroup(): PermissionlessGroup | undefined {
     cfg.liftERC20Address,
     cfg.scoreGroupsBackendUrl,
     rpcUrl,
-    circlesConfig.circlesRpcUrl,
+    cfg.circlesRpcUrl,
   ].join('|');
 
   if (cached?.key === key) return cached.group;
@@ -65,7 +60,7 @@ export function getScoreGroup(): PermissionlessGroup | undefined {
     liftERC20Address: cfg.liftERC20Address,
     backendBaseUrl: cfg.scoreGroupsBackendUrl,
     rpcUrl,
-    circlesConfig,
+    circlesConfig: cfg,
   });
   cached = { key, group };
   return group;

--- a/circles-app/src/routes/dashboard/+page.svelte
+++ b/circles-app/src/routes/dashboard/+page.svelte
@@ -104,8 +104,12 @@
         ($circlesBalances?.data?.length ?? 0) > 0 || ($circlesBalances?.ended ?? false),
     );
 
-    function openBalances() {
-        popupControls.open({ title: 'Balance breakdown', component: Balances, props: {} });
+    function openBalances(initialFilterType?: 'personal' | 'group') {
+        popupControls.open({
+            title: initialFilterType === 'group' ? 'Group balances' : initialFilterType === 'personal' ? 'Personal balances' : 'Balance breakdown',
+            component: Balances,
+            props: { initialFilterType },
+        });
     }
     function openSend() {
         openSendFlowPopup({ selectedAddress: undefined, amount: undefined, transitiveOnly: true });
@@ -185,7 +189,7 @@
 
             <!-- BIG NUMBER -->
             <button
-                onclick={openBalances}
+                onclick={() => openBalances()}
                 aria-label="Open balance breakdown"
                 class="btn-naked"
                 style="
@@ -208,12 +212,12 @@
                 {#if !balanceLoaded}
                     <span class="balance-skel" style="display:inline-block;width:200px;height:14px;background:rgba(15,10,30,0.06);border-radius:7px;"></span>
                 {:else}
-                <button onclick={openBalances} class="btn-naked" style="background:transparent;border:0;padding:0;cursor:pointer;display:flex;align-items:center;gap:6px;">
+                <button onclick={() => openBalances('personal')} class="btn-naked" style="background:transparent;border:0;padding:0;cursor:pointer;display:flex;align-items:center;gap:6px;">
                     <span style="width:6px;height:6px;border-radius:3px;background:{T.coral};display:inline-block;"></span>
                     <span style="font-size:13px;color:{T.inkBody};"><b style="color:{T.ink};">{personalToken}</b> people</span>
                 </button>
                 <span style="color:{T.inkFaint};">·</span>
-                <button onclick={openBalances} class="btn-naked" style="background:transparent;border:0;padding:0;cursor:pointer;display:flex;align-items:center;gap:6px;">
+                <button onclick={() => openBalances('group')} class="btn-naked" style="background:transparent;border:0;padding:0;cursor:pointer;display:flex;align-items:center;gap:6px;">
                     <span style="width:6px;height:6px;border-radius:3px;background:{T.primary};display:inline-block;"></span>
                     <span style="font-size:13px;color:{T.inkBody};"><b style="color:{T.ink};">{groupToken}</b> groups</span>
                 </button>


### PR DESCRIPTION
## Summary
Two small follow-ups to the reputation-gated minting feature, both display/config only.

## What changed
- **Group/people balance stats are now scoped.** Clicking the dashboard **"N people"** or **"N groups"** stat opens the balance breakdown filtered to that token type (personal vs group). `Balances` already supported an `initialFilterType` prop; the dashboard wasn't passing it, so both stats opened the same unfiltered list. The total-balance figure still opens the full breakdown.
- **Removed unused config env overrides.** Dropped `VITE_SCORE_GROUPS_BACKEND_URL` / `VITE_SCORE_GATED_GROUP_ADDRESS` / `VITE_SCORE_GROUPS_RPC_URL` and the `scoreGroupsRpcUrl` field. The score-group proof backend and group address are plain public constants, and the migration pathfinder uses `circlesRpcUrl` — so no per-deployment env wiring is needed.

## Verification
- `npm run check` — 0 errors.
- Branched off current `dev`; no deprecated envs remain; existing RPC config untouched.

## Notes
- A larger follow-up will add an event-level breakdown for mint/group-mint/wrap/unwrap/migration transactions (the history endpoint returns aggregated transfer summaries, so personal-vs-group mint isn't currently distinguishable in the list/detail).