### PR TITLE
feat(dashboard): per-leg transaction breakdown + truthful history-row labels

### DIFF
--- a/circles-app/src/lib/shared/config/circles.ts
+++ b/circles-app/src/lib/shared/config/circles.ts
@@ -32,6 +32,14 @@ export type CirclesConfig = BaseCirclesConfig & {
    * Undefined → score-group minting is unavailable on this network.
    */
   scoreGatedGroupAddress?: string;
+  /**
+   * Migration sink contract that legacy-group CRC is routed through when
+   * migrating into the score group. Used only for display: a transaction whose
+   * counterparty resolves to this sink is a group migration, so the history row
+   * can label it as such and show the destination group instead of the faceless,
+   * profile-less sink. Undefined → no migration labeling on this network.
+   */
+  scoreGroupMigrationSink?: string;
 };
 
 export const chiadoConfig: { production: CirclesConfig; rings: CirclesConfig } =
@@ -134,6 +142,7 @@ export const gnosisConfig: { production: CirclesConfig; rings: CirclesConfig } =
       // pathfinder uses circlesRpcUrl, so no extra env wiring is needed.
       scoreGroupsBackendUrl: 'https://rpc.aboutcircles.com/score-groups',
       scoreGatedGroupAddress: '0x93eD5A96347927ff6fF6b790F8Cf5258240c321f',
