### PR TITLE
feat(dashboard): economic insights — marketplace spend + /insights drill-down

### DIFF
--- a/circles-app/src/lib/shared/data/circles/paymentReceived.ts
+++ b/circles-app/src/lib/shared/data/circles/paymentReceived.ts
@@ -57,16 +57,39 @@ export function formatCrcAmount(amountWei: bigint | string): string {
 }
 
 /**
- * Fetch all PaymentReceived events for a given payee address.
- * Public, no auth required. Mirrors marketplaceExplorer.html:1151-1154.
+ * Fetch all PaymentReceived events for a given payee address (the SELLER side — what
+ * this address has been paid). Public, no auth required.
  */
 export async function fetchPaymentsByPayee(
   sdk: Sdk,
   payee: string,
   limit: number = 200
 ): Promise<PaymentRow[]> {
-  if (!sdk?.rpc || !payee) return [];
-  if (!ethers.isAddress(payee)) return [];
+  return fetchPaymentsByColumn(sdk, 'payee', payee, limit);
+}
+
+/**
+ * Fetch all PaymentReceived events for a given payer address (the BUYER side — what this
+ * address has spent through payment gateways / the marketplace). Same table, filtered on
+ * `payer` instead of `payee`. Public, no auth required.
+ */
+export async function fetchPaymentsByPayer(
+  sdk: Sdk,
+  payer: string,
+  limit: number = 200
+): Promise<PaymentRow[]> {
+  return fetchPaymentsByColumn(sdk, 'payer', payer, limit);
+}
+
+/** Shared PaymentReceived fetch, filtered on a single address column (`payer` or `payee`). */
+async function fetchPaymentsByColumn(
+  sdk: Sdk,
+  column: 'payer' | 'payee',
+  address: string,
+  limit: number
+): Promise<PaymentRow[]> {
+  if (!sdk?.rpc || !address) return [];
+  if (!ethers.isAddress(address)) return [];
 
   const resp: RpcQueryResult = await sdk.rpc.client.call('circles_query', [
     {
@@ -77,8 +100,8 @@ export async function fetchPaymentsByPayee(
         {
           Type: 'FilterPredicate',
           FilterType: 'Equals',
-          Column: 'payee',
-          Value: payee.toLowerCase(),
+          Column: column,
+          Value: address.toLowerCase(),
         },
       ],
       Order: [{ Column: 'blockNumber', SortOrder: 'DESC' }],
@@ -108,6 +131,11 @@ export async function fetchPaymentsByPayee(
       const gwRaw = r[idxGw];
       if (!payerRaw || !payeeRaw || !gwRaw) continue;
 
+      // A missing/zero timestamp would render as garbage ("56 years ago") and sort to the
+      // top of any window list — drop it like the flow engine drops timestamp-less legs.
+      const timestamp = Number(r[idxTs] ?? 0);
+      if (!(timestamp > 0)) continue;
+
       const data = String(r[idxData] ?? '');
       let amount: bigint = 0n;
       try {
@@ -123,7 +151,7 @@ export async function fetchPaymentsByPayee(
         amount,
         data,
         dataDecoded: hexToUtf8(data),
-        timestamp: Number(r[idxTs] ?? 0),
+        timestamp,
         tx: String(r[idxTx] ?? ''),
         blockNumber: Number(r[idxBn] ?? 0),
       });

--- a/circles-app/src/lib/shared/state/gatewaySpending.svelte.ts
+++ b/circles-app/src/lib/shared/state/gatewaySpending.svelte.ts
@@ -1,0 +1,163 @@
+import { get, writable } from 'svelte/store';
+import type { Avatar } from '@aboutcircles/sdk';
+import { circles } from '$lib/shared/state/circles';
+import {
+  fetchPaymentsByPayer,
+  type PaymentRow,
+} from '$lib/shared/data/circles/paymentReceived';
+
+/**
+ * Marketplace / payment-gateway SPENDING (buyer side).
+ *
+ * One avatar-scoped fetch of every `PaymentReceived` event where the active avatar is the
+ * `payer`, shared by two consumers:
+ *   - DashboardSpendingCard — time-horizon spend totals.
+ *   - TransactionRow — labels a gateway payment "Marketplace" and shows the SELLER (payee)
+ *     instead of the faceless gateway/sink the CRC technically routed through.
+ *
+ * `byTxHash` keys the payments by (lowercase) transaction hash so the row can correlate an
+ * aggregated history entry to its underlying gateway payment in O(1). `loaded`/`error`
+ * distinguish "still fetching" from "fetched, genuinely no spend" (same lesson as the
+ * contacts store — never infer loading from an empty list).
+ */
+export interface GatewaySpendingState {
+  payments: PaymentRow[];
+  byTxHash: Map<string, PaymentRow>;
+  loaded: boolean;
+  error: boolean;
+}
+
+function emptyState(): GatewaySpendingState {
+  return { payments: [], byTxHash: new Map(), loaded: false, error: false };
+}
+
+export const gatewaySpending = writable<GatewaySpendingState>(emptyState());
+
+let currentAddress = '';
+let inflight = 0;
+
+/**
+ * Initialise the gateway-spending store for an avatar. Dedup-guarded per address (a no-op
+ * when already loaded for the same avatar), mirroring the other avatar stores.
+ */
+export function initGatewaySpendingStore(avatar: Avatar): void {
+  const address = avatar?.address?.toLowerCase();
+  if (!address) return;
+  if (address === currentAddress) return;
+  void loadGatewaySpending(address);
+}
+
+/** Force a reload past the dedup guard (e.g. after a marketplace purchase). */
+export function refreshGatewaySpendingStore(avatar: Avatar): void {
+  const address = avatar?.address?.toLowerCase();
+  if (!address) return;
+  currentAddress = '';
+  void loadGatewaySpending(address);
+}
+
+async function loadGatewaySpending(address: string): Promise<void> {
+  currentAddress = address;
+  const sdk = get(circles);
+  if (!sdk) {
+    // No SDK yet. initAvatarStores fires once per avatar, so it won't retry on its own.
+    // Keep `currentAddress = address` (so a duplicate init still dedups and we don't stack
+    // subscribers) and reload once the SDK lands. Unsubscribe on the first truthy value
+    // either way, so an avatar-switch before the SDK arrives can't leak this listener — the
+    // `currentAddress === wanted` check makes the late callback a no-op in that case.
+    const wanted = address;
+    const unsub = circles.subscribe((s) => {
+      if (!s) return;
+      unsub();
+      if (currentAddress === wanted) void loadGatewaySpending(wanted);
+    });
+    return;
+  }
+
+  // Reset to a loading state for the new avatar so a stale list can't show through.
+  gatewaySpending.set(emptyState());
+  const ticket = ++inflight;
+
+  try {
+    const payments = await fetchPaymentsByPayer(sdk, address);
+    // Ignore a result that arrived after a newer avatar load started.
+    if (ticket !== inflight) return;
+    const byTxHash = new Map<string, PaymentRow>();
+    for (const p of payments) {
+      const key = p.tx?.toLowerCase();
+      if (key && !byTxHash.has(key)) byTxHash.set(key, p);
+    }
+    gatewaySpending.set({ payments, byTxHash, loaded: true, error: false });
+  } catch (e) {
+    if (ticket !== inflight) return;
+    console.warn('[gatewaySpending] failed to load payer payments', e);
+    gatewaySpending.set({ payments: [], byTxHash: new Map(), loaded: true, error: true });
+  }
+}
+
+/** Clear on logout so the next session starts clean. */
+export function clearGatewaySpendingStore(): void {
+  currentAddress = '';
+  inflight++;
+  gatewaySpending.set(emptyState());
+}
+
+// --- spend summaries -------------------------------------------------------------------------
+
+const DAY_SECONDS = 86_400;
+
+export type SpendWindow = '7d' | '30d' | 'all';
+
+export interface SpendWindowSummary {
+  /** CRC spent in the window. */
+  total: number;
+  /** Number of gateway payments in the window. */
+  count: number;
+}
+
+/** wei (18 decimals) bigint → CRC number. Safe for typical payment magnitudes. */
+function weiToCrc(amount: bigint): number {
+  // Divide in float space; payment amounts are far below Number.MAX_SAFE_INTEGER once
+  // scaled down, so this is precise enough for display totals.
+  return Number(amount) / 1e18;
+}
+
+function windowStartSeconds(window: SpendWindow, nowSeconds: number): number {
+  switch (window) {
+    case '7d':
+      return nowSeconds - 7 * DAY_SECONDS;
+    case '30d':
+      return nowSeconds - 30 * DAY_SECONDS;
+    case 'all':
+    default:
+      return 0;
+  }
+}
+
+/** Total CRC + count of gateway payments within a single window. */
+export function summarizeSpend(
+  payments: PaymentRow[],
+  window: SpendWindow,
+  nowSeconds: number = Math.floor(Date.now() / 1000)
+): SpendWindowSummary {
+  const start = windowStartSeconds(window, nowSeconds);
+  let total = 0;
+  let count = 0;
+  for (const p of payments) {
+    if (p.timestamp < start) continue;
+    total += weiToCrc(p.amount);
+    count++;
+  }
+  return { total, count };
+}
+
+/** All three windows at once (for the dashboard card / insights page). */
+export function summarizeSpendWindows(
+  payments: PaymentRow[],
+  nowSeconds: number = Math.floor(Date.now() / 1000)
+): Record<SpendWindow, SpendWindowSummary> {
+  return {
+    '7d': summarizeSpend(payments, '7d', nowSeconds),
+    '30d': summarizeSpend(payments, '30d', nowSeconds),
+    all: summarizeSpend(payments, 'all', nowSeconds),
+  };
+}

--- a/circles-app/src/lib/shared/state/realtimeSync.ts
+++ b/circles-app/src/lib/shared/state/realtimeSync.ts
@@ -5,6 +5,7 @@ import { circles } from '$lib/shared/state/circles';
 import { initTransactionHistoryStore, refreshTransactionHistory } from '$lib/shared/state/transactionHistory';
 import { initContactStore, refreshContactStore } from '$lib/shared/state/contacts';
 import { initBalanceStore, refreshBalanceStore } from '$lib/shared/state/circlesBalances';
+import { initGatewaySpendingStore } from '$lib/shared/state/gatewaySpending.svelte';
 import { initGroupMetricsStore } from '$lib/areas/groups/state';
 
 const MIN_RESYNC_INTERVAL_MS = 5_000;
@@ -20,6 +21,10 @@ export function initAvatarStores(avatar: Avatar): void {
   void initTransactionHistoryStore(avatar);
   initContactStore(avatar);
   initBalanceStore(avatar);
+  // Marketplace/gateway spend is infrequent and not realtime-critical, so it loads once per
+  // avatar (dedup-guarded) and is NOT part of the steady-state liveness refresh — that keeps
+  // the spending card from blanking every tick.
+  initGatewaySpendingStore(avatar);
   if (avatarState.isGroup) {
     const sdk = get(circles);
     if (sdk) {

--- a/circles-app/src/lib/shared/state/wallet.svelte.ts
+++ b/circles-app/src/lib/shared/state/wallet.svelte.ts
@@ -27,6 +27,7 @@ import { withRetry, isTransientError } from '$lib/shared/utils/retry';
 import { EoaBrowserRunner } from '$lib/shared/integrations/wallet/EoaBrowserRunner';
 import { clearAll as clearCache } from '$lib/shared/cache';
 import { teardownTransactionHistoryStore } from '$lib/shared/state/transactionHistory';
+import { clearGatewaySpendingStore } from '$lib/shared/state/gatewaySpending.svelte';
 
 export const wallet = writable<ContractRunner | undefined>();
 
@@ -442,6 +443,7 @@ export async function clearSession() {
   // The transaction-history store holds its event subscription + timers at module scope,
   // so release them explicitly (the balance/contacts stores self-clean on unmount).
   teardownTransactionHistoryStore();
+  clearGatewaySpendingStore();
   CirclesStorage.getInstance().clear();
   void clearCache();
   await goto('/');

--- a/circles-app/src/lib/shared/ui/shell/AppSidebar.svelte
+++ b/circles-app/src/lib/shared/ui/shell/AppSidebar.svelte
@@ -24,14 +24,20 @@
   import Tooltip from '$lib/shared/ui/primitives/Tooltip.svelte';
   import EnvironmentInfoPopup from '$lib/shared/ui/shell/EnvironmentInfoPopup.svelte';
 
-  // "Invite" is only meaningful for human v2 avatars, so it's inserted
-  // conditionally rather than living in the static base list.
+  // "Invite" is only meaningful for human v2 avatars. While the avatar is still
+  // restoring (`avatar` undefined) we OPTIMISTICALLY reserve its slot — the common
+  // case is a human avatar that can invite, so showing it during load eliminates the
+  // pop-in that previously inserted Invite mid-nav and shoved Groups/Market down on
+  // resolve. A non-human avatar (org/group) simply drops the slot once resolved (rare).
+  const showInvite = $derived(
+    !avatarState.avatar || canCreateInviteLinks(avatarState.avatar)
+  );
   const NAV_ITEMS = $derived.by(() => {
     const items = [
       { label: 'Wallet',   href: '/dashboard', icon: LWallet },
       { label: 'Contacts', href: '/contacts',  icon: LUsers },
     ];
-    if (canCreateInviteLinks(avatarState.avatar)) {
+    if (showInvite) {
       items.push({ label: 'Invite', href: '/invites', icon: LUserPlus });
     }
     items.push(

--- a/circles-app/src/routes/dashboard/+page.svelte
+++ b/circles-app/src/routes/dashboard/+page.svelte
@@ -26,6 +26,7 @@
     import Icon from '$lib/design-system/Icon.svelte';
     import DashboardFlowStrip from './DashboardFlowStrip.svelte';
     import DashboardTrustCard from './DashboardTrustCard.svelte';
+    import DashboardSpendingCard from './DashboardSpendingCard.svelte';
 
     let mintableAmount: number = $state(0);
     // Whether the (async) mintable check has resolved. Lets the dashboard RESERVE the
@@ -275,6 +276,9 @@
 
         <!-- ─── TRUST INSIGHTS ────────────────────────────────────────── -->
         <DashboardTrustCard />
+
+        <!-- ─── MARKETPLACE SPENDING (renders only when there's spend) ─── -->
+        <DashboardSpendingCard />
 
         <!-- ─── ACTIVITY HEADING ──────────────────────────────────────── -->
         <div style="margin-top:22px;margin-bottom:10px;padding:0 4px;">

--- a/circles-app/src/routes/dashboard/DashboardFlowStrip.svelte
+++ b/circles-app/src/routes/dashboard/DashboardFlowStrip.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { goto } from '$app/navigation';
     import { avatarState } from '$lib/shared/state/avatar.svelte';
     import { roundToDecimals } from '$lib/shared/utils/shared';
     import { T } from '$lib/design-system/tokens.js';
@@ -176,6 +177,21 @@
                 </div>
             {/each}
         </div>
+    {/if}
+
+    <!-- Drill-down entry: the /insights page expands exactly this net + buckets into
+         per-leg detail (plus minting + marketplace spend). Always shown once loaded so the
+         page is reachable even when there's no marketplace spend (the spending card hides). -->
+    {#if !loading && !errored}
+        <button
+            onclick={() => goto('/insights')}
+            class="flow-insights-link"
+            style="
+                align-self:flex-start;margin-top:2px;padding:2px 0;background:transparent;border:0;
+                cursor:pointer;font-family:{T.fontSans};font-size:12px;font-weight:560;
+                color:{T.primaryDeep};display:inline-flex;align-items:center;gap:3px;
+            "
+        >Insights ›</button>
     {/if}
 </div>
 

--- a/circles-app/src/routes/dashboard/DashboardSpendingCard.svelte
+++ b/circles-app/src/routes/dashboard/DashboardSpendingCard.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+    import { goto } from '$app/navigation';
+    import { roundToDecimals } from '$lib/shared/utils/shared';
+    import {
+        gatewaySpending,
+        summarizeSpendWindows,
+        type SpendWindow,
+    } from '$lib/shared/state/gatewaySpending.svelte';
+    import { T } from '$lib/design-system/tokens.js';
+
+    // Time-horizon spend totals derived from the shared gateway-spending store. Recomputed
+    // whenever the payment list changes; cheap (a few sums over a bounded list).
+    const windows = $derived(summarizeSpendWindows($gatewaySpending.payments));
+
+    // Store load-completion signals — never infer "no spend" from an empty list mid-load
+    // (same lesson as the contacts/trust store).
+    const loaded = $derived($gatewaySpending.loaded);
+    const errored = $derived($gatewaySpending.error);
+    const totalCount = $derived(windows.all.count);
+
+    // The card is OPTIONAL: most avatars never use the marketplace, so render nothing until
+    // loaded and only when there's genuine spend (or a load error worth surfacing). This
+    // avoids cluttering non-marketplace dashboards with a permanent empty state. Gate on
+    // spend MAGNITUDE (not count) so a sub-0.01 purchase can't show "1 purchase / 0 all
+    // time" — roundToDecimals floors, so a <0.01 total would render as a confusing "0".
+    const show = $derived(loaded && (errored || windows.all.total >= 0.01));
+
+    type HorizonRow = { id: SpendWindow; label: string };
+    const HORIZONS: HorizonRow[] = [
+        { id: '7d', label: 'last 7d' },
+        { id: '30d', label: 'last 30d' },
+        { id: 'all', label: 'all time' },
+    ];
+
+    // Only show a horizon that actually carries spend, so an all-in-30-days history doesn't
+    // print "0.00 last 7d". `all` always shows when there's any spend (it's the total).
+    const visibleHorizons = $derived(
+        HORIZONS.filter((h) => h.id === 'all' || windows[h.id].total >= 0.01)
+    );
+</script>
+
+{#if show}
+    <button
+        onclick={() => goto('/insights')}
+        aria-label="View your marketplace spending"
+        style="
+            width:100%;margin-top:14px;padding:14px 16px;border-radius:18px;
+            background:{T.surface};border:1px solid {T.hairlineSoft};
+            box-shadow:{T.shadow.xs};cursor:pointer;text-align:left;display:block;
+            font-family:{T.fontSans};
+        "
+    >
+        <!-- Header row -->
+        <div style="display:flex;align-items:center;justify-content:space-between;gap:8px;">
+            <span style="font-size:11px;font-weight:600;color:{T.inkMuted};letter-spacing:0.06em;text-transform:uppercase;">Marketplace spending</span>
+            {#if !errored && totalCount > 0}
+                <span style="
+                    font-size:10.5px;font-weight:580;color:#8A3A1E;
+                    background:{T.coralSoft};border-radius:9999px;padding:2px 8px;
+                    white-space:nowrap;
+                ">{totalCount} {totalCount === 1 ? 'purchase' : 'purchases'}</span>
+            {/if}
+        </div>
+
+        {#if errored}
+            <div style="margin-top:8px;font-size:13px;color:{T.inkMuted};">Couldn’t load spending</div>
+        {:else}
+            <!-- Horizon totals — each on one row (number · label), matching the trust card. -->
+            <div style="display:flex;align-items:center;gap:16px;margin-top:10px;flex-wrap:wrap;">
+                {#each visibleHorizons as h}
+                    <div style="display:flex;align-items:baseline;gap:6px;min-width:0;">
+                        <span style="font-family:{T.fontDisplay};font-size:18px;color:{T.ink};line-height:1;letter-spacing:-0.015em;font-weight:400;">{roundToDecimals(windows[h.id].total)}</span>
+                        <span style="font-size:12px;color:{T.inkMuted};white-space:nowrap;">{h.label}</span>
+                    </div>
+                {/each}
+            </div>
+        {/if}
+    </button>
+{/if}

--- a/circles-app/src/routes/dashboard/DashboardTrustCard.svelte
+++ b/circles-app/src/routes/dashboard/DashboardTrustCard.svelte
@@ -101,15 +101,14 @@
         <!-- Empty state -->
         <div style="margin-top:8px;font-size:13px;color:{T.inkMuted};">No trust connections yet</div>
     {:else}
-        <!-- Counts -->
-        <div style="display:flex;align-items:flex-start;gap:18px;margin-top:10px;flex-wrap:wrap;">
+        <!-- Counts — each metric on ONE row (dot · number · label) so the card stays
+             compact and visually matches the balance legend's inline style. -->
+        <div style="display:flex;align-items:center;gap:16px;margin-top:10px;flex-wrap:wrap;">
             {#each metrics as m}
-                <div style="display:flex;flex-direction:column;gap:3px;min-width:0;">
-                    <span style="font-family:{T.fontDisplay};font-size:22px;color:{T.ink};line-height:1;letter-spacing:-0.015em;font-weight:400;">{m.value}</span>
-                    <div style="display:flex;align-items:center;gap:5px;">
-                        <span style="width:6px;height:6px;border-radius:3px;background:{m.dot};display:inline-block;flex-shrink:0;"></span>
-                        <span style="font-size:11.5px;color:{T.inkMuted};white-space:nowrap;">{m.label}</span>
-                    </div>
+                <div style="display:flex;align-items:center;gap:6px;min-width:0;">
+                    <span style="width:6px;height:6px;border-radius:3px;background:{m.dot};display:inline-block;flex-shrink:0;"></span>
+                    <span style="font-family:{T.fontDisplay};font-size:18px;color:{T.ink};line-height:1;letter-spacing:-0.015em;font-weight:400;">{m.value}</span>
+                    <span style="font-size:12px;color:{T.inkMuted};white-space:nowrap;">{m.label}</span>
                 </div>
             {/each}
         </div>

--- a/circles-app/src/routes/dashboard/TransactionRow.svelte
+++ b/circles-app/src/routes/dashboard/TransactionRow.svelte
@@ -9,6 +9,7 @@
     import TransactionDetailsPopup from './TransactionDetailsPopup.svelte';
     import { ZERO_ADDRESS } from '$lib/shared/utils/tx';
     import { getActiveConfig } from '$lib/shared/state/settings.svelte';
+    import { gatewaySpending } from '$lib/shared/state/gatewaySpending.svelte';
     import { createKeyboardListNavigator } from '$lib/shared/ui/lists/utils/keyboardListNavigator';
     import {
         VIRTUAL_LIST_CONTEXT_KEY,
@@ -41,10 +42,27 @@
         );
     });
 
-    // For a migration, show the destination score group (a real, named avatar) rather
-    // than the profile-less sink the transfer technically routed through.
+    // A payment-gateway (marketplace) purchase routes CRC me → gateway → seller. In
+    // aggregated history the counterparty surfaces as the faceless gateway/sink contract
+    // (no profile → a generic "shop" placeholder + truncated address). The gateway-spending
+    // store carries the underlying PaymentReceived event keyed by tx hash, so when this row
+    // matches one we can label it "Marketplace" and show the actual SELLER (payee) instead.
+    const gatewayPayment = $derived(
+        item.transactionHash
+            ? $gatewaySpending.byTxHash.get(item.transactionHash.toLowerCase())
+            : undefined
+    );
+    const isMarketplace = $derived(!!gatewayPayment);
+
+    // For a migration, show the destination score group; for a marketplace purchase, the
+    // seller (payee) — both real, named avatars rather than the profile-less contract the
+    // transfer technically routed through.
     const avatarAddress = $derived(
-        isMigration && scoreGroupAddress ? scoreGroupAddress : counterpartyAddress
+        isMigration && scoreGroupAddress
+            ? scoreGroupAddress
+            : isMarketplace && gatewayPayment
+              ? (gatewayPayment.payee.toLowerCase() as typeof counterpartyAddress)
+              : counterpartyAddress
     );
 
     // Small label above the counterparty name. "Minted" is the honest umbrella for any
@@ -54,12 +72,14 @@
     // that merely contain a mint hop.
     const topInfoText = $derived.by(() => {
         if (isMigration) return 'Group migration';
+        if (isMarketplace) return 'Marketplace';
         if (item.type === 'mint') return 'Minted';
         return '';
     });
 
     const badgeUrl = $derived.by(() => {
         if (isMigration) return '/badge-mint.svg'; // migration mints the new group token
+        if (isMarketplace) return '/badge-sent.svg'; // a marketplace purchase is an outflow
         if (item.type === 'mint') return '/badge-mint.svg';
         if (item.type === 'burn') return '/badge-burn.svg';
         if (item.type === 'send') return '/badge-sent.svg';

--- a/circles-app/src/routes/insights/+page.svelte
+++ b/circles-app/src/routes/insights/+page.svelte
@@ -1,0 +1,327 @@
+<script lang="ts">
+    import { goto } from '$app/navigation';
+    import { avatarState } from '$lib/shared/state/avatar.svelte';
+    import { roundToDecimals, getTimeAgo } from '$lib/shared/utils/shared';
+    import { T } from '$lib/design-system/tokens.js';
+    import Avatar from '$lib/shared/ui/avatar/Avatar.svelte';
+    import {
+        computeFlowMetrics,
+        emptyFlowMetrics,
+        type FlowWindow,
+        type FlowMetrics,
+        type FlowBucket,
+        type FlowTx,
+    } from '$lib/shared/utils/flowMetrics';
+    import { gatewaySpending } from '$lib/shared/state/gatewaySpending.svelte';
+
+    // --- window selection ---------------------------------------------------------------
+    // Default to 30d — the widest fully-covered window (the flow engine bounds at 30d/600
+    // legs, so "all" is annotated as capped rather than truly lifetime).
+    let activeWindow: FlowWindow = $state('30d');
+
+    const WINDOWS: { id: FlowWindow; label: string }[] = [
+        { id: 'today', label: 'Today' },
+        { id: '7d', label: '7d' },
+        { id: '30d', label: '30d' },
+        { id: 'all', label: 'All' },
+    ];
+
+    const DAY_SECONDS = 86_400;
+    function windowStartSeconds(window: FlowWindow): number {
+        const now = Math.floor(Date.now() / 1000);
+        switch (window) {
+            case 'today': {
+                const start = new Date();
+                start.setHours(0, 0, 0, 0);
+                return Math.floor(start.getTime() / 1000);
+            }
+            case '7d':
+                return now - 7 * DAY_SECONDS;
+            case '30d':
+                return now - 30 * DAY_SECONDS;
+            case 'all':
+            default:
+                return 0;
+        }
+    }
+
+    // Take the window as a typed param so the comparisons stay against `FlowWindow` rather
+    // than the `$state` initializer's narrowed literal (which would make `=== 'today'` etc.
+    // a "no overlap" type error).
+    function labelFor(window: FlowWindow): string {
+        return window === 'today' ? 'today' : window === 'all' ? 'all time' : `last ${window}`;
+    }
+    const windowLabel = $derived(labelFor(activeWindow));
+
+    // --- flow metrics -------------------------------------------------------------------
+    let metricsByWindow: Record<FlowWindow, FlowMetrics> | null = $state(null);
+    let loading = $state(true);
+    let errored = $state(false);
+
+    $effect(() => {
+        const address = avatarState.avatar?.address;
+        if (!address) {
+            metricsByWindow = null;
+            loading = false;
+            errored = false;
+            return;
+        }
+        let cancelled = false;
+        loading = true;
+        errored = false;
+        metricsByWindow = null;
+        (async () => {
+            try {
+                const result = await computeFlowMetrics(address);
+                if (cancelled) return;
+                metricsByWindow = result;
+            } catch (e) {
+                if (cancelled) return;
+                console.warn('[insights] failed to compute flow metrics', e);
+                errored = true;
+            } finally {
+                if (!cancelled) loading = false;
+            }
+        })();
+        return () => {
+            cancelled = true;
+        };
+    });
+
+    const metrics: FlowMetrics = $derived(
+        metricsByWindow ? metricsByWindow[activeWindow] : emptyFlowMetrics()
+    );
+
+    // --- bucket display -----------------------------------------------------------------
+    type BucketRow = { id: FlowBucket; label: string; sign: '+' | '−' | ''; color: string };
+    const BUCKETS: BucketRow[] = [
+        { id: 'minted', label: 'Minted', sign: '+', color: T.sage },
+        { id: 'received', label: 'Received', sign: '+', color: T.sage },
+        { id: 'sent', label: 'Sent', sign: '−', color: T.coral },
+        { id: 'spent', label: 'Spent', sign: '−', color: T.coral },
+        { id: 'demurrage', label: 'Demurrage', sign: '−', color: T.inkMuted },
+        { id: 'converted', label: 'Converted', sign: '', color: T.inkMuted },
+    ];
+    const visibleBuckets = $derived(BUCKETS.filter((b) => Math.abs(metrics[b.id]) >= 0.01));
+    const net = $derived(metrics.net);
+
+    // Expandable bucket → its contributing legs. One open at a time keeps the page tidy.
+    let expanded: FlowBucket | null = $state(null);
+    function toggle(b: FlowBucket) {
+        expanded = expanded === b ? null : b;
+    }
+
+    // Per-bucket lists are bounded to keep the DOM light; surface the dropped count rather
+    // than silently truncating.
+    const ROW_CAP = 50;
+    function legsFor(b: FlowBucket): FlowTx[] {
+        const all = metrics.txByBucket[b] ?? [];
+        return [...all].sort((x, y) => y.timestamp - x.timestamp);
+    }
+
+    // --- minting (Phase D) --------------------------------------------------------------
+    // Derived from the minted bucket of the SELECTED window. Personal CRC accrues
+    // continuously and is claimed on-demand, so "days active" (distinct UTC days with a
+    // mint) is the honest engagement signal; a current streak is shown only when ≥2.
+    const mintStats = $derived.by(() => {
+        const legs = metrics.txByBucket.minted ?? [];
+        const days = new Set<string>();
+        for (const l of legs) {
+            const d = new Date(l.timestamp * 1000);
+            days.add(`${d.getUTCFullYear()}-${d.getUTCMonth()}-${d.getUTCDate()}`);
+        }
+        // Current streak: walk back from today over consecutive UTC days present in `days`.
+        let streak = 0;
+        const cursor = new Date();
+        cursor.setUTCHours(0, 0, 0, 0);
+        // Allow the streak to start at today OR yesterday (a not-yet-claimed today shouldn't
+        // zero an otherwise live streak).
+        const key = (dt: Date) => `${dt.getUTCFullYear()}-${dt.getUTCMonth()}-${dt.getUTCDate()}`;
+        if (!days.has(key(cursor))) cursor.setUTCDate(cursor.getUTCDate() - 1);
+        while (days.has(key(cursor))) {
+            streak++;
+            cursor.setUTCDate(cursor.getUTCDate() - 1);
+        }
+        return { total: metrics.minted, count: legs.length, daysActive: days.size, streak };
+    });
+
+    // --- marketplace spending (Phase C detail) ------------------------------------------
+    const spendPayments = $derived.by(() => {
+        const start = windowStartSeconds(activeWindow);
+        return $gatewaySpending.payments
+            .filter((p) => p.timestamp >= start)
+            .sort((a, b) => b.timestamp - a.timestamp);
+    });
+    const spendTotal = $derived(
+        spendPayments.reduce((acc, p) => acc + Number(p.amount) / 1e18, 0)
+    );
+</script>
+
+<div style="background:{T.page};min-height:100%;width:100%;font-family:{T.fontSans};color:{T.inkBody};">
+    <div style="padding:8px 18px 24px;" class="md:!p-9 md:max-w-[1280px] md:mx-auto">
+
+        <!-- Header -->
+        <div style="display:flex;align-items:center;justify-content:space-between;gap:8px 12px;flex-wrap:wrap;margin-bottom:6px;">
+            <div style="display:flex;align-items:center;gap:10px;">
+                <button
+                    onclick={() => goto('/dashboard')}
+                    aria-label="Back to wallet"
+                    class="btn-naked"
+                    style="background:transparent;border:0;padding:4px;cursor:pointer;color:{T.inkMuted};display:inline-flex;"
+                >‹ Back</button>
+                <h1 style="font-family:{T.fontDisplay};font-size:24px;color:{T.ink};letter-spacing:-0.01em;font-weight:500;margin:0;">Insights</h1>
+            </div>
+            <div role="tablist" aria-label="Time window" style="display:inline-flex;gap:2px;padding:3px;border-radius:9999px;flex-shrink:0;background:{T.surface};border:1px solid {T.hairlineSoft};">
+                {#each WINDOWS as w}
+                    <button
+                        role="tab"
+                        aria-selected={activeWindow === w.id}
+                        onclick={() => (activeWindow = w.id)}
+                        style="padding:5px 12px;border:0;cursor:pointer;border-radius:9999px;font-size:12px;font-weight:560;line-height:1;background:{activeWindow === w.id ? T.primary : 'transparent'};color:{activeWindow === w.id ? '#fff' : T.inkMuted};transition:background 140ms ease-out,color 140ms ease-out;"
+                    >{w.label}</button>
+                {/each}
+            </div>
+        </div>
+
+        {#if !avatarState.avatar}
+            <div style="margin-top:40px;text-align:center;color:{T.inkMuted};font-size:14px;">
+                Connect your wallet to see insights.
+            </div>
+        {:else if loading}
+            <div style="margin-top:24px;display:flex;flex-direction:column;gap:12px;">
+                {#each [0, 1, 2] as _}
+                    <div class="ins-skel" style="height:64px;border-radius:18px;"></div>
+                {/each}
+            </div>
+        {:else if errored}
+            <div style="margin-top:40px;text-align:center;color:{T.inkMuted};font-size:14px;">Couldn’t load insights. Try again later.</div>
+        {:else}
+            <!-- ─── FLOW ──────────────────────────────────────────────── -->
+            <section style="margin-top:14px;padding:18px 18px 8px;border-radius:20px;background:{T.surface};border:1px solid {T.hairlineSoft};box-shadow:{T.shadow.xs};">
+                <div style="display:flex;align-items:baseline;justify-content:space-between;gap:8px;flex-wrap:wrap;">
+                    <span style="font-size:11px;font-weight:600;color:{T.inkMuted};letter-spacing:0.06em;text-transform:uppercase;">Flow {windowLabel}</span>
+                    <div style="display:flex;align-items:baseline;gap:6px;">
+                        <span style="font-family:{T.fontSans};font-size:18px;font-weight:640;line-height:1;font-variant-numeric:tabular-nums;color:{net >= 0 ? T.sage : T.coral};">{net >= 0 ? '+' : '−'}{roundToDecimals(Math.abs(net))}</span>
+                        <span style="font-size:11px;color:{T.inkMuted};font-weight:500;">net{metrics.capped && activeWindow === 'all' ? ' (30d+)' : ''}</span>
+                    </div>
+                </div>
+
+                {#if visibleBuckets.length === 0}
+                    <div style="margin:14px 0 10px;font-size:13px;color:{T.inkMuted};">No activity {windowLabel}.</div>
+                {:else}
+                    <div style="margin-top:12px;display:flex;flex-direction:column;">
+                        {#each visibleBuckets as b (b.id)}
+                            {@const legs = legsFor(b.id)}
+                            <button
+                                onclick={() => toggle(b.id)}
+                                aria-expanded={expanded === b.id}
+                                style="display:flex;align-items:center;gap:10px;width:100%;padding:11px 4px;background:transparent;border:0;border-bottom:1px solid {T.hairlineSoft};cursor:pointer;text-align:left;font-family:{T.fontSans};"
+                            >
+                                <span style="width:7px;height:7px;border-radius:4px;background:{b.color};flex-shrink:0;"></span>
+                                <span style="flex:1;font-size:14px;color:{T.ink};font-weight:540;">{b.label}</span>
+                                <span style="font-size:11px;color:{T.inkMuted};">{legs.length}×</span>
+                                <span style="font-family:{T.fontMono};font-size:14px;font-weight:600;font-variant-numeric:tabular-nums;color:{b.color};">{b.sign}{roundToDecimals(Math.abs(metrics[b.id]))}</span>
+                                <span style="color:{T.inkFaint};font-size:13px;width:14px;text-align:center;">{expanded === b.id ? '▾' : '▸'}</span>
+                            </button>
+                            {#if expanded === b.id}
+                                <div style="padding:4px 4px 12px;display:flex;flex-direction:column;gap:2px;">
+                                    {#each legs.slice(0, ROW_CAP) as leg (leg.hash + leg.counterparty + leg.timestamp)}
+                                        <div style="display:flex;align-items:center;gap:10px;padding:7px 8px;border-radius:10px;background:{T.surfaceAlt ?? T.page};">
+                                            <div style="flex:1;min-width:0;">
+                                                {#if b.id === 'minted'}
+                                                    <span style="font-size:13px;color:{T.ink};">Personal mint</span>
+                                                {:else if b.id === 'demurrage'}
+                                                    <span style="font-size:13px;color:{T.ink};">Demurrage</span>
+                                                {:else}
+                                                    <Avatar address={leg.counterparty} view="small" clickable={false} />
+                                                {/if}
+                                                <div style="font-size:11px;color:{T.inkMuted};margin-top:1px;">{getTimeAgo(leg.timestamp)}</div>
+                                            </div>
+                                            <span style="font-family:{T.fontMono};font-size:13px;font-weight:600;font-variant-numeric:tabular-nums;color:{b.color};">{b.sign}{roundToDecimals(leg.amount)}</span>
+                                        </div>
+                                    {/each}
+                                    {#if legs.length > ROW_CAP}
+                                        <div style="font-size:11px;color:{T.inkMuted};padding:6px 8px;">+{legs.length - ROW_CAP} more not shown</div>
+                                    {/if}
+                                </div>
+                            {/if}
+                        {/each}
+                    </div>
+                {/if}
+            </section>
+
+            <!-- ─── MINTING (Phase D) ─────────────────────────────────── -->
+            {#if mintStats.count > 0}
+                <section style="margin-top:14px;padding:18px;border-radius:20px;background:{T.surface};border:1px solid {T.hairlineSoft};box-shadow:{T.shadow.xs};">
+                    <div style="display:flex;align-items:center;justify-content:space-between;gap:8px;">
+                        <span style="font-size:11px;font-weight:600;color:{T.inkMuted};letter-spacing:0.06em;text-transform:uppercase;">Minting {windowLabel}</span>
+                        {#if mintStats.streak >= 2}
+                            <span style="font-size:10.5px;font-weight:580;color:{T.primaryDeep};background:{T.primarySoft};border-radius:9999px;padding:2px 8px;">🔥 {mintStats.streak}-day streak</span>
+                        {/if}
+                    </div>
+                    <div style="display:flex;align-items:center;gap:18px;margin-top:12px;flex-wrap:wrap;">
+                        <div style="display:flex;align-items:baseline;gap:6px;">
+                            <span style="font-family:{T.fontDisplay};font-size:22px;color:{T.ink};line-height:1;letter-spacing:-0.015em;">+{roundToDecimals(mintStats.total)}</span>
+                            <span style="font-size:12px;color:{T.inkMuted};">CRC minted</span>
+                        </div>
+                        <div style="display:flex;align-items:baseline;gap:6px;">
+                            <span style="font-family:{T.fontDisplay};font-size:22px;color:{T.ink};line-height:1;">{mintStats.daysActive}</span>
+                            <span style="font-size:12px;color:{T.inkMuted};">days active</span>
+                        </div>
+                        <div style="display:flex;align-items:baseline;gap:6px;">
+                            <span style="font-family:{T.fontDisplay};font-size:22px;color:{T.ink};line-height:1;">{mintStats.count}</span>
+                            <span style="font-size:12px;color:{T.inkMuted};">{mintStats.count === 1 ? 'mint' : 'mints'}</span>
+                        </div>
+                    </div>
+                </section>
+            {/if}
+
+            <!-- ─── MARKETPLACE SPENDING (Phase C detail) ─────────────── -->
+            {#if $gatewaySpending.error}
+                <section style="margin-top:14px;padding:18px;border-radius:20px;background:{T.surface};border:1px solid {T.hairlineSoft};box-shadow:{T.shadow.xs};">
+                    <span style="font-size:11px;font-weight:600;color:{T.inkMuted};letter-spacing:0.06em;text-transform:uppercase;">Marketplace spending</span>
+                    <div style="margin-top:8px;font-size:13px;color:{T.inkMuted};">Couldn’t load marketplace spending</div>
+                </section>
+            {:else if spendPayments.length > 0}
+                <section style="margin-top:14px;padding:18px;border-radius:20px;background:{T.surface};border:1px solid {T.hairlineSoft};box-shadow:{T.shadow.xs};">
+                    <div style="display:flex;align-items:baseline;justify-content:space-between;gap:8px;flex-wrap:wrap;">
+                        <span style="font-size:11px;font-weight:600;color:{T.inkMuted};letter-spacing:0.06em;text-transform:uppercase;">Marketplace spending {windowLabel}</span>
+                        <div style="display:flex;align-items:baseline;gap:6px;">
+                            <span style="font-family:{T.fontSans};font-size:16px;font-weight:640;font-variant-numeric:tabular-nums;color:{T.coral};">−{roundToDecimals(spendTotal)}</span>
+                            <span style="font-size:11px;color:{T.inkMuted};">{spendPayments.length} {spendPayments.length === 1 ? 'purchase' : 'purchases'}</span>
+                        </div>
+                    </div>
+                    <div style="margin-top:10px;display:flex;flex-direction:column;gap:2px;">
+                        {#each spendPayments.slice(0, ROW_CAP) as p (p.tx + p.timestamp)}
+                            <div style="display:flex;align-items:center;gap:10px;padding:7px 8px;border-radius:10px;background:{T.surfaceAlt ?? T.page};">
+                                <div style="flex:1;min-width:0;">
+                                    <Avatar address={p.payee.toLowerCase()} view="small" clickable={false} />
+                                    <div style="font-size:11px;color:{T.inkMuted};margin-top:1px;">
+                                        {getTimeAgo(p.timestamp)}{p.dataDecoded && p.dataDecoded.length > 0 && p.dataDecoded.length < 60 ? ` · ${p.dataDecoded}` : ''}
+                                    </div>
+                                </div>
+                                <span style="font-family:{T.fontMono};font-size:13px;font-weight:600;font-variant-numeric:tabular-nums;color:{T.coral};">−{roundToDecimals(Number(p.amount) / 1e18)}</span>
+                            </div>
+                        {/each}
+                        {#if spendPayments.length > ROW_CAP}
+                            <div style="font-size:11px;color:{T.inkMuted};padding:6px 8px;">+{spendPayments.length - ROW_CAP} more not shown</div>
+                        {/if}
+                    </div>
+                </section>
+            {/if}
+        {/if}
+
+        <div style="height:24px;"></div>
+    </div>
+</div>
+
+<style>
+    .ins-skel {
+        background: rgba(15, 10, 30, 0.06);
+        animation: ins-skel-pulse 1.6s ease-in-out infinite;
+    }
+    @keyframes ins-skel-pulse {
+        0%, 100% { opacity: 1; }
+        50% { opacity: 0.5; }
+    }
+</style>


### PR DESCRIPTION
## Summary

Extends the dashboard with economic insights and adds a dedicated drill-down page.

- **Marketplace/gateway spending** — a payer-side `PaymentReceived` store loaded once per avatar (via `initAvatarStores`, cleared on logout). Feeds two consumers from one fetch.
- **Transaction labelling** — payment-gateway purchases (which route CRC through a gateway contract and surface as a profile-less counterparty) are now labelled "Marketplace" and resolve the actual seller (payee) in the row, correlated by tx hash.
- **Dashboard spending card** — last 7d / 30d / all-time spend, rendered only when spend exists so non-marketplace dashboards stay clean.
- **`/insights` page** — per-bucket flow drill-down (each flow bucket expands to its contributing legs), minting history with a days-active / streak summary, and itemised marketplace-spend detail. Reachable from the dashboard flow strip.
- **Trust card** — one-row metric layout (`dot · number · label`).
- **Sidebar** — reserve the invite nav slot during avatar restore so it no longer pops in mid-list after the avatar resolves.

## Notes

- Per-bucket / per-purchase lists cap at 50 rows and surface the dropped count rather than truncating silently.
- Load-vs-empty everywhere keys off explicit `loaded`/`error` flags, never list emptiness.
- The spending store is excluded from the steady-state liveness refresh (spend is infrequent) so the card never blanks on a tick.

## Test plan

- [ ] Type check passes (`npm run check`) — 0 errors
- [ ] Production build passes (`npm run build:packages`)
- [ ] Dashboard: trust metrics render on one row; invite entry is present during load (no pop-in)
- [ ] Dashboard: spending card appears for an avatar with gateway spend, hidden otherwise
- [ ] A gateway purchase in the activity list shows "Marketplace" + the seller, not the routing contract
- [ ] `/insights`: window switcher works; flow buckets expand to legs; minting + spending sections render; error state shows on fetch failure