### PR TITLE
fix(dashboard): cancel mint popup auto-close timer on unmount

### DIFF
--- a/circles-app/src/routes/dashboard/MintPopup.svelte
+++ b/circles-app/src/routes/dashboard/MintPopup.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onDestroy } from 'svelte';
   import { T } from '$lib/design-system/tokens.js';
   import Icon from '$lib/design-system/Icon.svelte';
   import { popupControls } from '$lib/shared/state/popup';
@@ -20,6 +21,11 @@
   let mintableAmount = $state(initialAmount);
   let isMinting = $state(false);
   let lastMintedAt: Date | null = $state(null);
+
+  // Tracked so it can be cancelled on unmount. An uncancelled timer would fire a
+  // popup mutation after the user has already dismissed this popup and possibly
+  // opened another — popping an unrelated entry or leaving a stale stack behind.
+  let autoCloseTimer: ReturnType<typeof setTimeout> | null = null;
 
   async function refreshMintable() {
     const avatar = avatarState.avatar;
@@ -45,12 +51,23 @@
     } finally {
       await refreshMintable();
       isMinting = false;
-      // Auto-close shortly after a successful mint
+      // Auto-close shortly after a successful mint that drained the mintable
+      // amount. Use close() (not back()): Mint is a terminal leaf opened from the
+      // dashboard root, so a full close returns to the dashboard and can never
+      // leave a stale stack entry behind. The handle is cancelled on unmount.
       if (mintableAmount < 0.01) {
-        setTimeout(() => popupControls.back(), 1200);
+        if (autoCloseTimer) clearTimeout(autoCloseTimer);
+        autoCloseTimer = setTimeout(() => {
+          autoCloseTimer = null;
+          popupControls.close();
+        }, 1200);
       }
     }
   }
+
+  onDestroy(() => {
+    if (autoCloseTimer) clearTimeout(autoCloseTimer);
+  });
 
   const displayAmount = $derived(roundToDecimals(mintableAmount));
   const lastMintLabel = $derived.by(() => {


### PR DESCRIPTION
## Summary

The mint popup auto-closes ~1.2s after a successful mint that drains the mintable amount. It did so via an **uncancelled** `setTimeout(() => popupControls.back(), 1200)`. Two problems:

1. **Orphaned timer.** If the user dismisses the popup by any other means (backdrop, Escape, header button) within the delay, the timer still fires after the component is gone. `popupControls.back()` then mutates whatever popup state exists at that moment — popping an unrelated popup that was opened in the meantime, or leaving the stack unbalanced.
2. **Wrong dismiss verb.** The header control acts as **Back** whenever the stack is non-empty, so a leftover stale stack entry makes the close button stop closing — presenting as a stuck, empty-looking popup.

## Changes

- Store the timer handle and `clearTimeout` it in `onDestroy`, so a popup dismissed early never fires a late stack mutation.
- Switch the auto-dismiss from `back()` to `close()`. The mint popup is a terminal leaf opened from the dashboard root, so a full close returns cleanly to the dashboard and can never leave a stale stack entry behind.
- Clear any prior pending timer before scheduling a new one (defensive against repeat scheduling).

## Test plan

- [ ] `npm run check` — 0 errors (verified: 0 errors, 28 pre-existing warnings).
- [ ] Mint until nothing is mintable → popup auto-closes after ~1.2s straight to the dashboard (no leftover/empty popup).
- [ ] Mint, then immediately dismiss the popup manually (backdrop / Escape / header) before the 1.2s elapses, and open another popup → the other popup is not yanked or left stuck.
- [ ] Header close button closes the mint popup in one tap (no back-to-empty behavior).