+      scoreGroupMigrationSink: '0xD4cF9afd3aE777C24454b70dd28E32d1bd516F05',
     },
     rings: {
       circlesRpcUrl:

--- a/circles-app/src/lib/shared/utils/txBreakdown.ts
+++ b/circles-app/src/lib/shared/utils/txBreakdown.ts
@@ -1,0 +1,372 @@
+import { get } from 'svelte/store';
+import { CirclesConverter } from '@aboutcircles/sdk-utils';
+import { circles } from '$lib/shared/state/circles';
+import { isAddress, isZeroAddress, toBigIntMaybe, tokenIdToAddressMaybe } from '$lib/shared/utils/tx';
+
+/**
+ * Truthful "What happened" breakdown for a Circles transaction.
+ *
+ * The transaction-history RPC (`circles_getTransactionHistory…`) only returns AGGREGATED
+ * `CrcV2_TransferSummary` rows, which collapse personal mint + group mint + wrap + collateral +
+ * demurrage into a single `0x0 → you` summary. That is enough for a net number but hides what
+ * actually happened — especially for score-group mints and legacy-group migrations.
+ *
+ * The only RPC that exposes the granular event types is `circles_events`. It filters by
+ * (address + block range), not by tx hash, so we fetch all events in the tx's block for the
+ * avatar and then keep only the rows whose `transactionHash` matches.
+ *
+ * This is a pure ENHANCEMENT: if the fetch fails, the block is unknown, or nothing classifies,
+ * callers must fall back to the existing aggregated rendering. We never throw to the caller.
+ */
+
+/** A single raw `circles_events` row: `{ event, values }`. */
+interface RawCirclesEvent {
+    event: string;
+    values: Record<string, unknown>;
+}
+
+/**
+ * One classified leg of the breakdown. `amount` is in CRC (UI units, always positive);
+ * `sign` records whether it added to or subtracted from the avatar's holdings (or is neutral).
+ */
+export interface BreakdownLeg {
+    /** Human label, e.g. "Personal mint", "Group mint", "Wrapped", "Collateral", "Demurrage". */
+    label: string;
+    /** Positive CRC amount for the leg. */
+    amount: number;
+    /** Sign relative to the viewing avatar. */
+    sign: 'plus' | 'minus' | 'neutral';
+    /** Token contract address for this leg, if resolvable (for the small token avatar). */
+    tokenAddress: string | null;
+    /** Counterparty address to show alongside the leg, if meaningful (e.g. group, treasury). */
+    counterparty: string | null;
+    /** A stable-enough key for keyed `{#each}`. */
+    key: string;
+}
+
+/** Result of {@link buildTxBreakdown}. `kind` lets the UI title the section appropriately. */
+export interface TxBreakdown {
+    legs: BreakdownLeg[];
+    /** True when any leg routes through the migration SinkWrapper. */
+    isMigration: boolean;
+    /** True when a group-mint leg is present (score / standard group mint). */
+    isGroupMint: boolean;
+}
+
+// --- Verified Gnosis-mainnet protocol addresses (public). Used only to LABEL legs. ---
+// The migration sink is intentionally NOT hardcoded here — it is threaded in from the active
+// config (`scoreGroupMigrationSink`), the same field the list row reads, so the row label and
+// this breakdown share one source of truth and cannot drift if the deployed sink ever changes.
+const TREASURY = '0xe445f8b377f7689d2987920d51b8bba21b6241ce'; // parent treasury (collateral sink)
+const HUB_V2 = '0xc12c1e50abb450d6205ea2c3fa861b3b834d13e8';
+const LIFT_ERC20 = '0x5f99a795dd2743c36d63511f0d4bc667e6d3cdb5';
+
+// Inflationary ("static") wrapper deposit/withdraw events deal in static-circles atto units,
+// not demurraged atto-circles. Converting them with the demurraged converter still yields a
+// value of the right order of magnitude for display; the wrap label is what matters here.
+
+const lc = (v: unknown): string | null => (isAddress(v) ? String(v).toLowerCase() : null);
+
+/** Convert a raw value (hex string / decimal string / number / bigint) to CRC UI units. */
+function toCircles(val: unknown): number | null {
+    if (typeof val === 'number' && Number.isFinite(val)) {
+        return val;
+    }
+    const bi = toBigIntMaybe(val);
+    if (bi !== null) {
+        try {
+            const c = CirclesConverter.attoCirclesToCircles(bi);
+            return Number.isFinite(c) ? c : null;
+        } catch {
+            return null;
+        }
+    }
+    return null;
+}
+
+/** Accessors that tolerate both camelCase (`circles_events`) and PascalCase shapes. */
+const ev = {
+    type: (e: RawCirclesEvent): string => String(e.event ?? ''),
+    from: (e: RawCirclesEvent): unknown => e.values?.from ?? e.values?.From,
+    to: (e: RawCirclesEvent): unknown => e.values?.to ?? e.values?.To,
+    id: (e: RawCirclesEvent): unknown => e.values?.id ?? e.values?.Id,
+    value: (e: RawCirclesEvent): unknown =>
+        e.values?.value ?? e.values?.Value ?? e.values?.amount ?? e.values?.Amount,
+    account: (e: RawCirclesEvent): unknown => e.values?.account ?? e.values?.Account,
+    group: (e: RawCirclesEvent): unknown => e.values?.group ?? e.values?.Group,
+    cost: (e: RawCirclesEvent): unknown => e.values?.cost ?? e.values?.Cost,
+    txHash: (e: RawCirclesEvent): string =>
+        String(e.values?.transactionHash ?? e.values?.TransactionHash ?? ''),
+    blockNumber: (e: RawCirclesEvent): unknown => e.values?.blockNumber ?? e.values?.BlockNumber,
+};
+
+const tokenAddressOf = (e: RawCirclesEvent): string | null =>
+    tokenIdToAddressMaybe('id', ev.id(e)) ?? tokenIdToAddressMaybe('Id', ev.id(e)) ?? null;
+
+/**
+ * Fetch the granular `circles_events` for the tx's block, keep only the rows whose
+ * `transactionHash` matches `txHash` (case-insensitive). Returns `[]` on any failure.
+ *
+ * Call shape (verified against the prior raw integration):
+ *   circles_events(address, fromBlock, toBlock, eventTypes, filterPredicates, sortAscending, limit, cursor)
+ * The result is a plain array of `{ event, values }`; `values` carries camelCase keys with hex
+ * string numerics (`from`, `to`, `value`, `id`, `transactionHash`, `blockNumber`, …).
+ */
+export async function fetchTxEvents(
+    avatarAddress: string,
+    blockNumber: number,
+    txHash: string
+): Promise<RawCirclesEvent[]> {
+    if (!isAddress(avatarAddress) || !Number.isFinite(blockNumber) || blockNumber <= 0 || !txHash) {
+        return [];
+    }
+    const sdk = get(circles);
+    if (!sdk?.rpc?.client) {
+        return [];
+    }
+
+    // Only the RPC round-trip is an expected failure point (network/transport). A blip here is
+    // normal and falls back to the aggregated view, so swallow it. The deterministic response
+    // processing below is kept OUTSIDE the catch on purpose: a malformed response shape or a
+    // parsing defect should reject up to the caller (which logs it as a defect) rather than be
+    // silently mistaken for a transient network failure.
+    let raw: unknown;
+    try {
+        raw = await sdk.rpc.client.call<unknown[], unknown>('circles_events', [
+            avatarAddress,
+            blockNumber,
+            blockNumber,
+            null,
+            null,
+            true,
+            null,
+            null,
+        ]);
+    } catch (error) {
+        console.warn(
+            '[txBreakdown] circles_events fetch failed',
+            { avatarAddress, blockNumber, txHash },
+            error
+        );
+        return [];
+    }
+
+    const rows: unknown[] = Array.isArray(raw)
+        ? raw
+        : ((raw as { events?: unknown[]; results?: unknown[] })?.events ??
+          (raw as { events?: unknown[]; results?: unknown[] })?.results ??
+          []);
+
+    const wantHash = txHash.toLowerCase();
+    const out: RawCirclesEvent[] = [];
+    for (const r of rows) {
+        if (!r || typeof r !== 'object') {
+            continue;
+        }
+        const row = r as RawCirclesEvent;
+        if (!row.values || typeof row.values !== 'object') {
+            continue;
+        }
+        if (ev.txHash(row).toLowerCase() !== wantHash) {
+            continue;
+        }
+        out.push(row);
+    }
+    return out;
+}
+
+/**
+ * Resolve the block number for a tx from its already-inferred `item.events`.
+ * Those rows store `blockNumber` directly (decimal); fall back to scanning all of them.
+ */
+export function deriveBlockNumber(itemEvents: unknown): number | null {
+    if (!Array.isArray(itemEvents)) {
+        return null;
+    }
+    for (const e of itemEvents) {
+        if (!e || typeof e !== 'object') {
+            continue;
+        }
+        const bn = (e as { blockNumber?: unknown; BlockNumber?: unknown }).blockNumber
+            ?? (e as { blockNumber?: unknown; BlockNumber?: unknown }).BlockNumber;
+        const n = typeof bn === 'number' ? bn : Number(toBigIntMaybe(bn) ?? NaN);
+        if (Number.isFinite(n) && n > 0) {
+            return n;
+        }
+    }
+    return null;
+}
+
+/**
+ * Classify the granular events of ONE transaction into labeled legs, from the viewpoint of
+ * `avatarAddress`. Conservative by design: a leg that cannot be confidently classified is shown
+ * as a neutral transfer rather than mislabeled.
+ */
+export function buildTxBreakdown(
+    rawEvents: RawCirclesEvent[],
+    avatarAddress: string,
+    groupNameFor?: (address: string) => string | null,
+    migrationSink?: string | null
+): TxBreakdown {
+    const me = lc(avatarAddress);
+    // The migration sink comes from config (single source of truth). When absent (networks
+    // without score-group support), migration legs simply fall through to a neutral transfer.
+    const sink = migrationSink ? migrationSink.toLowerCase() : null;
+    const legs: BreakdownLeg[] = [];
+    let isMigration = false;
+    let isGroupMint = false;
+
+    // Pre-aggregate DiscountCost burns so we can label them "Demurrage": (account|id) -> atto cost.
+    const discountCost = new Map<string, bigint>();
+    for (const e of rawEvents) {
+        if (ev.type(e) !== 'CrcV2_DiscountCost') {
+            continue;
+        }
+        const acct = lc(ev.account(e));
+        const id = ev.id(e);
+        const cost = toBigIntMaybe(ev.cost(e));
+        if (!acct || id === undefined || cost === null) {
+            continue;
+        }
+        const key = `${acct}|${String(id)}`;
+        discountCost.set(key, (discountCost.get(key) ?? 0n) + cost);
+    }
+
+    const touchesSink = (a: string | null, b: string | null): boolean =>
+        sink !== null && (a === sink || b === sink);
+
+    let i = 0;
+    for (const e of rawEvents) {
+        const type = ev.type(e);
+        const from = lc(ev.from(e));
+        const to = lc(ev.to(e));
+        const tokenAddress = tokenAddressOf(e);
+        const key = `${type}|${i++}`;
+
+        if (type === 'CrcV2_PersonalMint') {
+            const amount = toCircles(ev.value(e));
+            if (amount && amount > 0) {
+                legs.push({ label: 'Personal mint', amount, sign: 'plus', tokenAddress, counterparty: null, key });
+            }
+            continue;
+        }
+
+        if (type === 'CrcV2_GroupMint') {
+            isGroupMint = true;
+            const groupRaw = lc(ev.group(e)) ?? to;
+            const amount = toCircles(ev.value(e));
+            const name = groupRaw && groupNameFor ? groupNameFor(groupRaw) : null;
+            if (amount && amount > 0) {
+                legs.push({
+                    label: name ? `Group mint (${name})` : 'Group mint',
+                    amount,
+                    sign: 'plus',
+                    tokenAddress,
+                    counterparty: groupRaw,
+                    key,
+                });
+            }
+            continue;
+        }
+
+        // Wrap (lift to ERC-20). Inflationary = static wrapper (s-gCRC), Demurraged = demurrage wrapper.
+        if (type === 'CrcV2_DepositInflationary' || type === 'CrcV2_DepositDemurraged') {
+            const amount = toCircles(ev.value(e));
+            if (amount && amount > 0) {
+                legs.push({ label: 'Wrapped', amount, sign: 'neutral', tokenAddress, counterparty: to, key });
+            }
+            continue;
+        }
+
+        // Unwrap (withdraw back to ERC-1155).
+        if (type === 'CrcV2_WithdrawInflationary' || type === 'CrcV2_WithdrawDemurraged') {
+            const amount = toCircles(ev.value(e));
+            if (amount && amount > 0) {
+                legs.push({ label: 'Unwrapped', amount, sign: 'neutral', tokenAddress, counterparty: from, key });
+            }
+            continue;
+        }
+
+        // Value-bearing transfers (ERC-1155 single / generic Transfer / wrapper transfer / burns).
+        const isTransferLike =
+            type === 'CrcV2_TransferSingle'
+            || type === 'CrcV2_Transfer'
+            || type === 'CrcV2_Erc20WrapperTransfer'
+            || type === 'CrcV2_GroupRedeemCollateralBurn'
+            || type === 'CrcV2_GroupRedeemCollateralReturn';
+
+        if (!isTransferLike) {
+            continue;
+        }
+        if (!from || !to || from === to) {
+            continue;
+        }
+
+        const amount = toCircles(ev.value(e));
+        if (!amount || amount <= 0) {
+            continue;
+        }
+
+        // Protocol demurrage burn: a burn to 0x0 whose value matches an aggregated DiscountCost.
+        if (isZeroAddress(to)) {
+            const id = ev.id(e);
+            const expected = id !== undefined ? discountCost.get(`${from}|${String(id)}`) : undefined;
+            const valueBi = toBigIntMaybe(ev.value(e));
+            if (expected !== undefined && valueBi !== null && expected === valueBi) {
+                legs.push({ label: 'Demurrage', amount, sign: 'minus', tokenAddress, counterparty: null, key });
+                continue;
+            }
+        }
+
+        // Migration: any leg involving the SinkWrapper.
+        if (touchesSink(from, to)) {
+            isMigration = true;
+            const sign: BreakdownLeg['sign'] = me && from === me ? 'minus' : me && to === me ? 'plus' : 'neutral';
+            legs.push({
+                label: 'Group migration',
+                amount,
+                sign,
+                tokenAddress,
+                counterparty: from === sink ? to : from,
+                key,
+            });
+            continue;
+        }
+
+        // Collateral: a transfer to the parent treasury (collateral sink) during a mint.
+        if (to === TREASURY) {
+            legs.push({ label: 'Collateral', amount, sign: 'minus', tokenAddress, counterparty: to, key });
+            continue;
+        }
+
+        // Plain burn (to 0x0) that is not a protocol-cost burn.
+        if (isZeroAddress(to)) {
+            legs.push({ label: 'Burned', amount, sign: 'minus', tokenAddress, counterparty: null, key });
+            continue;
+        }
+
+        // Skip housekeeping legs to/from the hub or lift contract (not user-meaningful on their own).
+        if (from === HUB_V2 || to === HUB_V2 || from === LIFT_ERC20 || to === LIFT_ERC20) {
+            continue;
+        }
+
+        // Plain transfer — label relative to the avatar; otherwise neutral.
+        let label = 'Transfer';
+        let sign: BreakdownLeg['sign'] = 'neutral';
+        let counterparty: string | null = null;
+        if (me && from === me) {
+            label = 'Sent';
+            sign = 'minus';
+            counterparty = to;
+        } else if (me && to === me) {
+            label = 'Received';
+            sign = 'plus';
+            counterparty = from;
+        } else {
+            counterparty = to;
+        }
+        legs.push({ label, amount, sign, tokenAddress, counterparty, key });
+    }
+
+    return { legs, isMigration, isGroupMint };
+}

--- a/circles-app/src/routes/dashboard/TransactionDetailsPopup.svelte
+++ b/circles-app/src/routes/dashboard/TransactionDetailsPopup.svelte
@@ -8,11 +8,20 @@
     import { CirclesConverter } from '@aboutcircles/sdk-utils';
     import { isAddress, isZeroAddress, toBigIntMaybe, tokenIdToAddressMaybe } from '$lib/shared/utils/tx';
     import TxEvents from './TxEvents.svelte';
+    import TxBreakdown from './TxBreakdown.svelte';
     import { annotationsByTx } from '$lib/shared/state/transferAnnotations';
     import { popupControls } from '$lib/shared/state/popup';
     import JumpPopup from '$lib/shared/ui/content/jump/JumpPopup.svelte';
     import { T } from '$lib/design-system/tokens.js';
     import Icon from '$lib/design-system/Icon.svelte';
+    import {
+        buildTxBreakdown,
+        deriveBlockNumber,
+        fetchTxEvents,
+        type BreakdownLeg,
+    } from '$lib/shared/utils/txBreakdown';
+    import { getProfile } from '$lib/shared/utils/profile';
+    import { getActiveConfig } from '$lib/shared/state/settings.svelte';
 
     interface Props { item: TransactionHistoryRow }
     let { item }: Props = $props();
@@ -109,6 +118,102 @@
             return [];
         }
     });
