### PR TITLE
fix(receive,shell): full receive address + clearer copy; mobile access to environment info

### DIFF
--- a/circles-app/src/routes/DefaultHeader.svelte
+++ b/circles-app/src/routes/DefaultHeader.svelte
@@ -14,6 +14,7 @@
   import { avatarState } from '$lib/shared/state/avatar.svelte';
   import { canCreateInviteLinks } from '$lib/areas/invites/data/canCreateInviteLinks';
   import GlobalAvatarSearchPopup from '$lib/shared/ui/avatar-search/GlobalAvatarSearchPopup.svelte';
+  import EnvironmentInfoPopup from '$lib/shared/ui/shell/EnvironmentInfoPopup.svelte';
   import {
     basketCount,
     ensureBasketCountSubscription,
@@ -27,6 +28,13 @@
       dismiss: 'backdrop',
       component: GlobalAvatarSearchPopup,
     });
+  }
+
+  // The desktop AppSidebar footer hosts the environment info; on mobile that sidebar is
+  // hidden, so expose the same popup from the header menu.
+  function openEnvInfo(): void {
+    closeMenu();
+    popupControls.open({ title: 'Environment', component: EnvironmentInfoPopup, props: {} });
   }
 
   const isMarketPage = $derived($page.url.pathname.startsWith('/market'));
@@ -188,6 +196,16 @@
       <li><a class="defaultheader-link" href="/terms">Terms of use</a></li>
       <li>
         <a class="defaultheader-link" href="/privacy-policy">Privacy policy</a>
+      </li>
+      <li>
+        <button
+          class="defaultheader-link"
+          type="button"
+          style="width:100%;text-align:left;background:transparent;border:0;cursor:pointer;"
+          onclick={openEnvInfo}
+        >
+          Environment
+        </button>
       </li>
       {#if dev}
         <li><a class="defaultheader-link" href="/kitchen-sink">Kitchen sink</a></li>

--- a/circles-app/src/routes/dashboard/ReceivePopup.svelte
+++ b/circles-app/src/routes/dashboard/ReceivePopup.svelte
@@ -5,7 +5,6 @@
     import { T } from '$lib/design-system/tokens.js';
 
     const address = $derived(avatarState.avatar?.address ?? '');
-    const shortAddr = $derived(address ? `${address.slice(0, 6)}…${address.slice(-4)}` : '');
     const displayName = $derived(avatarState.profile?.name ?? 'My Wallet');
 
     let copied = $state(false);
@@ -55,7 +54,7 @@
         ">
             <div style="display:flex;flex-direction:column;gap:1px;flex:1;min-width:0;">
                 <span style="font-size:10.5px;font-weight:600;color:{T.inkMuted};letter-spacing:0.06em;text-transform:uppercase;">Wallet address</span>
-                <span style="font-family:{T.fontMono};font-size:12.5px;color:{T.ink};font-weight:540;">{shortAddr}</span>
+                <span style="font-family:{T.fontMono};font-size:12.5px;color:{T.ink};font-weight:540;word-break:break-all;line-height:1.4;">{address}</span>
             </div>
             <button
                 type="button"
@@ -95,7 +94,7 @@
     <div style="display:flex;align-items:flex-start;gap:8px;padding:0 2px;">
         <Icon name="info" size={13} stroke={T.inkMuted} style="flex-shrink:0;margin-top:2px;" />
         <span style="font-size:11.5px;color:{T.inkMuted};line-height:1.5;">
-            Receiving CRC requires a trust path. People without trust can still scan to <b style="color:{T.inkBody};">start one</b>.
+            Receiving CRC requires a trust path. Someone who doesn't trust you yet can scan this code to <b style="color:{T.inkBody};">set up a trust connection</b>.
         </span>
     </div>
 </div>


### PR DESCRIPTION
- **Receive popup:** show the full wallet address (was truncated `0x…1234`) — the row has the width — and replace the ambiguous trust-path copy ("…scan to **start one**") with "…scan this code to **set up a trust connection**".
- **Mobile access to environment info:** the environment popup added in #247/#251 was only reachable from the desktop `AppSidebar` footer, which is `hidden md:flex` (desktop-only). Added an "Environment" item to the mobile header (`DefaultHeader`) hamburger menu so the same info (network, realtime status, RPC, contracts, build) is reachable on mobile.

## Test plan
- [x] `npm run check` — 0 errors
- [x] `npm run build` — passes
- [x] `npm run test:run` — unit
- [x] `npm run test:e2e` — 12 e2e
- [ ] Live (mobile width): header menu → Environment opens the popup
- [ ] Live: Receive popup shows the full address and the clearer copy