### PR TITLE
feat(invites): inviter-side referral-link creation and dashboard

### DIFF
--- a/circles-app/src/lib/areas/invites/constants.ts
+++ b/circles-app/src/lib/areas/invites/constants.ts
@@ -1,0 +1,23 @@
+import { env } from '$env/dynamic/public';
+
+/**
+ * Base URL of the Circles wallet that hosts the referral-claim landing page.
+ *
+ * core-app only *creates* referral links — it has no `/referral/<key>` claim
+ * route of its own (claiming needs the passkey/account-abstraction flow that
+ * lives in the Gnosis wallet). Generated links therefore point at that wallet,
+ * where a brand-new person redeems the pre-generated account.
+ *
+ * Overridable via `PUBLIC_INVITE_WALLET_BASE_URL` so staging can repoint.
+ */
+export const INVITE_WALLET_BASE_URL =
+  env.PUBLIC_INVITE_WALLET_BASE_URL?.trim().replace(/\/+$/, '') ||
+  'https://app.gnosis.io';
+
+/**
+ * Build the shareable invite link for a referral private key. Matches the
+ * format the Gnosis wallet expects at `/referral/<key>`.
+ */
+export function buildReferralLink(privateKey: string): string {
+  return `${INVITE_WALLET_BASE_URL}/referral/${privateKey}?utm_campaign=referral`;
+}

--- a/circles-app/src/lib/areas/invites/data/canCreateInviteLinks.ts
+++ b/circles-app/src/lib/areas/invites/data/canCreateInviteLinks.ts
@@ -1,0 +1,18 @@
+import type { Avatar } from '@aboutcircles/sdk';
+import { isHumanAvatar } from '$lib/shared/utils/avatarHelpers';
+
+/**
+ * Whether an avatar can create invite links — a registered human (v2) avatar.
+ *
+ * Mirrors the intent of the `canInvite` guard, but works against the live
+ * avatar object we hold reactively in the UI (its `.avatarInfo` is an
+ * `AvatarRow`, which lacks `isHuman`, so we use the `isHumanAvatar` type guard
+ * instead). Organizations and groups cannot send invitations.
+ */
+export function canCreateInviteLinks(avatar: Avatar | undefined): boolean {
+  return (
+    !!avatar &&
+    isHumanAvatar(avatar) &&
+    (avatar.avatarInfo?.version ?? 0) === 2
+  );
+}

--- a/circles-app/src/lib/areas/invites/data/referralLinkStore.ts
+++ b/circles-app/src/lib/areas/invites/data/referralLinkStore.ts
@@ -1,0 +1,98 @@
+import type { Address } from '@aboutcircles/sdk-types';
+
+/**
+ * Local persistence for invite (referral) links created by this avatar.
+ *
+ * Why local: the referrals backend only returns *full* private keys to an
+ * authenticated caller (`Referrals.listMine`), and core-app has no Circles auth
+ * token. The public `listReferrals` returns masked key previews, which cannot
+ * rebuild a shareable link. So the keys we generate are the only place the full
+ * key lives client-side — we keep them here, keyed by inviter address.
+ *
+ * The keys are referral claim credentials for not-yet-funded accounts (by
+ * design embedded in the shared URL). They live only in localStorage at
+ * runtime — never log, commit, or fixture them.
+ */
+
+const STORAGE_KEY = 'Circles.InviteLinks';
+
+export interface StoredReferral {
+  /** Referral private key (the claim credential embedded in the shared link). */
+  privateKey: `0x${string}`;
+  /** ms epoch when the link was created locally. */
+  createdAt: number;
+  /** Whether the key has been persisted to the referrals backend yet. */
+  saved: boolean;
+}
+
+type Store = Record<string, StoredReferral[]>;
+
+function read(): Store {
+  if (typeof localStorage === 'undefined') return {};
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as Store) : {};
+  } catch {
+    return {};
+  }
+}
+
+function write(store: Store): void {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+  } catch (e) {
+    console.warn('[invites] failed to persist invite links', e);
+  }
+}
+
+function bucketKey(inviter: Address): string {
+  return inviter.toLowerCase();
+}
+
+/** All locally-stored links for an inviter, newest first. */
+export function loadReferrals(inviter: Address): StoredReferral[] {
+  const list = read()[bucketKey(inviter)] ?? [];
+  return [...list].sort((a, b) => b.createdAt - a.createdAt);
+}
+
+/** Persist a freshly-created link. No-op if the key is already stored. */
+export function addReferral(
+  inviter: Address,
+  privateKey: `0x${string}`,
+  opts?: { saved?: boolean },
+): void {
+  const store = read();
+  const k = bucketKey(inviter);
+  const list = store[k] ?? [];
+  if (list.some((r) => r.privateKey === privateKey)) return;
+  list.push({ privateKey, createdAt: Date.now(), saved: opts?.saved ?? false });
+  store[k] = list;
+  write(store);
+}
+
+/** Mark a key as successfully persisted to the referrals backend. */
+export function markSaved(inviter: Address, privateKey: `0x${string}`): void {
+  const store = read();
+  const list = store[bucketKey(inviter)];
+  const entry = list?.find((r) => r.privateKey === privateKey);
+  if (entry && !entry.saved) {
+    entry.saved = true;
+    write(store);
+  }
+}
+
+/** Drop a key (e.g. its creation transaction failed, so the link is dead). */
+export function removeReferral(inviter: Address, privateKey: `0x${string}`): void {
+  const store = read();
+  const k = bucketKey(inviter);
+  const list = store[k];
+  if (!list) return;
+  store[k] = list.filter((r) => r.privateKey !== privateKey);
+  write(store);
+}
+
+/** Links whose key never reached the backend (need a save retry). */
+export function getUnsavedReferrals(inviter: Address): StoredReferral[] {
+  return loadReferrals(inviter).filter((r) => !r.saved);
+}