+
+    // --- Granular "What happened" breakdown (circles_events enhancement) ---
+    // The aggregated history RPC collapses personal mint + group mint + wrap + collateral +
+    // demurrage into one summary. circles_events exposes the granular legs; we fetch them for
+    // this tx's block and classify them. Purely additive: any failure falls back to the
+    // existing aggregated rendering below.
+    let breakdownLegs = $state<BreakdownLeg[]>([]);
+    let breakdownLoading = $state(false);
+    // group address (lowercase) -> resolved display name, for labeling group-mint legs.
+    let groupNames = $state<Map<string, string>>(new Map());
+
+    $effect(() => {
+        // Re-run whenever the viewed tx changes.
+        const txHash = item.transactionHash;
+        const me = avatarState.avatar?.address;
+        breakdownLegs = [];
+        groupNames = new Map();
+        if (!txHash || !me) {
+            return;
+        }
+        const block = deriveBlockNumber((item as ItemWithEvents)?.events);
+        if (block === null) {
+            return;
+        }
+
+        // Single source of truth for the migration sink: the active config (the list row reads
+        // the same field), so the row and this breakdown can never disagree on what's a migration.
+        const migrationSink = getActiveConfig().scoreGroupMigrationSink ?? null;
+
+        let cancelled = false;
+        breakdownLoading = true;
+        (async () => {
+            const raw = await fetchTxEvents(me, block, txHash);
+            if (cancelled) {
+                return;
+            }
+            const nameLookup = (addr: string): string | null =>
+                groupNames.get(addr.toLowerCase()) ?? null;
+            const result = buildTxBreakdown(raw, me, nameLookup, migrationSink);
+            if (cancelled) {
+                return;
+            }
+            // Only show the breakdown when it tells us more than the aggregated view —
+            // i.e. there is more than one leg, or a mint/migration we can label specially.
+            const worthShowing =
+                result.legs.length > 1 || result.isGroupMint || result.isMigration;
+            breakdownLegs = worthShowing ? result.legs : [];
+            breakdownLoading = false;
+
+            // Resolve group names asynchronously, then re-label the affected legs.
+            const groupAddrs = new Set<string>();
+            for (const leg of result.legs) {
+                if (leg.label.startsWith('Group mint') && leg.counterparty) {
+                    groupAddrs.add(leg.counterparty.toLowerCase());
+                }
+            }
+            for (const addr of groupAddrs) {
+                try {
+                    const profile = await getProfile(addr as `0x${string}`);
+                    if (cancelled || !profile?.name) {
+                        continue;
+                    }
+                    const next = new Map(groupNames);
+                    next.set(addr, profile.name);
+                    groupNames = next;
+                } catch {
+                    // Non-fatal: leave the generic "Group mint" label.
+                }
+            }
+            if (cancelled || groupAddrs.size === 0) {
+                return;
+            }
+            // Re-build with the now-resolved names so labels pick them up.
+            const relabeled = buildTxBreakdown(raw, me, nameLookup, migrationSink);
+            if (!cancelled) {
+                breakdownLegs = (relabeled.legs.length > 1 || relabeled.isGroupMint || relabeled.isMigration)
+                    ? relabeled.legs
+                    : [];
+            }
+        })().catch((error) => {
+            // fetchTxEvents never throws, so anything reaching here is an unexpected defect in
+            // the breakdown build / name resolution — surface it rather than dropping it silently.
+            console.error('[txBreakdown] breakdown effect failed', error);
+            if (!cancelled) {
+                breakdownLoading = false;
+            }
+        });
+
+        return () => {
+            cancelled = true;
+        };
+    });
+
+    const breakdownTitle = $derived(
+        breakdownLegs.some(l => l.label === 'Group migration') ? 'Group migration' : 'What happened'
+    );
 
     // Event accessors that work with both PascalCase (raw RPC events) and
     // camelCase (rows produced by transactionHistory.ts) shapes.
