### PR TITLE
fix(realtime): unconditional backstop refresh + staging server switch

### DIFF
--- a/circles-app/src/lib/shared/state/realtimeSync.ts
+++ b/circles-app/src/lib/shared/state/realtimeSync.ts
@@ -143,18 +143,20 @@ export function initRealtimeSync(): () => void {
   document.addEventListener('visibilitychange', onVisible);
   window.addEventListener('online', onOnline);
 
-  // Safety net for a clean idle-close while the tab is foregrounded: only
-  // resyncs when the socket actually reports disconnected, so it doesn't leak
-  // subscriptions or reload on every tick. This is a QUIET resync — transaction
-  // history and balances refetch in place without blanking, and no-op when nothing
-  // changed — so it never flickers the UI even though it can fire every interval.
+  // Backstop refresh while the tab is foregrounded. Runs every tick REGARDLESS of socket
+  // state: a "connected" websocket does NOT guarantee events are actually being delivered —
+  // the server's realtime push can be silently broken (e.g. the events producer notifying on
+  // a channel the push endpoint doesn't listen on) while the socket itself stays open. So
+  // connection state can't be used as a proxy for "events are flowing" to gate this poll;
+  // gating it that way froze background refresh whenever the socket looked healthy but was
+  // silent. This is a QUIET resync — transaction history and balances refetch in place without
+  // blanking, and no-op when nothing changed — so it never flickers the UI even firing every
+  // interval, and when the socket is genuinely down resync() also re-subscribes. When push
+  // works this is cheap redundant insurance; when it silently fails it's the only thing
+  // keeping the dashboard fresh.
   const interval = setInterval(() => {
     if (document.visibilityState !== 'visible') return;
-    // Fail safe: resync when the socket reports disconnected OR when the connection
-    // state is unknown (the SDK field is private/undocumented and may return undefined
-    // after an SDK change). `!== true` means an SDK shape change degrades to a harmless
-    // quiet resync rather than silently freezing the only background refresh path.
-    if (isWebsocketConnected() !== true) void resync();
+    void resync();
   }, LIVENESS_CHECK_INTERVAL_MS);
 
   return () => {

--- a/circles-app/src/lib/shared/state/settings.svelte.ts
+++ b/circles-app/src/lib/shared/state/settings.svelte.ts
@@ -8,6 +8,20 @@ import type { NetworkType } from '$lib/shared/integrations/chain/chainConfig';
 const SETTINGS_STORAGE_KEY = 'circles.network.settings';
 
 /**
+ * Which backend deployment to talk to. Both index the same Gnosis mainnet — only the data
+ * host (indexer RPC + its co-hosted endpoints, and the realtime websocket derived from it)
+ * changes, never the chain, contracts or addresses. `staging` points at the staging
+ * deployment; useful for validating server-side changes (e.g. realtime push) before they
+ * reach production.
+ */
+export type ServerEnv = 'production' | 'staging';
+
+/** Production indexer RPC host (the default data backend). */
+const PROD_RPC_HOST = 'https://rpc.aboutcircles.com';
+/** Staging indexer RPC host — same Gnosis mainnet, separate deployment. */
+const STAGING_RPC_HOST = 'https://rpc.staging.aboutcircles.com';
+
+/**
  * Network settings interface
  */
 export interface NetworkSettings {
@@ -15,6 +29,8 @@ export interface NetworkSettings {
   ring: boolean;
   /** Network to connect to */
   network: NetworkType;
+  /** Backend deployment to talk to (gnosis only). Defaults to production. */
+  server?: ServerEnv;
   /** Custom Circles RPC URL override */
   customCirclesRpcUrl?: string;
   /** Custom Chain RPC URL override */
@@ -92,9 +108,26 @@ export function getActiveConfig(): CirclesConfig {
   const baseConfigs = settings.network === 'chiado' ? chiadoConfig : gnosisConfig;
   const baseConfig = settings.ring ? baseConfigs.rings : baseConfigs.production;
 
-  // Apply any custom URL overrides
   const config: CirclesConfig = { ...baseConfig };
 
+  // Staging server: repoint the indexer RPC — and the endpoints co-hosted on it — at the
+  // staging deployment. The SDK derives the realtime websocket URL from `circlesRpcUrl`, so
+  // this also moves live events to staging. Only the data host changes; chain, contracts and
+  // addresses stay identical (staging indexes the same Gnosis mainnet), so this applies to the
+  // gnosis network only. Explicit custom* overrides below still win over this rewrite.
+  if (settings.server === 'staging' && settings.network === 'gnosis') {
+    const toStaging = (url: string | undefined): string | undefined =>
+      url?.startsWith(PROD_RPC_HOST)
+        ? STAGING_RPC_HOST + url.slice(PROD_RPC_HOST.length)
+        : url;
+    config.circlesRpcUrl = toStaging(config.circlesRpcUrl) ?? config.circlesRpcUrl;
+    config.chainRpcUrl = toStaging(config.chainRpcUrl) ?? config.chainRpcUrl;
+    config.profileServiceUrl = toStaging(config.profileServiceUrl) ?? config.profileServiceUrl;
+    config.profilePinningServiceUrl = toStaging(config.profilePinningServiceUrl);
+    config.scoreGroupsBackendUrl = toStaging(config.scoreGroupsBackendUrl);
+  }
+
+  // Apply any custom URL overrides (highest precedence)
   if (settings.customCirclesRpcUrl) {
     config.circlesRpcUrl = settings.customCirclesRpcUrl;
   }

--- a/circles-app/src/lib/shared/ui/shell/EnvironmentInfoPopup.svelte
+++ b/circles-app/src/lib/shared/ui/shell/EnvironmentInfoPopup.svelte
@@ -15,6 +15,9 @@
       : { name: 'Gnosis Chain', chainId: 100, testnet: false },
   );
 
+  // Backend deployment the data + realtime are pointed at (independent of chain/contracts).
+  const serverLabel = $derived(settings.server === 'staging' ? 'Staging' : 'Production');
+
   // The websocket flag is a plain (non-reactive) field on the SDK rpc client, so poll it
   // while the popup is open to keep the realtime indicator live.
   let wsConnected = $state<boolean | undefined>(undefined);
@@ -88,6 +91,12 @@
       <span style="font-size:11px;font-weight:600;color:{T.inkMuted};letter-spacing:0.06em;text-transform:uppercase;">Mode</span>
       <span style="font-size:13px;color:{T.ink};font-weight:560;">
         {settings.ring ? 'Rings (experimental)' : 'Production'}
+      </span>
+    </div>
+    <div style="display:flex;align-items:center;justify-content:space-between;gap:12px;">
+      <span style="font-size:11px;font-weight:600;color:{T.inkMuted};letter-spacing:0.06em;text-transform:uppercase;">Server</span>
+      <span style="font-size:13px;color:{T.ink};font-weight:560;">
+        {serverLabel}
       </span>
     </div>
     <div style="display:flex;align-items:center;justify-content:space-between;gap:12px;">

--- a/circles-app/src/lib/shared/ui/shell/NetworkSettings.svelte
+++ b/circles-app/src/lib/shared/ui/shell/NetworkSettings.svelte
@@ -20,6 +20,15 @@
     updateSettings({ ring: target.checked });
   }
 
+  // The SDK (and its realtime websocket) is built once from getActiveConfig() at wallet
+  // init, so switching the backend deployment only takes effect on a fresh load. Persist
+  // then reload so the whole app re-initialises against the chosen server.
+  function handleServerToggle(event: Event) {
+    const target = event.target as HTMLInputElement;
+    updateSettings({ server: target.checked ? 'staging' : 'production' });
+    if (typeof window !== 'undefined') window.location.reload();
+  }
+
   function saveCustomUrls() {
     updateSettings({
       customCirclesRpcUrl: customCirclesRpcUrl || undefined,
@@ -90,6 +99,26 @@
           <span class="label-text">Enable Rings</span>
           <span class="label-text-alt text-base-content/60">
             Experimental contract addresses
+          </span>
+        </div>
+      </label>
+    </div>
+
+    <!-- Server (deployment) Toggle -->
+    <div class="form-control">
+      <label class="label cursor-pointer justify-start gap-3" for="server-toggle">
+        <input
+          id="server-toggle"
+          type="checkbox"
+          class="toggle toggle-primary"
+          checked={settings.server === 'staging'}
+          disabled={settings.network !== 'gnosis'}
+          onchange={handleServerToggle}
+        />
+        <div class="flex flex-col">
+          <span class="label-text">Use staging server</span>
+          <span class="label-text-alt text-base-content/60">
+            Point data + realtime at the staging deployment (same Gnosis mainnet). Reloads to apply.
           </span>
         </div>
       </label>


### PR DESCRIPTION
## Summary
- **realtimeSync**: remove the websocket-connected gate on the foreground liveness poll. A connected socket does not guarantee event delivery — the server's realtime push can be silently broken (events produced on a channel the push endpoint does not listen on) while the socket stays open — so connection state no longer gates the quiet backstop refresh. `resync()` still re-subscribes when the socket is genuinely down.
- **settings**: add a `server: 'production' | 'staging'` toggle that repoints the indexer RPC, its co-hosted endpoints, and the derived realtime websocket at the staging deployment (same Gnosis mainnet; chain/contracts/addresses unchanged). Explicit custom URL overrides keep precedence.
- **NetworkSettings**: add the "Use staging server" toggle (gnosis only; reloads to re-init the SDK against the chosen backend).
- **EnvironmentInfoPopup**: surface the active server (Production/Staging).

## Why
The liveness gate treated a healthy socket as proof that events were flowing; when push is silently broken, the dashboard stopped refreshing entirely until a manual reload. The backstop poll is quiet (in-place refetch, no-op when unchanged), so it never flickers. The staging switch allows validating server-side realtime changes before they reach production.

## Test plan
- [x] `npm run check` — 0 errors
- [x] `npm run build` — passes
- [x] `npm run test:run` — 208 pass
- [ ] Toggle "Use staging server" → app reloads; EnvironmentInfoPopup shows `Server: Staging` and the RPC row points at the staging host
- [ ] With realtime fixed server-side, an incoming on-chain event updates balances/tx list without a manual reload