--- a/circles-app/src/lib/areas/invites/data/referralService.ts
+++ b/circles-app/src/lib/areas/invites/data/referralService.ts
@@ -1,0 +1,80 @@
+import { get } from 'svelte/store';
+import type { Address } from '@aboutcircles/sdk-types';
+import { circles } from '$lib/shared/state/circles';
+import { getActiveConfig } from '$lib/shared/state/settings.svelte';
+import { getUnsavedReferrals, markSaved } from './referralLinkStore';
+
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+/** Lifecycle of a referral, as reported by the public referrals backend. */
+export type ReferralLifecycle =
+  | 'pending'
+  | 'stale'
+  | 'confirmed'
+  | 'claimed'
+  | 'expired';
+
+/** Subset of the SDK `ReferralInfo` we consume (kept structural to avoid
+ * importing the transitive `@aboutcircles/sdk-invitations` package). */
+export interface ReferralStatusInfo {
+  inviter?: string;
+  status?: ReferralLifecycle;
+  accountAddress?: string;
+  error?: string;
+}
+
+/**
+ * Whether referral links are deployed on the active network. Chiado and the
+ * rings environments carry a zero referrals-module address, so the feature is
+ * Gnosis-mainnet only today.
+ */
+export function referralsAvailable(): boolean {
+  const cfg = getActiveConfig();
+  return (
+    !!cfg.referralsServiceUrl &&
+    !!cfg.referralsModuleAddress &&
+    cfg.referralsModuleAddress.toLowerCase() !== ZERO_ADDRESS
+  );
+}
+
+function requireSdk() {
+  const sdk = get(circles);
+  if (!sdk) throw new Error('Circles SDK not initialised');
+  return sdk;
+}
+
+/**
+ * Persist a referral key to the referrals backend via the SDK's referrals
+ * client. `getReferralCode()` does NOT do this itself, and a link only resolves
+ * on the claim wallet once its key is stored — so this runs after the on-chain
+ * creation transaction (the backend validates the account exists on-chain).
+ */
+export async function saveReferral(
+  inviter: Address,
+  privateKey: `0x${string}`,
+): Promise<void> {
+  await requireSdk().referrals.store(privateKey, inviter);
+}
+
+/** Public status lookup for one referral key (no auth). */
+export async function getReferralStatus(
+  privateKey: string,
+): Promise<ReferralStatusInfo> {
+  return requireSdk().referrals.retrieve(privateKey);
+}
+
+/**
+ * Best-effort: re-save any locally-created keys that never reached the backend
+ * (created offline, or before the on-chain account was indexed). Recovers dead
+ * links on the next dashboard load.
+ */
+export async function retryUnsavedReferrals(inviter: Address): Promise<void> {
+  for (const r of getUnsavedReferrals(inviter)) {
+    try {
+      await saveReferral(inviter, r.privateKey);
+      markSaved(inviter, r.privateKey);
+    } catch (e) {
+      console.debug('[invites] retry save failed (will retry later)', e);
+    }
+  }
+}

