### PR TITLE
fix(dashboard): accurate daily-net pill, dust-gated migration banner, collapsible tx breakdown

### DIFF
--- a/circles-app/src/lib/areas/minting/ui/MigrateLegacyGroupBanner.svelte
+++ b/circles-app/src/lib/areas/minting/ui/MigrateLegacyGroupBanner.svelte
@@ -39,6 +39,11 @@
   const fmt = (atto: bigint): number =>
     roundToDecimals(parseFloat(ethers.formatEther(atto)));
 
+  // Display rounds to 2 decimals, so a dust amount (e.g. 0.004 CRC) is > 0n yet renders
+  // as "0 CRC". Gate the banner on the ROUNDED value so it only appears when there is a
+  // real, non-dust amount to migrate — never a confusing "migrate 0 CRC" prompt.
+  const migratableCrc = $derived(fmt(migratable));
+
   onMount(() => {
     void check();
   });
@@ -108,7 +113,7 @@
   }
 </script>
 
-{#if checked && migratable > 0n && !done}
+{#if checked && migratableCrc >= 0.01 && !done}
   <div
     style="
       display:flex;align-items:center;gap:14px;flex-wrap:wrap;

--- a/circles-app/src/lib/shared/utils/txBreakdown.ts
+++ b/circles-app/src/lib/shared/utils/txBreakdown.ts
@@ -28,11 +28,17 @@ interface RawCirclesEvent {
 /**
  * One classified leg of the breakdown. `amount` is in CRC (UI units, always positive);
  * `sign` records whether it added to or subtracted from the avatar's holdings (or is neutral).
+ *
+ * A leg is normally an individual hop (`kind` omitted or `'leg'`). A `kind: 'group'` leg is a
+ * synthetic SUMMARY row standing in for a folded tail of minor flow legs: its `children` hold the
+ * folded legs and the UI renders it as an expandable "Transfers (N)" row. The summary sentinel is
+ * emitted inside `legs` (rather than as a separate return field) so the popup's existing
+ * `<TxBreakdown legs={…}>` contract keeps working without any change there.
  */
 export interface BreakdownLeg {
     /** Human label, e.g. "Personal mint", "Group mint", "Wrapped", "Collateral", "Demurrage". */
     label: string;
-    /** Positive CRC amount for the leg. */
+    /** Positive CRC amount for the leg (for a `group` leg this is the absolute net of children). */
     amount: number;
     /** Sign relative to the viewing avatar. */
     sign: 'plus' | 'minus' | 'neutral';
@@ -42,11 +48,25 @@ export interface BreakdownLeg {
     counterparty: string | null;
     /** A stable-enough key for keyed `{#each}`. */
     key: string;
+    /** Discriminator. Absent / `'leg'` = a normal hop; `'group'` = a collapsed summary row. */
+    kind?: 'leg' | 'group';
+    /** For `kind: 'group'`: the individual minor flow legs folded under this summary. */
+    children?: BreakdownLeg[];
 }
 
 /** Result of {@link buildTxBreakdown}. `kind` lets the UI title the section appropriately. */
 export interface TxBreakdown {
+    /**
+     * Ordered prominent legs for display. Semantic legs (mints / wrap / collateral / demurrage)
+     * come first in priority order, followed by prominent flow legs. When the flow tail is folded,
+     * the LAST entry is a synthetic `kind: 'group'` summary leg carrying the folded legs in
+     * `children` — the popup passes this array straight to `<TxBreakdown legs={…}>` unchanged.
+     */
     legs: BreakdownLeg[];
+    /** The folded minor flow legs (same legs as the summary's `children`); empty when nothing folds. */
+    minorLegs: BreakdownLeg[];
+    /** Signed CRC sum of `minorLegs` relative to the viewer (plus adds, minus subtracts). */
+    minorNet: number;
     /** True when any leg routes through the migration SinkWrapper. */
     isMigration: boolean;
     /** True when a group-mint leg is present (score / standard group mint). */
@@ -212,6 +232,7 @@ export function buildTxBreakdown(
     // The migration sink comes from config (single source of truth). When absent (networks
     // without score-group support), migration legs simply fall through to a neutral transfer.
     const sink = migrationSink ? migrationSink.toLowerCase() : null;
+    // Classified in raw chain order first; ordering + collapse happen afterwards.
     const legs: BreakdownLeg[] = [];
     let isMigration = false;
     let isGroupMint = false;
@@ -368,5 +389,102 @@ export function buildTxBreakdown(
         legs.push({ label, amount, sign, tokenAddress, counterparty, key });
     }
 
-    return { legs, isMigration, isGroupMint };
+    const { legs: orderedLegs, minorLegs, minorNet } = prioritizeAndCollapse(legs);
+    return { legs: orderedLegs, minorLegs, minorNet, isMigration, isGroupMint };
+}
+
+// --- Prioritisation + collapse ---------------------------------------------------------------
+// Semantic legs (the meaningful "what happened" steps) are shown first, in this priority order.
+// "Group mint" matches by prefix because the live label is `Group mint (Name)` once resolved.
+const SEMANTIC_ORDER = ['Personal mint', 'Group mint', 'Wrapped', 'Unwrapped', 'Collateral', 'Demurrage'];
+// Flow legs are the noisy multi-hop tail emitted by flow-matrix settlement.
+const FLOW_LABELS = new Set(['Sent', 'Received', 'Transfer', 'Burned', 'Group migration']);
+// Below this leg count everything is shown verbatim (a clean mint must never collapse).
+const COLLAPSE_THRESHOLD = 6;
+// When there are NO semantic legs (a plain multi-hop transfer), keep this many of the largest
+// flow legs prominent before folding the rest, so the headline hops stay visible.
+const MAX_PROMINENT_FLOW = 3;
+
+/** Priority index of a semantic label (prefix match for "Group mint"); -1 if not semantic. */
+function semanticRank(label: string): number {
+    for (let i = 0; i < SEMANTIC_ORDER.length; i++) {
+        const s = SEMANTIC_ORDER[i];
+        if (label === s || label.startsWith(`${s} (`)) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+const isSemantic = (leg: BreakdownLeg): boolean => semanticRank(leg.label) >= 0;
+const isFlow = (leg: BreakdownLeg): boolean => FLOW_LABELS.has(leg.label);
+
+/** Signed contribution of a leg to the viewer's net (plus adds, minus subtracts, neutral 0). */
+function signedAmount(leg: BreakdownLeg): number {
+    if (leg.sign === 'plus') {
+        return leg.amount;
+    }
+    if (leg.sign === 'minus') {
+        return -leg.amount;
+    }
+    return 0;
+}
+
+/**
+ * Order the prominent legs by importance and fold the long flow-matrix tail into one expandable
+ * summary leg. Rules:
+ *   • ≤ COLLAPSE_THRESHOLD legs → return them semantic-first, nothing folded.
+ *   • otherwise prominent = ALL semantic legs (semantic-first), plus — only when there are no
+ *     semantic legs at all — the largest MAX_PROMINENT_FLOW flow legs; everything else flow-typed
+ *     is folded into a trailing `kind: 'group'` summary leg ("Transfers (N)").
+ * Non-flow, non-semantic legs (should be rare) are always kept prominent so nothing meaningful is
+ * hidden behind the toggle.
+ */
+function prioritizeAndCollapse(rawLegs: BreakdownLeg[]): {
+    legs: BreakdownLeg[];
+    minorLegs: BreakdownLeg[];
+    minorNet: number;
+} {
+    const semantic = rawLegs.filter(isSemantic).sort((a, b) => semanticRank(a.label) - semanticRank(b.label));
+    const flow = rawLegs.filter((l) => !isSemantic(l) && isFlow(l));
+    const other = rawLegs.filter((l) => !isSemantic(l) && !isFlow(l));
+
+    // Small transactions stay fully expanded, just reordered semantic-first.
+    if (rawLegs.length <= COLLAPSE_THRESHOLD) {
+        return { legs: [...semantic, ...other, ...flow], minorLegs: [], minorNet: 0 };
+    }
+
+    // Keep some flow legs prominent only when there is nothing semantic to anchor the view.
+    let prominentFlow: BreakdownLeg[] = [];
+    let foldedFlow = flow;
+    if (semantic.length === 0) {
+        const byAmount = [...flow].sort((a, b) => b.amount - a.amount);
+        prominentFlow = byAmount.slice(0, MAX_PROMINENT_FLOW);
+        const keep = new Set(prominentFlow);
+        foldedFlow = flow.filter((l) => !keep.has(l));
+    }
+
+    // Nothing actually folds (e.g. only 1 flow leg over threshold) → behave like the small case.
+    if (foldedFlow.length <= 1) {
+        return { legs: [...semantic, ...other, ...prominentFlow, ...foldedFlow], minorLegs: [], minorNet: 0 };
+    }
+
+    const minorNet = foldedFlow.reduce((acc, l) => acc + signedAmount(l), 0);
+    const sign: BreakdownLeg['sign'] = minorNet > 1e-9 ? 'plus' : minorNet < -1e-9 ? 'minus' : 'neutral';
+    const summary: BreakdownLeg = {
+        label: `Transfers (${foldedFlow.length})`,
+        amount: Math.abs(minorNet),
+        sign,
+        tokenAddress: null,
+        counterparty: null,
+        key: `summary|${foldedFlow.length}`,
+        kind: 'group',
+        children: foldedFlow,
+    };
+
+    return {
+        legs: [...semantic, ...other, ...prominentFlow, summary],
+        minorLegs: foldedFlow,
+        minorNet,
+    };
 }

--- a/circles-app/src/routes/dashboard/+page.svelte
+++ b/circles-app/src/routes/dashboard/+page.svelte
@@ -12,7 +12,7 @@
     import Balances from '$lib/areas/wallet/ui/pages/Balances.svelte';
     import { circlesBalances } from '$lib/shared/state/circlesBalances';
     import { totalCirclesBalance } from '$lib/shared/state/totalCirclesBalance';
-    import { transactionHistory, groupedTransactionHistory } from '$lib/shared/state/transactionHistory';
+    import { groupedTransactionHistory } from '$lib/shared/state/transactionHistory';
     import { buildGroupOwnerSet } from '$lib/shared/utils/tokenClassification';
 
     import { openSendFlowPopup } from '$lib/areas/wallet/flows/send/openSendFlowPopup';
@@ -100,18 +100,22 @@
     }
 
     const todayNet: number = $derived.by(() => {
-        const avatar = avatarState.avatar?.address?.toLowerCase();
-        if (!avatar) return 0;
-        const rows = $transactionHistory?.data ?? [];
+        if (!avatarState.avatar?.address) return 0;
+        // Sum the NET of each GROUPED transaction today — never raw legs. Raw-leg summing
+        // double-counts conversions: a split mint / migration moves personal CRC into group
+        // CRC, which the individual legs record as outflows (collateral → treasury, wrap →
+        // ERC-20) WITHOUT crediting the group CRC received, so a value-neutral conversion
+        // looks like a large loss (the "−57 today" bug). The grouped net already nets each
+        // transaction's own legs and is exactly the per-row amount shown in the list, so the
+        // pill agrees with the rows below it.
+        const groups = $groupedTransactionHistory?.data ?? [];
         const startOfDay = new Date();
         startOfDay.setHours(0, 0, 0, 0);
         const startTs = Math.floor(startOfDay.getTime() / 1000);
         let net = 0;
-        for (const item of rows) {
-            if ((item.timestamp ?? 0) < startTs) continue;
-            const isSent = (item.from ?? '').toLowerCase() === avatar;
-            const amount = Math.abs(item.circles ?? 0);
-            net += isSent ? -amount : amount;
+        for (const g of groups) {
+            if ((g.timestamp ?? 0) < startTs) continue;
+            net += g.netCircles ?? 0;
         }
         return net;
     });

--- a/circles-app/src/routes/dashboard/TransactionDetailsPopup.svelte
+++ b/circles-app/src/routes/dashboard/TransactionDetailsPopup.svelte
@@ -126,6 +126,10 @@
     // existing aggregated rendering below.
     let breakdownLegs = $state<BreakdownLeg[]>([]);
     let breakdownLoading = $state(false);
+    // True when this tx routes through the migration sink. Tracked separately from the legs
+    // because migration hops are folded into the "Transfers (N)" summary's children, so the
+    // top-level legs array no longer carries a literal "Group migration" label to scan for.
+    let breakdownIsMigration = $state(false);
     // group address (lowercase) -> resolved display name, for labeling group-mint legs.
     let groupNames = $state<Map<string, string>>(new Map());
 
@@ -134,6 +138,7 @@
         const txHash = item.transactionHash;
         const me = avatarState.avatar?.address;
         breakdownLegs = [];
+        breakdownIsMigration = false;
         groupNames = new Map();
         if (!txHash || !me) {
             return;
@@ -165,6 +170,7 @@
             const worthShowing =
                 result.legs.length > 1 || result.isGroupMint || result.isMigration;
             breakdownLegs = worthShowing ? result.legs : [];
+            breakdownIsMigration = worthShowing && result.isMigration;
             breakdownLoading = false;
 
             // Resolve group names asynchronously, then re-label the affected legs.
@@ -193,9 +199,10 @@
             // Re-build with the now-resolved names so labels pick them up.
             const relabeled = buildTxBreakdown(raw, me, nameLookup, migrationSink);
             if (!cancelled) {
-                breakdownLegs = (relabeled.legs.length > 1 || relabeled.isGroupMint || relabeled.isMigration)
-                    ? relabeled.legs
-                    : [];
+                const relabeledWorth =
+                    relabeled.legs.length > 1 || relabeled.isGroupMint || relabeled.isMigration;
+                breakdownLegs = relabeledWorth ? relabeled.legs : [];
+                breakdownIsMigration = relabeledWorth && relabeled.isMigration;
             }
         })().catch((error) => {
             // fetchTxEvents never throws, so anything reaching here is an unexpected defect in
@@ -211,9 +218,9 @@
         };
     });
 
-    const breakdownTitle = $derived(
-        breakdownLegs.some(l => l.label === 'Group migration') ? 'Group migration' : 'What happened'
-    );
+    // Title off the builder's isMigration flag (computed from the raw legs before folding), not a
+    // label scan — migration hops are now folded into the "Transfers (N)" summary's children.
+    const breakdownTitle = $derived(breakdownIsMigration ? 'Group migration' : 'What happened');
 
     // Event accessors that work with both PascalCase (raw RPC events) and
     // camelCase (rows produced by transactionHistory.ts) shapes.

--- a/circles-app/src/routes/dashboard/TxBreakdown.svelte
+++ b/circles-app/src/routes/dashboard/TxBreakdown.svelte
@@ -7,8 +7,32 @@
     interface Props {
         legs: BreakdownLeg[];
         title?: string;
+        /** Optional pre-folded minor legs; normally the summary leg carries them in `children`. */
+        minorLegs?: BreakdownLeg[];
+        /** Optional signed net of the folded legs (unused when the summary leg carries its own). */
+        minorNet?: number;
     }
     let { legs, title = 'What happened' }: Props = $props();
+
+    // Each collapsed summary leg (kind === 'group') toggles independently. Keyed by leg.key.
+    let openGroups = $state<Set<string>>(new Set());
+    function isGroupOpen(key: string): boolean {
+        return openGroups.has(key);
+    }
+    function toggleGroup(key: string) {
+        const next = new Set(openGroups);
+        if (next.has(key)) {
+            next.delete(key);
+        } else {
+            next.add(key);
+        }
+        openGroups = next;
+    }
+
+    // Count of all rendered rows (individual legs + folded children) for the section header.
+    const totalRowCount = $derived(
+        legs.reduce((acc, l) => acc + (l.kind === 'group' ? (l.children?.length ?? 0) : 1), 0)
+    );
 
     function formatAmount(v: number): string {
         const abs = Math.abs(v);
@@ -42,38 +66,68 @@
     }
 </script>
 
+{#snippet legRow(leg: BreakdownLeg, withTopBorder: boolean)}
+    <div style="padding:10px 14px;{withTopBorder ? `border-top:1px solid ${T.hairlineSoft};` : ''}display:flex;align-items:center;gap:10px;">
+        <div style="flex:1;min-width:0;display:flex;flex-direction:column;gap:2px;">
+            <span style="font-size:13px;font-weight:580;color:{T.inkBody};white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">
+                {leg.label}
+            </span>
+            {#if leg.counterparty}
+                <div style="display:flex;align-items:center;min-width:0;">
+                    <Avatar address={leg.counterparty} view="small" clickable={true} />
+                </div>
+            {/if}
+        </div>
+        <span style="flex-shrink:0;min-width:88px;text-align:right;font-size:13px;font-weight:580;color:{signColor(leg.sign)};font-variant-numeric:tabular-nums;white-space:nowrap;">
+            {signPrefix(leg.sign)}{formatAmount(leg.amount)}<span style="color:{T.inkMuted};font-weight:540;margin-left:3px;">CRC</span>
+        </span>
+        <div style="flex-shrink:0;display:inline-flex;align-items:center;gap:6px;color:{T.inkMuted};width:26px;justify-content:flex-end;">
+            {#if leg.tokenAddress}
+                <Avatar address={leg.tokenAddress} view="small_no_text" clickable={true} />
+            {:else}
+                <div style="width:22px;height:22px;border-radius:9999px;background:{T.pageDeep};display:inline-flex;align-items:center;justify-content:center;">
+                    <Icon name="sparkle" size={11} stroke={T.inkMuted} />
+                </div>
+            {/if}
+        </div>
+    </div>
+{/snippet}
+
 {#if legs.length}
     <div style="background:{T.surface};border:1px solid {T.hairlineSoft};border-radius:14px;overflow:hidden;">
         <div style="padding:10px 14px;border-bottom:1px solid {T.hairlineSoft};">
             <span style="font-size:11px;color:{T.inkMuted};font-weight:600;letter-spacing:0.06em;text-transform:uppercase;">
-                {title} <span style="color:{T.inkFaint};">({legs.length})</span>
+                {title} <span style="color:{T.inkFaint};">({totalRowCount})</span>
             </span>
         </div>
         {#each legs as leg, li (leg.key)}
-            <div style="padding:10px 14px;{li > 0 ? `border-top:1px solid ${T.hairlineSoft};` : ''}display:flex;align-items:center;gap:10px;">
-                <div style="flex:1;min-width:0;display:flex;flex-direction:column;gap:2px;">
-                    <span style="font-size:13px;font-weight:580;color:{T.inkBody};white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">
+            {#if leg.kind === 'group'}
+                <!-- Collapsed flow-matrix tail: expandable summary row (same pattern as Burns). -->
+                <button
+                    type="button"
+                    style="width:100%;padding:10px 14px;{li > 0 ? `border-top:1px solid ${T.hairlineSoft};` : ''}background:{T.surfaceAlt};border-left:0;border-right:0;border-bottom:0;cursor:pointer;display:flex;align-items:center;justify-content:space-between;gap:10px;color:{T.inkMuted};"
+                    onclick={() => toggleGroup(leg.key)}
+                    aria-expanded={isGroupOpen(leg.key)}
+                    title={isGroupOpen(leg.key) ? 'Hide transfers' : 'Show transfers'}
+                >
+                    <span style="font-size:11px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;display:inline-flex;align-items:center;gap:6px;">
+                        <span style="display:inline-flex;transition:transform 0.15s;transform:rotate({isGroupOpen(leg.key) ? 90 : 0}deg);">
+                            <Icon name="arrowRight" size={11} stroke={T.inkMuted} />
+                        </span>
                         {leg.label}
                     </span>
-                    {#if leg.counterparty}
-                        <div style="display:flex;align-items:center;min-width:0;">
-                            <Avatar address={leg.counterparty} view="small" clickable={true} />
-                        </div>
-                    {/if}
-                </div>
-                <span style="flex-shrink:0;min-width:88px;text-align:right;font-size:13px;font-weight:580;color:{signColor(leg.sign)};font-variant-numeric:tabular-nums;white-space:nowrap;">
-                    {signPrefix(leg.sign)}{formatAmount(leg.amount)}<span style="color:{T.inkMuted};font-weight:540;margin-left:3px;">CRC</span>
-                </span>
-                <div style="flex-shrink:0;display:inline-flex;align-items:center;gap:6px;color:{T.inkMuted};width:26px;justify-content:flex-end;">
-                    {#if leg.tokenAddress}
-                        <Avatar address={leg.tokenAddress} view="small_no_text" clickable={true} />
-                    {:else}
-                        <div style="width:22px;height:22px;border-radius:9999px;background:{T.pageDeep};display:inline-flex;align-items:center;justify-content:center;">
-                            <Icon name="sparkle" size={11} stroke={T.inkMuted} />
-                        </div>
-                    {/if}
-                </div>
-            </div>
+                    <span style="flex-shrink:0;min-width:88px;text-align:right;font-size:13px;font-weight:580;color:{signColor(leg.sign)};font-variant-numeric:tabular-nums;white-space:nowrap;">
+                        {leg.sign === 'neutral' ? '' : signPrefix(leg.sign)}{formatAmount(leg.amount)}<span style="color:{T.inkMuted};font-weight:540;margin-left:3px;">CRC</span>
+                    </span>
+                </button>
+                {#if isGroupOpen(leg.key)}
+                    {#each leg.children ?? [] as child (child.key)}
+                        {@render legRow(child, true)}
+                    {/each}
+                {/if}
+            {:else}
+                {@render legRow(leg, li > 0)}
+            {/if}
         {/each}
     </div>
 {/if}


### PR DESCRIPTION
## Summary

Display-only follow-ups to the transaction breakdown work on the dashboard. No contract calls changed.

- **Daily-net pill accuracy.** `todayNet` summed raw transfer legs, which double-counted value-neutral conversions: a split mint / legacy-group migration moves personal CRC into group CRC, and the individual legs record the outflows (collateral → treasury, wrap → ERC-20) without crediting the group CRC received — so a neutral conversion read as a large loss. It now sums each *grouped* transaction's net, which already nets its own legs and equals the per-row amount shown in the list. The pill and the rows below it now agree.
- **Migration banner dust gate.** The banner appeared with "migrate 0 CRC" when only a dust amount was migratable (a `> 0n` wei value that rounds to 0 for display). It is now gated on the rounded value (`>= 0.01 CRC`), using the same rounding as the displayed amount, so it only shows for a real, non-dust amount.
- **Collapsible breakdown.** The per-leg "What happened" breakdown now keeps the semantic legs (personal/group mint, wrap/unwrap, collateral, demurrage) prominent in priority order and folds the long flow-matrix settlement tail into one expandable "Transfers (N)" summary row. Small transactions (≤ 6 legs) stay fully expanded.
- **Section title.** The breakdown title is now driven by the builder's migration flag instead of scanning the top-level legs for a "Group migration" label — those hops now fold into the summary, so the label scan would have regressed the title.

## Test plan

- [ ] `npm run check` — 0 errors (verified: 0 errors, 28 pre-existing warnings).
- [ ] Dashboard daily-net pill matches the sum of today's transaction rows (no phantom loss after a mint/migration).
- [ ] Migration banner hidden when nothing (or only dust) is migratable; shown with the correct amount otherwise.
- [ ] Transaction detail popup: a multi-hop mint/migration shows semantic legs on top + a collapsible "Transfers (N)"; a simple transfer/mint (≤ 6 legs) shows all legs uncollapsed.
- [ ] Migration transaction detail popup still titles the breakdown "Group migration".