### PR TITLE
fix(realtime): resolve deferred review findings on event-driven stores

### DIFF
--- a/circles-app/src/lib/shared/state/contacts/query/circlesContactsQueryStore.svelte.ts
+++ b/circles-app/src/lib/shared/state/contacts/query/circlesContactsQueryStore.svelte.ts
@@ -58,6 +58,12 @@ export async function createContactsQueryStore(
       // accumulates rows across pages and the subscriber merges them.
       let cursor: string | null = null;
       let exhausted = false;
+      // 1-based page ordinal, used as a STABLE per-page row key (via blockNumber). A fresh
+      // factory call on a trust event restarts at page 1, so the refreshed page-1 snapshot
+      // heals the existing page-1 row in place rather than appending a duplicate — and,
+      // unlike a wall-clock key, it can never collide when two refetches land in the same
+      // millisecond.
+      let pageIndex = 0;
 
       const fetchNextGroupPage = async (): Promise<CirclesQuery<ContactEventRow>> => {
         if (exhausted) {
@@ -94,7 +100,7 @@ export async function createContactsQueryStore(
         exhausted = !hasMore;
 
         const row: ContactEventRow = {
-          blockNumber: Date.now(),
+          blockNumber: ++pageIndex,
           transactionIndex: 0,
           logIndex: 0,
           data: enriched,
@@ -108,8 +114,13 @@ export async function createContactsQueryStore(
     const contacts = await trustDataSource.getAggregatedTrustRelations(address);
     const enrichedContacts = await enrichContactData(contacts, address, sdk);
 
+    // A single full-contact-list snapshot with a STABLE key (block 0): a fresh factory
+    // call on a trust event re-emits the same key, so _mergeData heals this one row in
+    // place — an added contact appears, an untrusted contact disappears live, and an
+    // unchanged list is a no-op (no flicker). A wall-clock key would instead append a new
+    // snapshot every event (unbounded growth, and an untrust never disappearing).
     const contactEventRow: ContactEventRow = {
-      blockNumber: Date.now(),
+      blockNumber: 0,
       transactionIndex: 0,
       logIndex: 0,
       data: enrichedContacts,

--- a/circles-app/src/lib/shared/state/query/circlesQueryStore.ts
+++ b/circles-app/src/lib/shared/state/query/circlesQueryStore.ts
@@ -53,19 +53,63 @@ export async function createCirclesQueryStore<T extends EventRow>(
   let circlesQuery = await circlesQueryFactory();
 
   /**
-   * Merges two arrays of event rows, ensuring no duplicates based on unique keys.
+   * Compares two rows by value to decide whether a same-key row needs healing. Runs only
+   * on a key collision (a re-fetched row already in the list), which for the current
+   * consumers is the single full-list contacts snapshot — never the paginated group/member
+   * rows, whose keys are distinct. JSON serialisation is the pragmatic deep-compare here;
+   * a non-serialisable row falls back to "changed" so a real correction is never swallowed.
+   */
+  function _rowsEqual(a: T, b: T): boolean {
+    if (a === b) return true;
+    try {
+      // bigint replacer: enriched contact rows can carry bigint fields (avatarInfo), which
+      // a bare JSON.stringify would throw on — handle them so equality (and the no-flicker
+      // path) still works instead of falling through to "changed" on every event. Wrap in
+      // an object (not a string) so a bigint 5n can never serialise equal to a string "5n".
+      const replacer = (_k: string, v: unknown) =>
+        typeof v === 'bigint' ? { __bigint: v.toString() } : v;
+      return JSON.stringify(a, replacer) === JSON.stringify(b, replacer);
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Merges new rows into the current list:
+   *  - a key not yet present is appended (pagination / a newly-trusted contact);
+   *  - a key already present whose content changed heals the existing row in place —
+   *    surfacing a correction, and (for the single-snapshot contacts store) letting an
+   *    untrust shrink the list live instead of leaving the stale row behind;
+   *  - when nothing was appended and nothing healed, the SAME array reference is returned
+   *    so the store re-emit is a no-op for keyed lists (no flicker / needless re-render).
+   * It never drops a key absent from `newData`, so the merge stays additive — a partial
+   * refetch can't blank already-loaded rows.
    *
    * @param {T[]} currentData - The current array of event rows.
    * @param {T[]} newData - The new array of event rows to be merged.
-   * @returns {T[]} - The merged array of event rows.
+   * @returns {T[]} - The merged array (or `currentData` unchanged when nothing changed).
    */
   function _mergeData(currentData: T[], newData: T[]): T[] {
-    const transactionKeys = new Set(
-      currentData.map((tx) => getKeyFromItem(tx))
-    );
-    return currentData.concat(
-      newData.filter((tx) => !transactionKeys.has(getKeyFromItem(tx)))
-    );
+    if (newData.length === 0) return currentData;
+
+    const indexByKey = new Map<string, number>();
+    currentData.forEach((tx, i) => indexByKey.set(getKeyFromItem(tx), i));
+
+    const appended: T[] = [];
+    const heals = new Map<number, T>();
+    for (const tx of newData) {
+      const idx = indexByKey.get(getKeyFromItem(tx));
+      if (idx === undefined) {
+        appended.push(tx);
+      } else if (!_rowsEqual(currentData[idx], tx)) {
+        heals.set(idx, tx);
+      }
+    }
+
+    if (appended.length === 0 && heals.size === 0) return currentData;
+    const base =
+      heals.size > 0 ? currentData.map((row, i) => heals.get(i) ?? row) : currentData;
+    return base.concat(appended);
   }
 
   /**
@@ -115,13 +159,11 @@ export async function createCirclesQueryStore<T extends EventRow>(
   ): Promise<T[]> {
     const refreshedQuery = await circlesQueryFactory();
     const updateQuery = refreshedQuery.rows || [];
-    const merged = _mergeData(currentData, updateQuery);
-    // _mergeData only ever appends new-key rows (it never rewrites an existing row), so an
-    // unchanged length means nothing was added. Return the same reference in that case so
-    // the store re-emit is a no-op for keyed lists — no flicker / needless re-render when
-    // no rows were added. (In-place corrections to an already-listed row are not surfaced
-    // here either way; that is pre-existing additive-merge behaviour, not changed here.)
-    return merged.length === currentData.length ? currentData : merged;
+    // _mergeData appends new-key rows, heals same-key rows whose content changed, and
+    // returns the SAME reference when neither happened — so an unchanged refetch is a
+    // no-op re-emit (no flicker) while a correction (or an untrust shrinking the single
+    // contacts snapshot) now surfaces instead of being silently dropped.
+    return _mergeData(currentData, updateQuery);
   }
 
   /**

--- a/circles-app/src/lib/shared/state/transactionHistory.ts
+++ b/circles-app/src/lib/shared/state/transactionHistory.ts
@@ -35,6 +35,24 @@ function parseNumericValue(raw: unknown): number {
 }
 
 /**
+ * Has any display-relevant field of an already-listed row been corrected by a re-fetch?
+ * `circles` (the amount) is the most common backfill, but a late-arriving event type,
+ * counterparty (from/to), operator, group or timestamp also changes how the row renders
+ * (its label, direction and grouping), so heal on any of them rather than amount alone.
+ */
+function rowChanged(a: ExtendedTransactionRow, b: ExtendedTransactionRow): boolean {
+  return (
+    a.circles !== b.circles ||
+    a.eventType !== b.eventType ||
+    a.from !== b.from ||
+    a.to !== b.to ||
+    a.operator !== b.operator ||
+    a.group !== b.group ||
+    a.timestamp !== b.timestamp
+  );
+}
+
+/**
  * Merge a freshly-fetched page 1 into the currently-displayed rows for a quiet
  * (event-driven or liveness) refresh, WITHOUT tearing the list down to a skeleton:
  *
@@ -66,8 +84,8 @@ function mergeLeadingPage(
     const existingIdx = indexByKey.get(keyOf(row));
     if (existingIdx === undefined) {
       newRows.push(row);
-    } else if (current[existingIdx].circles !== row.circles) {
-      heals.set(existingIdx, row); // amount correction to heal
+    } else if (rowChanged(current[existingIdx], row)) {
+      heals.set(existingIdx, row); // backfilled/corrected fields → heal in place
     }
   }
 
@@ -132,6 +150,15 @@ const refreshOnTxEvents = new Set<CirclesEventType>([
 ]);
 let txEventUnsubscribe: (() => void) | undefined;
 let txEventDebounceTimer: ReturnType<typeof setTimeout> | undefined;
+
+// Self-heal a failed `avatar.events.subscribe()`. A subscribe error while the websocket
+// still reports connected would not trip the disconnect-gated liveness poll, so the list
+// could otherwise stay frozen until a tab refocus. Retry a bounded number of times; if it
+// keeps failing, realtimeSync's visibility/online resync remains the final safety net.
+const TX_SUBSCRIBE_RETRY_MS = 2_000;
+const TX_SUBSCRIBE_MAX_RETRIES = 3;
+let txSubscribeRetries = 0;
+let txSubscribeRetryTimer: ReturnType<typeof setTimeout> | undefined;
 
 // Profile cache for enriched transaction participants
 const enrichedProfileCache = new Map<string, { name?: string; previewImageUrl?: string }>();
@@ -784,7 +811,7 @@ async function loadNextPage(opts?: { replace?: boolean }): Promise<boolean> {
  * reconnect hands out a fresh `avatar.events` observable and the previous one goes
  * silent, so the old subscription would otherwise never fire again.
  */
-function subscribeToTransactionEvents(avatar: Avatar): void {
+function subscribeToTransactionEvents(avatar: Avatar, opts?: { isRetry?: boolean }): void {
   if (txEventUnsubscribe) {
     txEventUnsubscribe();
     txEventUnsubscribe = undefined;
@@ -794,6 +821,17 @@ function subscribeToTransactionEvents(avatar: Avatar): void {
   if (txEventDebounceTimer) {
     clearTimeout(txEventDebounceTimer);
     txEventDebounceTimer = undefined;
+  }
+  // Cancel a pending retry from an earlier failed attempt — this (re)subscribe supersedes it.
+  if (txSubscribeRetryTimer) {
+    clearTimeout(txSubscribeRetryTimer);
+    txSubscribeRetryTimer = undefined;
+  }
+  // An externally-driven (re)subscribe — initial mount or a realtimeSync visibility/online/
+  // liveness rebind — is a fresh attempt, so restore the full fast-retry budget. Only the
+  // internal retry timer (isRetry) preserves the running count, so the burst stays bounded.
+  if (!opts?.isRetry) {
+    txSubscribeRetries = 0;
   }
   try {
     txEventUnsubscribe = avatar.events.subscribe((event: CirclesEvent) => {
@@ -808,10 +846,19 @@ function subscribeToTransactionEvents(avatar: Avatar): void {
         void loadTransferAnnotations(a, true);
       }, TX_EVENT_DEBOUNCE_MS);
     });
+    txSubscribeRetries = 0; // live again — reset the retry budget
   } catch (e) {
-    // Subscription failed: the list falls back to the realtimeSync liveness/visibility
-    // resync (which also rebinds here), so it degrades to poll-driven rather than frozen.
     console.error('[TxHistory] failed to subscribe to events', e);
+    // Don't degrade silently to poll-only: retry a bounded number of times so a connected
+    // socket whose subscribe call threw still recovers without waiting for a tab refocus.
+    if (txSubscribeRetries < TX_SUBSCRIBE_MAX_RETRIES) {
+      txSubscribeRetries++;
+      txSubscribeRetryTimer = setTimeout(() => {
+        txSubscribeRetryTimer = undefined;
+        const a = currentAvatar;
+        if (a) subscribeToTransactionEvents(a, { isRetry: true });
+      }, TX_SUBSCRIBE_RETRY_MS);
+    }
   }
 }
 
@@ -1018,4 +1065,43 @@ export async function refreshTransactionHistory(opts?: { quiet?: boolean }): Pro
 
   // Refetch from page 1
   await loadNextPage();
+}
+
+/**
+ * Tear down the realtime transaction subscription and reset module state on logout.
+ *
+ * The balance and contacts stores self-clean via their Svelte `readable` stop-callback
+ * when their last component subscriber unmounts, but this store holds its event
+ * subscription (and debounce/retry timers) at module scope, so it must be released
+ * explicitly — otherwise the old avatar's subscription and timers outlive the session.
+ * Clearing `currentAvatar`/`currentAvatarAddress` also lets a re-login (even to the same
+ * avatar) re-initialise cleanly past the dedup guard in `initTransactionHistoryStore`.
+ */
+export function teardownTransactionHistoryStore(): void {
+  if (txEventUnsubscribe) {
+    txEventUnsubscribe();
+    txEventUnsubscribe = undefined;
+  }
+  if (txEventDebounceTimer) {
+    clearTimeout(txEventDebounceTimer);
+    txEventDebounceTimer = undefined;
+  }
+  if (txSubscribeRetryTimer) {
+    clearTimeout(txSubscribeRetryTimer);
+    txSubscribeRetryTimer = undefined;
+  }
+  txSubscribeRetries = 0;
+  currentAvatar = null;
+  currentAvatarAddress = '';
+  isLoading = false;
+  nextCursor = null;
+  hasMore = true;
+  resetGroupedCache();
+  resetTransferAnnotations();
+  _transactionHistory.set({
+    data: [],
+    next: async () => false,
+    ended: false,
+    isLoading: false,
+  });
 }

--- a/circles-app/src/lib/shared/state/wallet.svelte.ts
+++ b/circles-app/src/lib/shared/state/wallet.svelte.ts
@@ -26,6 +26,7 @@ import { isHumanType, isGroupType, isOrganizationType } from '$lib/shared/utils/
 import { withRetry, isTransientError } from '$lib/shared/utils/retry';
 import { EoaBrowserRunner } from '$lib/shared/integrations/wallet/EoaBrowserRunner';
 import { clearAll as clearCache } from '$lib/shared/cache';
+import { teardownTransactionHistoryStore } from '$lib/shared/state/transactionHistory';
 
 export const wallet = writable<ContractRunner | undefined>();
 
@@ -398,7 +399,14 @@ export async function clearSession() {
   const connectorId = connectorState.id || localStorage.getItem('connectorId');
   const connector = getConnectors(config).find((c) => c.id == connectorId);
   if (connector) {
-    await disconnect(config, { connector: connector });
+    // A wallet/connector that rejects on disconnect must not abort the rest of teardown —
+    // otherwise the avatar's event subscription + timers (released below) would leak and a
+    // re-login could hit the dedup guard. Swallow the disconnect error and continue.
+    try {
+      await disconnect(config, { connector: connector });
+    } catch (e) {
+      console.warn('[Wallet] disconnect failed during clearSession; continuing teardown', e);
+    }
     localStorage.removeItem('connectorId');
   }
   // Reset connector state
@@ -431,6 +439,9 @@ export async function clearSession() {
     privateKey: undefined,
   });
   circles.set(undefined);
+  // The transaction-history store holds its event subscription + timers at module scope,
+  // so release them explicitly (the balance/contacts stores self-clean on unmount).
+  teardownTransactionHistoryStore();
   CirclesStorage.getInstance().clear();
   void clearCache();
   await goto('/');


### PR DESCRIPTION
Follow-up fixes to the event-subscribed transaction/trust history stores. Each item was previously deferred during review; this addresses all of them, plus three findings from an adversarial re-review.

## What changed

**Transaction history (`transactionHistory.ts`)**
- Quiet-refresh heal now triggers on any display-relevant field change (event type, from, to, operator, group, timestamp), not just the amount — a late indexer backfill keeps the row's label/direction correct.
- Bounded self-heal retry when `avatar.events.subscribe()` throws: a connected socket whose subscribe failed recovers without waiting for a tab refocus, instead of silently degrading to poll-only. The retry budget resets on every externally-driven rebind so the fast retry survives past the first reconnect; falls back to the existing liveness/visibility resync if it keeps failing.
- `teardownTransactionHistoryStore()` releases the module-scope event subscription and debounce/retry timers on logout (wired into `clearSession`), and resets state so re-login re-initialises cleanly past the dedup guard. The balance/contacts stores already self-clean via their readable stop-callback; this store's subscription is held at module scope and needed explicit release.

**Generic query store (`query/circlesQueryStore.ts`) — backs contacts + group list**
- The merge now heals same-key rows in place (was append-only) and returns the same array reference when nothing was appended or healed, so an unchanged refetch is a no-op re-emit (no flicker) while a correction surfaces instead of being dropped. Stays additive — a partial refetch never blanks already-loaded rows.
- `_rowsEqual` is a bigint-safe deep compare (object-wrapped bigints can't collide with string values).

**Contacts query store (`contacts/query/circlesContactsQueryStore.svelte.ts`)**
- The single full-list snapshot uses a stable key, so a trust event heals it in place: an added contact appears, an untrusted contact disappears live, an unchanged list is a no-op. Replaces a wall-clock key that appended a fresh snapshot every event (unbounded growth, untrust never disappearing).
- Group member pages use a 1-based page ordinal as their key — distinct per page (pagination still appends) and free of the prior same-millisecond `Date.now()` collision.

**Logout (`wallet.svelte.ts`)**
- Guard the wallet disconnect in `clearSession` so the store teardown always runs even when the connector rejects.

## Test plan
- [x] `npm run check` — 0 errors (28 pre-existing warnings)
- [x] `npm run build` — passes
- [x] `npm run test:run` — 205 unit tests pass
- [x] `npm run test:e2e` — 12 e2e tests pass
- [ ] Manual: logged-in session — incoming transaction appears live without manual refresh; no 15s flicker when data is unchanged; untrust on a personal contact list disappears live