--- a/circles-app/src/lib/areas/invites/flows/createInvite/CreateInviteLink.svelte
+++ b/circles-app/src/lib/areas/invites/flows/createInvite/CreateInviteLink.svelte
@@ -1,0 +1,130 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { get } from 'svelte/store';
+  import type { Address } from '@aboutcircles/sdk-types';
+  import { avatarState } from '$lib/shared/state/avatar.svelte';
+  import { isHumanAvatar } from '$lib/shared/utils/avatarHelpers';
+  import { circles } from '$lib/shared/state/circles';
+  import { totalCirclesBalance } from '$lib/shared/state/totalCirclesBalance';
+  import { executeTxConfirmFirst } from '$lib/shared/utils/txExecution';
+  import { replaceStep } from '$lib/shared/flow';
+  import {
+    addReferral,
+    markSaved,
+    removeReferral,
+  } from '../../data/referralLinkStore';
+  import { saveReferral } from '../../data/referralService';
+  import InviteLinkReady from './InviteLinkReady.svelte';
+  import { T } from '$lib/design-system/tokens.js';
+  import Icon from '$lib/design-system/Icon.svelte';
+  import ActionButton from '$lib/shared/ui/primitives/ActionButton.svelte';
+
+  // The invite fee is ~96 CRC; we refine it from-chain on mount.
+  const DEFAULT_FEE_CRC = 96;
+  let feeCrc = $state(DEFAULT_FEE_CRC);
+
+  onMount(async () => {
+    const avatar = avatarState.avatar;
+    if (!avatar || !isHumanAvatar(avatar)) return;
+    try {
+      const fee = await avatar.invitation.getInvitationFee();
+      if (fee && fee > 0n) feeCrc = Number(fee) / 1e18;
+    } catch (e) {
+      console.debug('[invites] could not load invitation fee, using default', e);
+    }
+  });
+
+  const insufficient = $derived($totalCirclesBalance < feeCrc);
+
+  async function createLink() {
+    const avatar = avatarState.avatar;
+    if (!avatar || !isHumanAvatar(avatar)) {
+      throw new Error('Only human Circles accounts can create invite links');
+    }
+    const sdk = get(circles);
+    if (!sdk?.contractRunner?.sendTransaction) {
+      throw new Error('Wallet is not ready to send transactions');
+    }
+    const inviter = avatar.address as Address;
+
+    const { transactions, privateKey } = await avatar.invitation.getReferralCode();
+    // Persist the key before sending so a crash mid-flow leaves it recoverable.
+    addReferral(inviter, privateKey, { saved: false });
+
+    try {
+      await executeTxConfirmFirst({
+        name: 'Creating invite link …',
+        submit: () => sdk.contractRunner!.sendTransaction!(transactions),
+        onSuccess: async () => {
+          try {
+            await saveReferral(inviter, privateKey);
+            markSaved(inviter, privateKey);
+          } catch (e) {
+            // The link is still recovered by retryUnsavedReferrals on next load.
+            console.warn('[invites] saveReferral deferred to retry', e);
+          }
+        },
+      });
+    } catch (e) {
+      // Creation transaction failed → no on-chain account, so the key is a dead
+      // link. Drop it so it never shows up as a shareable link.
+      removeReferral(inviter, privateKey);
+      throw e;
+    }
+
+    replaceStep({ title: '', component: InviteLinkReady, props: { privateKey } });
+  }
+</script>
+
+<div style="display:flex;flex-direction:column;gap:14px;">
+  <!-- Hero -->
+  <div style="display:flex;flex-direction:column;gap:4px;">
+    <span style="font-family:{T.fontDisplay};font-size:22px;color:{T.ink};letter-spacing:-0.015em;line-height:1.15;">
+      Create an invite link
+    </span>
+    <span style="font-size:12.5px;color:{T.inkMuted};line-height:1.5;">
+      Generate a link you can share with anyone. They join Circles with it — no wallet needed.
+    </span>
+  </div>
+
+  <!-- Cost card -->
+  <div style="
+    background:{T.surfaceAlt};border:1px solid {T.hairlineSoft};border-radius:14px;
+    padding:14px 16px;display:flex;flex-direction:column;gap:8px;
+  ">
+    <div style="display:flex;align-items:center;justify-content:space-between;gap:12px;">
+      <span style="font-size:13px;color:{T.inkBody};">Cost to create</span>
+      <span style="font-family:{T.fontDisplay};font-size:18px;color:{T.ink};letter-spacing:-0.01em;">≈ {feeCrc.toFixed(0)} CRC</span>
+    </div>
+    <div style="height:1px;background:{T.hairlineSoft};"></div>
+    <div style="display:flex;align-items:center;justify-content:space-between;gap:12px;">
+      <span style="font-size:12px;color:{T.inkMuted};">Your balance</span>
+      <span style="font-size:12.5px;font-weight:540;color:{insufficient ? T.negative : T.inkBody};">{$totalCirclesBalance.toFixed(2)} CRC</span>
+    </div>
+  </div>
+
+  <!-- Info row -->
+  <div style="display:flex;align-items:flex-start;gap:8px;padding:0 4px;">
+    <Icon name="info" size={13} stroke={T.inkMuted} style="flex-shrink:0;margin-top:2px;" />
+    <span style="font-size:12px;color:{T.inkMuted};line-height:1.5;">
+      When someone joins with your link, you earn a share of the Circles they create for their first year.
+    </span>
+  </div>
+
+  {#if insufficient}
+    <div style="display:flex;align-items:flex-start;gap:8px;padding:10px 12px;border-radius:12px;background:{T.negativeSoft};border:1px solid {T.hairlineSoft};">
+      <Icon name="info" size={13} stroke={T.negative} style="flex-shrink:0;margin-top:2px;" />
+      <span style="font-size:12px;color:{T.negative};line-height:1.5;">
+        You need at least {feeCrc.toFixed(0)} CRC to create an invite link.
+      </span>
+    </div>
+  {/if}
+
+  <!-- Action -->
+  <ActionButton
+    action={createLink}
+    disabled={insufficient}
+    style="width:100%;"
+    data-popup-default-action
+  >Create invite link</ActionButton>
+</div>

--- a/circles-app/src/lib/areas/invites/flows/createInvite/InviteLinkReady.svelte
+++ b/circles-app/src/lib/areas/invites/flows/createInvite/InviteLinkReady.svelte
@@ -1,0 +1,110 @@
+<script lang="ts">
+  import { popupControls } from '$lib/shared/state/popup';
+  import { buildReferralLink } from '../../constants';
+  import { T } from '$lib/design-system/tokens.js';
+  import Icon from '$lib/design-system/Icon.svelte';
+
+  interface Props {
+    privateKey: string;
+  }
+  let { privateKey }: Props = $props();
+
+  const link = $derived(buildReferralLink(privateKey));
+  const canShare = typeof navigator !== 'undefined' && typeof navigator.share === 'function';
+
+  let copied = $state(false);
+  let copyResetTimer: ReturnType<typeof setTimeout> | null = null;
+
+  async function copyLink() {
+    try {
+      await navigator.clipboard.writeText(link);
+      copied = true;
+      if (copyResetTimer) clearTimeout(copyResetTimer);
+      copyResetTimer = setTimeout(() => (copied = false), 2000);
+    } catch (e) {
+      console.warn('[invites] clipboard write failed', e);
+    }
+  }
+
+  async function shareLink() {
+    if (!canShare) {
+      await copyLink();
+      return;
+    }
+    try {
+      await navigator.share({
+        title: 'Join me on Circles',
+        text: 'I’d like to invite you to Circles. Use my link to join:',
+        url: link,
+      });
+    } catch {
+      // user dismissed the share sheet — not an error
+    }
+  }
+</script>
+
+<div style="display:flex;flex-direction:column;gap:14px;">
+  <!-- Hero -->
+  <div style="display:flex;flex-direction:column;gap:6px;align-items:center;text-align:center;padding-top:4px;">
+    <div style="width:44px;height:44px;border-radius:9999px;background:{T.sageSoft};display:flex;align-items:center;justify-content:center;">
+      <Icon name="check" size={22} stroke={T.positive} strokeWidth={2.2} />
+    </div>
+    <span style="font-family:{T.fontDisplay};font-size:22px;color:{T.ink};letter-spacing:-0.015em;line-height:1.15;">
+      Your invite link is ready
+    </span>
+    <span style="font-size:12.5px;color:{T.inkMuted};line-height:1.5;max-width:320px;">
+      Share it with someone new. They can join Circles with this link — no wallet required.
+    </span>
+  </div>
+
+  <!-- Link card -->
+  <div style="
+    background:{T.surfaceAlt};border:1px solid {T.hairlineSoft};border-radius:14px;
+    padding:14px 16px;display:flex;flex-direction:column;gap:8px;
+  ">
+    <span style="font-size:10.5px;font-weight:600;color:{T.inkMuted};letter-spacing:0.06em;text-transform:uppercase;">Invite link</span>
+    <span style="font-family:{T.fontMono};font-size:12px;color:{T.inkBody};word-break:break-all;line-height:1.5;">
+      {link}
+    </span>
+  </div>
+
+  <!-- Actions -->
+  <div style="display:flex;gap:8px;margin-top:2px;">
+    <button
+      onclick={copyLink}
+      style="
+        flex:1;height:42px;border-radius:12px;cursor:pointer;
+        background:{copied ? T.sageSoft : T.surface};border:1px solid {copied ? T.sage : T.hairline};
+        display:inline-flex;align-items:center;justify-content:center;gap:7px;
+        font-family:{T.fontSans};font-size:13px;font-weight:540;color:{copied ? T.positive : T.inkBody};
+      "
+    >
+      <Icon name={copied ? 'check' : 'copy'} size={15} stroke={copied ? T.positive : T.inkBody} />
+      {copied ? 'Copied' : 'Copy link'}
+    </button>
+    {#if canShare}
+      <button
+        onclick={shareLink}
+        style="
+          flex:1;height:42px;border-radius:12px;cursor:pointer;
+          background:{T.primary};border:0;color:#fff;
+          display:inline-flex;align-items:center;justify-content:center;gap:7px;
+          font-family:{T.fontSans};font-size:13px;font-weight:540;
+        "
+      >
+        <Icon name="share" size={15} stroke="#fff" />
+        Share
+      </button>
+    {/if}
+  </div>
+
+  <button
+    onclick={() => popupControls.close()}
+    data-popup-default-action
+    style="
+      width:100%;height:44px;border-radius:12px;cursor:pointer;margin-top:2px;
+      background:{T.surface};border:1px solid {T.hairline};
+      font-family:{T.fontSans};font-size:14px;font-weight:540;color:{T.inkBody};
+    "
+  >Done</button>
+</div>

--- a/circles-app/src/lib/areas/invites/flows/createInvite/openCreateInviteFlow.ts
+++ b/circles-app/src/lib/areas/invites/flows/createInvite/openCreateInviteFlow.ts
@@ -1,0 +1,12 @@
+import { openStep } from '$lib/shared/flow';
+import CreateInviteLink from './CreateInviteLink.svelte';
+
+/** Open the "create invite link" flow as a fresh popup. */
+export function openCreateInviteFlow(): void {
+  openStep({
+    title: 'Invite to Circles',
+    component: CreateInviteLink,
+    props: {},
+    key: 'create-invite-link',
+  });
+}

--- a/circles-app/src/lib/areas/invites/ui/pages/InviteLinks.svelte
+++ b/circles-app/src/lib/areas/invites/ui/pages/InviteLinks.svelte
@@ -1,0 +1,230 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import type { Address } from '@aboutcircles/sdk-types';
+  import { avatarState } from '$lib/shared/state/avatar.svelte';
+  import { popupState } from '$lib/shared/state/popup';
+  import { loadReferrals, type StoredReferral } from '../../data/referralLinkStore';
+  import {
+    getReferralStatus,
+    retryUnsavedReferrals,
+    referralsAvailable,
+    type ReferralLifecycle,
+  } from '../../data/referralService';
+  import { buildReferralLink } from '../../constants';
+  import { openCreateInviteFlow } from '../../flows/createInvite/openCreateInviteFlow';
+  import { T } from '$lib/design-system/tokens.js';
+  import Icon from '$lib/design-system/Icon.svelte';
+
+  let referrals = $state<StoredReferral[]>([]);
+  let statusByKey = $state<Record<string, ReferralLifecycle | undefined>>({});
+  const available = referralsAvailable();
+
+  function loadLocal() {
+    const inviter = avatarState.avatar?.address as Address | undefined;
+    referrals = inviter ? loadReferrals(inviter) : [];
+  }
+
+  async function syncStatuses() {
+    const inviter = avatarState.avatar?.address as Address | undefined;
+    if (!inviter || !available) return;
+    await retryUnsavedReferrals(inviter);
+    loadLocal(); // saved flags may have changed during retry
+    const next: Record<string, ReferralLifecycle | undefined> = { ...statusByKey };
+    await Promise.allSettled(
+      referrals.map(async (r) => {
+        try {
+          const info = await getReferralStatus(r.privateKey);
+          next[r.privateKey] = info.status;
+        } catch {
+          next[r.privateKey] = undefined; // not indexed yet / not found
+        }
+      }),
+    );
+    statusByKey = next;
+  }
+
+  onMount(() => {
+    loadLocal();
+    void syncStatuses();
+  });
+
+  // Refresh when a popup (e.g. the create flow) closes, so a newly-created link
+  // appears without a manual reload.
+  let prevPopupOpen = false;
+  $effect(() => {
+    const open = $popupState.content !== null;
+    if (prevPopupOpen && !open) {
+      loadLocal();
+      void syncStatuses();
+    }
+    prevPopupOpen = open;
+  });
+
+  function badge(status: ReferralLifecycle | undefined): {
+    label: string;
+    color: string;
+    bg: string;
+  } {
+    switch (status) {
+      case 'claimed':
+        return { label: 'Joined', color: T.positive, bg: T.positiveSoft };
+      case 'confirmed':
+        return { label: 'Account created', color: T.primaryDeep, bg: T.primarySoft };
+      case 'stale':
+      case 'expired':
+        return { label: 'Expired', color: T.inkMuted, bg: T.pageDeep };
+      case 'pending':
+      default:
+        return { label: 'Awaiting claim', color: T.warning, bg: T.warningSoft };
+    }
+  }
+
+  function formatDate(ms: number): string {
+    try {
+      return new Date(ms).toLocaleDateString(undefined, {
+        month: 'short',
+        day: 'numeric',
+      });
+    } catch {
+      return '';
+    }
+  }
+
+  const canShare = typeof navigator !== 'undefined' && typeof navigator.share === 'function';
+  let copiedKey = $state<string | null>(null);
+  let copyTimer: ReturnType<typeof setTimeout> | null = null;
+
+  async function copyRow(pk: string) {
+    try {
+      await navigator.clipboard.writeText(buildReferralLink(pk));
+      copiedKey = pk;
+      if (copyTimer) clearTimeout(copyTimer);
+      copyTimer = setTimeout(() => (copiedKey = null), 2000);
+    } catch (e) {
+      console.warn('[invites] clipboard write failed', e);
+    }
+  }
+
+  async function shareRow(pk: string) {
+    const url = buildReferralLink(pk);
+    if (canShare) {
+      try {
+        await navigator.share({
+          title: 'Join me on Circles',
+          text: 'I’d like to invite you to Circles. Use my link to join:',
+          url,
+        });
+      } catch {
+        // user dismissed the share sheet — not an error
+      }
+    } else {
+      await copyRow(pk);
+    }
+  }
+</script>
+
+<div style="background:{T.page};min-height:100%;width:100%;font-family:{T.fontSans};color:{T.inkBody};">
+  <div style="padding:8px 18px 24px;" class="md:!p-9 md:max-w-[860px] md:mx-auto">
+
+    <!-- Page title + primary action -->
+    <div style="display:flex;align-items:center;justify-content:space-between;padding:8px 0 14px;gap:12px;">
+      <div style="display:flex;flex-direction:column;gap:2px;min-width:0;">
+        <span style="font-family:{T.fontDisplay};font-size:32px;color:{T.ink};letter-spacing:-0.02em;line-height:1;font-weight:400;">Invite links</span>
+        <span style="font-size:12.5px;color:{T.inkMuted};">{referrals.length} {referrals.length === 1 ? 'link' : 'links'} created</span>
+      </div>
+      {#if available}
+        <button
+          onclick={openCreateInviteFlow}
+          style="
+            height:40px;padding:0 14px;border-radius:9999px;flex-shrink:0;
+            background:{T.primary};color:#fff;border:0;cursor:pointer;
+            display:inline-flex;align-items:center;gap:6px;
+            font-family:{T.fontSans};font-size:13.5px;font-weight:540;
+            box-shadow:0 1px 0 rgba(255,255,255,0.18) inset, 0 1px 2px rgba(15,10,30,0.12);
+          "
+        >
+          <Icon name="plus" size={15} stroke="#fff" strokeWidth={2.0} />
+          New link
+        </button>
+      {/if}
+    </div>
+
+    <!-- Intro / explainer -->
+    <div style="display:flex;align-items:flex-start;gap:8px;padding:12px 14px;border-radius:16px;background:{T.surface};border:1px solid {T.hairlineSoft};box-shadow:{T.shadow.xs};">
+      <Icon name="sparkle" size={15} stroke={T.primary} style="flex-shrink:0;margin-top:1px;" />
+      <span style="font-size:12.5px;color:{T.inkMuted};line-height:1.5;">
+        Share an invite link to bring someone new into Circles — no wallet required. They open it in the Circles wallet to join, and you earn a share of the Circles they create in their first year.
+      </span>
+    </div>
+
+    {#if !available}
+      <div style="margin-top:14px;background:{T.surface};border-radius:18px;border:1px solid {T.hairlineSoft};padding:32px 16px;text-align:center;">
+        <span style="font-size:13.5px;color:{T.inkMuted};">Invite links aren’t available on this network.</span>
+      </div>
+    {:else}
+      <!-- Section heading -->
+      <span style="display:block;font-size:11.5px;font-weight:600;color:{T.inkMuted};letter-spacing:0.06em;text-transform:uppercase;margin-top:18px;margin-bottom:8px;padding-left:4px;">
+        Your links
+      </span>
+
+      {#if referrals.length === 0}
+        <div style="background:{T.surface};border-radius:18px;border:1px solid {T.hairlineSoft};padding:32px 16px;text-align:center;display:flex;flex-direction:column;align-items:center;gap:12px;">
+          <div style="width:44px;height:44px;border-radius:9999px;background:{T.primarySoft};display:flex;align-items:center;justify-content:center;">
+            <Icon name="link" size={20} stroke={T.primary} />
+          </div>
+          <span style="font-size:13.5px;color:{T.inkMuted};">No invite links yet</span>
+          <button
+            onclick={openCreateInviteFlow}
+            style="
+              height:38px;padding:0 16px;border-radius:9999px;
+              background:{T.primary};color:#fff;border:0;cursor:pointer;
+              display:inline-flex;align-items:center;gap:6px;
+              font-family:{T.fontSans};font-size:13px;font-weight:540;
+            "
+          >
+            <Icon name="plus" size={14} stroke="#fff" strokeWidth={2.0} />
+            Create your first link
+          </button>
+        </div>
+      {:else}
+        <div style="background:{T.surface};border-radius:18px;border:1px solid {T.hairlineSoft};overflow:hidden;box-shadow:{T.shadow.xs};">
+          {#each referrals as r, i (r.privateKey)}
+            {@const b = badge(statusByKey[r.privateKey])}
+            <div style="display:flex;align-items:center;gap:12px;padding:14px 16px;{i > 0 ? `border-top:1px solid ${T.hairlineSoft};` : ''}">
+              <div style="width:36px;height:36px;border-radius:9999px;background:{T.primaryFaint};display:flex;align-items:center;justify-content:center;flex-shrink:0;">
+                <Icon name="link" size={16} stroke={T.primary} />
+              </div>
+              <div style="display:flex;flex-direction:column;gap:3px;flex:1;min-width:0;">
+                <div style="display:flex;align-items:center;gap:8px;">
+                  <span style="font-size:13.5px;font-weight:540;color:{T.ink};">Invite link</span>
+                  <span style="font-size:10.5px;font-weight:600;color:{b.color};background:{b.bg};padding:2px 8px;border-radius:9999px;">{b.label}</span>
+                </div>
+                <span style="font-size:11.5px;color:{T.inkMuted};">Created {formatDate(r.createdAt)}</span>
+              </div>
+              <div style="display:flex;align-items:center;gap:6px;flex-shrink:0;">
+                <button
+                  onclick={() => copyRow(r.privateKey)}
+                  aria-label="Copy invite link"
+                  title="Copy link"
+                  style="width:34px;height:34px;border-radius:9999px;background:{copiedKey === r.privateKey ? T.sageSoft : T.pageDeep};border:0;cursor:pointer;display:inline-flex;align-items:center;justify-content:center;"
+                >
+                  <Icon name={copiedKey === r.privateKey ? 'check' : 'copy'} size={15} stroke={copiedKey === r.privateKey ? T.positive : T.inkBody} />
+                </button>
+                <button
+                  onclick={() => shareRow(r.privateKey)}
+                  aria-label="Share invite link"
+                  title="Share link"
+                  style="width:34px;height:34px;border-radius:9999px;background:{T.primarySoft};border:0;cursor:pointer;display:inline-flex;align-items:center;justify-content:center;"
+                >
+                  <Icon name="share" size={15} stroke={T.primaryDeep} />
+                </button>
+              </div>
+            </div>
+          {/each}
+        </div>
+      {/if}
+    {/if}
+
+    <div style="height:24px;"></div>
+  </div>
+</div>

--- a/circles-app/src/lib/shared/ui/shell/AppSidebar.svelte
+++ b/circles-app/src/lib/shared/ui/shell/AppSidebar.svelte
@@ -12,16 +12,28 @@
     Sparkles as LSparkles,
     Info as LInfo,
     UserCircle as LUserCircle,
+    UserPlus as LUserPlus,
   } from 'lucide';
   import { popupControls } from '$lib/shared/state/popup';
+  import { canCreateInviteLinks } from '$lib/areas/invites/data/canCreateInviteLinks';
   import { T } from '$lib/design-system/tokens.js';
 
-  const NAV_ITEMS = [
-    { label: 'Wallet',   href: '/dashboard', icon: LWallet },
-    { label: 'Contacts', href: '/contacts',  icon: LUsers },
-    { label: 'Groups',   href: '/groups',    icon: LLayers },
-    { label: 'Market',   href: '/market',    icon: LShoppingBag },
-  ];
+  // "Invite" is only meaningful for human v2 avatars, so it's inserted
+  // conditionally rather than living in the static base list.
+  const NAV_ITEMS = $derived.by(() => {
+    const items = [
+      { label: 'Wallet',   href: '/dashboard', icon: LWallet },
+      { label: 'Contacts', href: '/contacts',  icon: LUsers },
+    ];
+    if (canCreateInviteLinks(avatarState.avatar)) {
+      items.push({ label: 'Invite', href: '/invites', icon: LUserPlus });
+    }
+    items.push(
+      { label: 'Groups', href: '/groups', icon: LLayers },
+      { label: 'Market', href: '/market', icon: LShoppingBag },
+    );
+    return items;
+  });
 
   function isActive(href: string): boolean {
     const p = $page.url.pathname;

--- a/circles-app/src/routes/contacts/+page.svelte
+++ b/circles-app/src/routes/contacts/+page.svelte
@@ -6,6 +6,7 @@
     import AvatarRowPlaceholder from '$lib/shared/ui/lists/placeholders/AvatarRowPlaceholder.svelte';
     import { derived, writable, type Writable } from 'svelte/store';
     import { avatarState } from '$lib/shared/state/avatar.svelte';
+    import { canCreateInviteLinks } from '$lib/areas/invites/data/canCreateInviteLinks';
     import { openAddTrustFlow } from '$lib/areas/trust/flows/addTrust/openAddTrustFlow';
     import { goto } from '$app/navigation';
     import { createListInputArrowDownHandler } from '$lib/shared/ui/lists/utils/listInputArrowDown';
@@ -232,6 +233,9 @@
     const titleText: string = $derived(avatarState.isGroup ? 'Members' : 'Contacts');
     const countLabel: string = $derived(avatarState.isGroup ? 'members' : 'in your network');
 
+    // Invite links are a human-v2 capability; offer the shortcut only there.
+    const canInviteHuman: boolean = $derived(canCreateInviteLinks(avatarState.avatar));
+
     const chips = $derived([
         { key: 'all',            label: 'All',         count: $trustCounts.total,     bg: T.pageDeep,    color: T.inkBody,     dot: T.inkMuted },
         { key: 'mutuallyTrusts', label: 'Mutual',      count: $trustCounts.mutual,    bg: T.sageSoft,    color: '#1F5E37',     dot: T.sage },
@@ -249,19 +253,35 @@
                 <span style="font-family:{T.fontDisplay};font-size:32px;color:{T.ink};letter-spacing:-0.02em;line-height:1;font-weight:400;">{titleText}</span>
                 <span style="font-size:12.5px;color:{T.inkMuted};">{avatarState.isGroup && groupMemberCount !== undefined ? groupMemberCount : $trustCounts.total} {countLabel}</span>
             </div>
-            <button
-                onclick={openAddContact}
-                style="
-                    height:40px;padding:0 14px;border-radius:9999px;
-                    background:{T.primary};color:#fff;border:0;cursor:pointer;
-                    display:inline-flex;align-items:center;gap:6px;
-                    font-family:{T.fontSans};font-size:13.5px;font-weight:540;
-                    box-shadow:0 1px 0 rgba(255,255,255,0.18) inset, 0 1px 2px rgba(15,10,30,0.12);
-                "
-            >
-                <Icon name="plus" size={15} stroke="#fff" strokeWidth={2.0} />
-                {avatarState.isGroup ? 'Add member' : 'Trust someone'}
-            </button>
+            <div style="display:flex;align-items:center;gap:8px;flex-shrink:0;">
+                {#if canInviteHuman}
+                    <button
+                        onclick={() => goto('/invites')}
+                        style="
+                            height:40px;padding:0 14px;border-radius:9999px;
+                            background:{T.surface};color:{T.inkBody};border:1px solid {T.hairline};cursor:pointer;
+                            display:inline-flex;align-items:center;gap:6px;
+                            font-family:{T.fontSans};font-size:13.5px;font-weight:540;
+                        "
+                    >
+                        <Icon name="link" size={15} stroke={T.inkBody} />
+                        Invite
+                    </button>
+                {/if}
+                <button
+                    onclick={openAddContact}
+                    style="
+                        height:40px;padding:0 14px;border-radius:9999px;
+                        background:{T.primary};color:#fff;border:0;cursor:pointer;
+                        display:inline-flex;align-items:center;gap:6px;
+                        font-family:{T.fontSans};font-size:13.5px;font-weight:540;
+                        box-shadow:0 1px 0 rgba(255,255,255,0.18) inset, 0 1px 2px rgba(15,10,30,0.12);
+                    "
+                >
+                    <Icon name="plus" size={15} stroke="#fff" strokeWidth={2.0} />
+                    {avatarState.isGroup ? 'Add member' : 'Trust someone'}
+                </button>
+            </div>
         </div>
 
         <!-- Search -->

--- a/circles-app/src/routes/invites/+page.svelte
+++ b/circles-app/src/routes/invites/+page.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import { avatarState } from '$lib/shared/state/avatar.svelte';
+  import { canCreateInviteLinks } from '$lib/areas/invites/data/canCreateInviteLinks';
+  import InviteLinks from '$lib/areas/invites/ui/pages/InviteLinks.svelte';
+  import { T } from '$lib/design-system/tokens.js';
+  import Icon from '$lib/design-system/Icon.svelte';
+
+  const inviteable = $derived(canCreateInviteLinks(avatarState.avatar));
+</script>
+
+{#if avatarState.avatar && inviteable}
+  <InviteLinks />
+{:else}
+  <div style="background:{T.page};min-height:100%;width:100%;font-family:{T.fontSans};display:flex;align-items:center;justify-content:center;padding:32px 18px;">
+    <div style="max-width:360px;text-align:center;display:flex;flex-direction:column;align-items:center;gap:14px;">
+      <div style="width:52px;height:52px;border-radius:9999px;background:{T.primarySoft};display:flex;align-items:center;justify-content:center;">
+        <Icon name="link" size={24} stroke={T.primary} />
+      </div>
+      {#if !avatarState.avatar}
+        <span style="font-family:{T.fontDisplay};font-size:22px;color:{T.ink};letter-spacing:-0.015em;">Connect your wallet</span>
+        <span style="font-size:13px;color:{T.inkMuted};line-height:1.5;">Connect a Circles account to create and share invite links.</span>
+        <a href="/" style="margin-top:4px;height:40px;padding:0 18px;border-radius:9999px;background:{T.primary};color:#fff;text-decoration:none;display:inline-flex;align-items:center;font-size:13.5px;font-weight:540;">Go to home</a>
+      {:else}
+        <span style="font-family:{T.fontDisplay};font-size:22px;color:{T.ink};letter-spacing:-0.015em;">Invites unavailable</span>
+        <span style="font-size:13px;color:{T.inkMuted};line-height:1.5;">Only human Circles accounts can create invite links.</span>
+        <a href="/dashboard" style="margin-top:4px;height:40px;padding:0 18px;border-radius:9999px;background:{T.primary};color:#fff;text-decoration:none;display:inline-flex;align-items:center;font-size:13.5px;font-weight:540;">Back to wallet</a>
+      {/if}
+    </div>
+  </div>
+{/if}


### PR DESCRIPTION
## Summary
Adds the inviter side of the Circles invitation flow: a human v2 avatar can generate a shareable invite link, track its status, and copy/share it. The link points at the Circles claim wallet, so brand-new users redeem it there — no claim page is added in this app.

## What changed
- **`/invites` dashboard** (`routes/invites/+page.svelte`, `areas/invites/ui/pages/InviteLinks.svelte`): lists the user's locally-stored links with live status (awaiting claim / account created / joined / expired) via the public referrals `retrieve` endpoint.
- **Create flow** (`areas/invites/flows/createInvite/*`): `avatar.invitation.getReferralCode()` → send the bundled setup+create transactions → persist the key via `sdk.referrals.store`. `getReferralCode()` does not persist the key itself, so it is stored client-side and re-saved on next load if a save was missed.
- **Link format** `https://app.gnosis.io/referral/<key>?utm_campaign=referral`; base overridable via `PUBLIC_INVITE_WALLET_BASE_URL`.
- **Gated entry points**: an "Invite" item in the sidebar and a button on the contacts header, shown only for human v2 avatars. Hidden on networks without a deployed referrals module.

## Notes
- No earnings display: the inviter reward accrues on-chain regardless of which app shows it; surfacing it would require an indexer this app does not use.
- Uses the SDK's public `sdk.referrals.*` surface rather than instantiating the transitive invitations package directly (avoids a phantom dependency).
- Optional manual check: open a generated link on the claim wallet to eyeball inviter resolution — implied by the "account created" status, which only appears once the key is stored on the backend.

## Test plan
- [x] `npm run check` — 0 errors
- [x] `npm run build` — passes
- [x] Create an invite link end-to-end on Gnosis mainnet → link generated, stored, persists with "account created" status on reload