@@ -780,6 +885,17 @@
             </div>
         </div>
     </div>
+
+    {#if breakdownLegs.length}
+        <!-- Truthful per-leg breakdown from circles_events (mints, wraps, collateral, demurrage). -->
+        <TxBreakdown legs={breakdownLegs} title={breakdownTitle} />
+    {:else if breakdownLoading}
+        <div style="background:{T.surface};border:1px solid {T.hairlineSoft};border-radius:14px;padding:10px 14px;">
+            <span style="font-size:11px;color:{T.inkFaint};font-weight:600;letter-spacing:0.06em;text-transform:uppercase;">
+                Loading breakdown…
+            </span>
+        </div>
+    {/if}
 
     {#if aggregatedTransfers.length}
         <div style="background:{T.surface};border:1px solid {T.hairlineSoft};border-radius:14px;overflow:hidden;">

--- a/circles-app/src/routes/dashboard/TransactionRow.svelte
+++ b/circles-app/src/routes/dashboard/TransactionRow.svelte
@@ -8,6 +8,7 @@
     import { T } from '$lib/design-system/tokens.js';
     import TransactionDetailsPopup from './TransactionDetailsPopup.svelte';
     import { ZERO_ADDRESS } from '$lib/shared/utils/tx';
+    import { getActiveConfig } from '$lib/shared/state/settings.svelte';
     import { createKeyboardListNavigator } from '$lib/shared/ui/lists/utils/keyboardListNavigator';
     import {
         VIRTUAL_LIST_CONTEXT_KEY,
@@ -21,13 +22,44 @@
 
     const counterpartyAddress = $derived(item.counterparty?.toLowerCase() ?? null);
 
-    // "Collected CRC" should only show for an actual mint (you collected your own CRC),
-    // where the counterparty resolves to yourself. Keying it off `hasMint` (ANY mint event
-    // anywhere in the bundle) mislabels received path-transfers that merely contain a mint
-    // hop as "Collected CRC · <sender>", which is nonsensical. Use the semantic group type.
-    const topInfoText = $derived(item.type === 'mint' ? 'Collected CRC' : '');
+    // Score-group config (migration sink + destination group). Read once: the active
+    // network rarely changes within a row's lifetime and virtualized rows rebuild on
+    // data change. Both are undefined on networks without score-group support.
+    const cfg = getActiveConfig();
+    const migrationSink = cfg.scoreGroupMigrationSink?.toLowerCase() ?? null;
+    const scoreGroupAddress = cfg.scoreGatedGroupAddress?.toLowerCase() ?? null;
+
+    // A legacy-group migration routes CRC through the migration sink, which has no
+    // profile and otherwise renders as a faceless "shop" counterparty. Detect it from
+    // the sink appearing as the counterparty or in any leg, so the row can label it and
+    // show the destination group instead.
+    const isMigration = $derived.by(() => {
+        if (!migrationSink) return false;
+        if (counterpartyAddress === migrationSink) return true;
+        return item.events.some(
+            (e) => e.from?.toLowerCase() === migrationSink || e.to?.toLowerCase() === migrationSink
+        );
+    });
+
+    // For a migration, show the destination score group (a real, named avatar) rather
+    // than the profile-less sink the transfer technically routed through.
+    const avatarAddress = $derived(
+        isMigration && scoreGroupAddress ? scoreGroupAddress : counterpartyAddress
+    );
+
+    // Small label above the counterparty name. "Minted" is the honest umbrella for any
+    // mint — the aggregated history can't distinguish personal from group/score mint at
+    // the row level (the detail popup breaks that down via granular events). Keying off
+    // the semantic group `type` (not `hasMint`) avoids mislabeling received path-transfers
+    // that merely contain a mint hop.
+    const topInfoText = $derived.by(() => {
+        if (isMigration) return 'Group migration';
+        if (item.type === 'mint') return 'Minted';
+        return '';
+    });
 
     const badgeUrl = $derived.by(() => {
+        if (isMigration) return '/badge-mint.svg'; // migration mints the new group token
         if (item.type === 'mint') return '/badge-mint.svg';
         if (item.type === 'burn') return '/badge-burn.svg';
         if (item.type === 'send') return '/badge-sent.svg';
@@ -151,7 +183,7 @@
     data-list-row-focusable
     tabindex={0}
     role="button"
-    aria-label={`Open transaction details for ${counterpartyAddress}`}
+    aria-label={`Open transaction details for ${avatarAddress}`}
     class="tr-row focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
     style="
         display:flex;align-items:center;gap:12px;padding:12px 20px;
@@ -164,7 +196,7 @@
 >
     <div style="flex:1;min-width:0;">
         <Avatar
-            address={counterpartyAddress}
+            address={avatarAddress}
             view="horizontal"
             clickable={false}
             pictureOverlayUrl={badgeUrl ?? undefined}

--- a/circles-app/src/routes/dashboard/TxBreakdown.svelte
+++ b/circles-app/src/routes/dashboard/TxBreakdown.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+    import Avatar from '$lib/shared/ui/avatar/Avatar.svelte';
+    import Icon from '$lib/design-system/Icon.svelte';
+    import { T } from '$lib/design-system/tokens.js';
+    import type { BreakdownLeg } from '$lib/shared/utils/txBreakdown';
+
+    interface Props {
+        legs: BreakdownLeg[];
+        title?: string;
+    }
+    let { legs, title = 'What happened' }: Props = $props();
+
+    function formatAmount(v: number): string {
+        const abs = Math.abs(v);
+        if (Object.is(abs, 0)) {
+            return '0';
+        }
+        if (abs < 0.01) {
+            return '< 0.01';
+        }
+        return abs.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+    }
+
+    function signColor(sign: BreakdownLeg['sign']): string {
+        if (sign === 'plus') {
+            return T.positive;
+        }
+        if (sign === 'minus') {
+            return T.negative;
+        }
+        return T.ink;
+    }
+
+    function signPrefix(sign: BreakdownLeg['sign']): string {
+        if (sign === 'plus') {
+            return '+';
+        }
+        if (sign === 'minus') {
+            return '−';
+        }
+        return '';
+    }
+</script>
+
+{#if legs.length}
+    <div style="background:{T.surface};border:1px solid {T.hairlineSoft};border-radius:14px;overflow:hidden;">
+        <div style="padding:10px 14px;border-bottom:1px solid {T.hairlineSoft};">
+            <span style="font-size:11px;color:{T.inkMuted};font-weight:600;letter-spacing:0.06em;text-transform:uppercase;">
+                {title} <span style="color:{T.inkFaint};">({legs.length})</span>
+            </span>
+        </div>
+        {#each legs as leg, li (leg.key)}
+            <div style="padding:10px 14px;{li > 0 ? `border-top:1px solid ${T.hairlineSoft};` : ''}display:flex;align-items:center;gap:10px;">
+                <div style="flex:1;min-width:0;display:flex;flex-direction:column;gap:2px;">
+                    <span style="font-size:13px;font-weight:580;color:{T.inkBody};white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">
+                        {leg.label}
+                    </span>
+                    {#if leg.counterparty}
+                        <div style="display:flex;align-items:center;min-width:0;">
+                            <Avatar address={leg.counterparty} view="small" clickable={true} />
+                        </div>
+                    {/if}
+                </div>
+                <span style="flex-shrink:0;min-width:88px;text-align:right;font-size:13px;font-weight:580;color:{signColor(leg.sign)};font-variant-numeric:tabular-nums;white-space:nowrap;">
+                    {signPrefix(leg.sign)}{formatAmount(leg.amount)}<span style="color:{T.inkMuted};font-weight:540;margin-left:3px;">CRC</span>
+                </span>
+                <div style="flex-shrink:0;display:inline-flex;align-items:center;gap:6px;color:{T.inkMuted};width:26px;justify-content:flex-end;">
+                    {#if leg.tokenAddress}
+                        <Avatar address={leg.tokenAddress} view="small_no_text" clickable={true} />
+                    {:else}
+                        <div style="width:22px;height:22px;border-radius:9999px;background:{T.pageDeep};display:inline-flex;align-items:center;justify-content:center;">
+                            <Icon name="sparkle" size={11} stroke={T.inkMuted} />
+                        </div>
+                    {/if}
+                </div>
+            </div>
+        {/each}
+    </div>
+{/if}


### PR DESCRIPTION
## What

The transaction-history RPC returns only aggregated transfer summaries (one net line per transaction), collapsing personal mint + group mint + wrap + collateral + demurrage together. That makes mints and group migrations unreadable in the UI (e.g. a split mint shows only its net). This adds a granular, truthful breakdown and corrects the list-row labels.

- **New `utils/txBreakdown.ts`** — fetches `circles_events` (the only RPC exposing per-leg event types) for a transaction's block, filters by transaction hash, and classifies legs: personal mint, group mint, wrapped/unwrapped, collateral, group migration, demurrage, sent/received. Conservative: a leg it can't confidently classify renders as a neutral transfer rather than a wrong label.
- **New `dashboard/TxBreakdown.svelte`** — renders a "What happened" card; wired into the transaction-detail popup via a cancel-guarded effect that resolves group-mint names asynchronously. Purely additive: any fetch failure / unknown block / nothing-extra-to-show falls back to the existing aggregated rendering.
- **`TransactionRow.svelte`** — `"Collected CRC"` → `"Minted"` (the aggregated history can't distinguish personal from group mint at the row level); a transaction routed through the migration sink is labeled **"Group migration"** and shows the destination group instead of the profile-less sink.
- **`CirclesConfig`** — adds `scoreGroupMigrationSink` (gnosis) as the single source of truth for migration detection, shared by the row and the breakdown.

## Notes

- Non-blocking enhancement; the existing hero / aggregated-transfers / burns sections are untouched.
- `npm run check`: 0 errors.

## Test plan

- [ ] Open a personal-mint transaction → detail shows a "Personal mint" leg.
- [ ] Open a score-group split mint → breakdown lists personal mint, group mint, wrapped, collateral, demurrage; list row reads "Minted".
- [ ] Open a legacy-group migration → list row reads "Group migration" with the destination group avatar (not a generic icon); detail card titled "Group migration".
- [ ] A plain send/receive renders as before, with no spurious breakdown.
- [ ] Reject a mint signature → no blank error screen (regression guard).