### PR TITLE
fix(mint): route mintable stat through Mint popup; no error dialog on user rejection

### DIFF
--- a/circles-app/src/lib/shared/utils/errorHandler.ts
+++ b/circles-app/src/lib/shared/utils/errorHandler.ts
@@ -57,6 +57,25 @@ function isSilentError(message: string): boolean {
 }
 
 /**
+ * Detect an intentional wallet/user rejection — EIP-1193 code 4001, ethers v6
+ * `ACTION_REJECTED`, or the common rejection messages. These are cancellations,
+ * not failures, and must never surface an error dialog.
+ */
+export function isUserRejection(error: unknown): boolean {
+  const code = (error as { code?: unknown } | null | undefined)?.code;
+  if (code === 4001 || code === 'ACTION_REJECTED') return true;
+  const message = getErrorMessage(error).toLowerCase();
+  return (
+    message.includes('user rejected') ||
+    message.includes('user denied') ||
+    message.includes('rejected the request') ||
+    message.includes('request rejected') ||
+    message.includes('rejected by user') ||
+    message.includes('denied transaction')
+  );
+}
+
+/**
  * Get a user-friendly title based on error context
  */
 function getContextTitle(context: ErrorContext): string {

--- a/circles-app/src/lib/shared/utils/tasks.ts
+++ b/circles-app/src/lib/shared/utils/tasks.ts
@@ -1,4 +1,5 @@
 import { writable } from 'svelte/store';
+import { isUserRejection } from '$lib/shared/utils/errorHandler';
 
 export type Task<T> = {
   name: string;
@@ -69,6 +70,14 @@ export async function runTask<T>(task: Task<T>): Promise<T> {
     pushCompleted(task.name, result);
     return result;
   } catch (e) {
+    // A wallet/user rejection is an intentional cancellation, not a failure —
+    // never open the error dialog for it (this was throwing users to a blank
+    // "Error" screen after rejecting a signature). Re-throw so callers can react.
+    if (isUserRejection(e)) {
+      console.info(`Task cancelled by user: ${task.name}`);
+      throw e;
+    }
+
     console.error(`Task errored: ${task.name}`, e);
 
     if (e instanceof Error) {

--- a/circles-app/src/routes/dashboard/+page.svelte
+++ b/circles-app/src/routes/dashboard/+page.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
     import { avatarState } from '$lib/shared/state/avatar.svelte';
     import { roundToDecimals } from '$lib/shared/utils/shared';
-    import { executeTxConfirmFirst } from '$lib/shared/utils/txExecution';
-    import { isBenignReceiptDecodeError } from '$lib/shared/utils/tx';
 
     import OverviewPanel from './OverviewPanel.svelte';
     import TransactionRow from './TransactionRow.svelte';
@@ -14,7 +12,7 @@
     import Balances from '$lib/areas/wallet/ui/pages/Balances.svelte';
     import { circlesBalances } from '$lib/shared/state/circlesBalances';
     import { totalCirclesBalance } from '$lib/shared/state/totalCirclesBalance';
-    import { refreshTransactionHistory, transactionHistory, groupedTransactionHistory } from '$lib/shared/state/transactionHistory';
+    import { transactionHistory, groupedTransactionHistory } from '$lib/shared/state/transactionHistory';
     import { buildGroupOwnerSet } from '$lib/shared/utils/tokenClassification';
 
     import { openSendFlowPopup } from '$lib/areas/wallet/flows/send/openSendFlowPopup';
@@ -50,33 +48,6 @@
                 onMinted: (next: number) => { mintableAmount = next; },
             },
         });
-    }
-
-    async function mintPersonalCircles() {
-        const avatar = avatarState.avatar;
-        if (!(avatar instanceof HumanAvatar)) {
-            throw new Error('Avatar is not a HumanAvatar');
-        }
-
-        try {
-            await executeTxConfirmFirst({
-                name: 'Collecting CRC ...',
-                submit: () => avatar.personalToken.mint(),
-            });
-        } catch (error) {
-            if (!isBenignReceiptDecodeError(error)) {
-                throw error;
-            }
-            console.warn('Ignoring benign receipt decode error after successful mint transaction', error);
-        } finally {
-            const refreshed = await avatar.personalToken.getMintableAmount();
-            mintableAmount = refreshed?.amount ? parseFloat(ethers.formatEther(refreshed.amount)) : 0;
-        }
-
-        mintableAmount = 0;
-
-        // Refresh tx history so the mint appears immediately
-        refreshTransactionHistory();
     }
 
     // Match the dust filter in Balances.svelte so the count matches the breakdown
@@ -223,7 +194,7 @@
                 </button>
                 {#if mintableAmount >= 0.01}
                     <span style="color:{T.inkFaint};">·</span>
-                    <button onclick={mintPersonalCircles} class="btn-naked" style="background:transparent;border:0;padding:0;cursor:pointer;display:flex;align-items:center;gap:6px;">
+                    <button onclick={() => openMintPopup()} class="btn-naked" style="background:transparent;border:0;padding:0;cursor:pointer;display:flex;align-items:center;gap:6px;">
                         <span style="width:6px;height:6px;border-radius:3px;background:{T.sage};display:inline-block;"></span>
                         <span style="font-size:13px;color:{T.inkBody};">mintable <b style="color:{T.ink};">{roundToDecimals(mintableAmount)}</b></span>
                     </button>


### PR DESCRIPTION
## Summary
Two consistency/UX fixes around minting and wallet rejections.

## What changed
- **Consistent mint entry point.** The dashboard **"mintable N"** stat previously fired a *direct* personal-mint signature with no choice, while the **Mint** card opened the Mint popup. Both now open the **Mint popup** (personal mint + optional reputation mint). The unused direct-mint code path and its imports are removed.
- **No error dialog on rejection (global).** `runTask` opened the error dialog for *any* thrown error — including a user/wallet **rejection** — which dumped users onto a blank "Error" screen after declining a signature, on every flow (mint, send, trust, …). It now detects rejections (EIP-1193 `4001`, ethers `ACTION_REJECTED`, and "user rejected/denied" messages) via a new `isUserRejection()` helper and skips the dialog (still re-throws so callers can react).

## Verification
- `npm run check` — 0 errors.
- Branched off current `dev` (incl. #236, #238).