### PR TITLE
feat(groups): Communities tab — view, join, and leave the multi-affiliate registry

### DIFF
--- a/circles-app/src/lib/__tests__/affiliateGroupCalldata.test.ts
+++ b/circles-app/src/lib/__tests__/affiliateGroupCalldata.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { ethers } from 'ethers';
+import type { Address } from '@aboutcircles/sdk-types';
+import {
+  encodeAffiliateGroupCall,
+  affiliateRegistryInterface,
+} from '$lib/areas/groups/utils/affiliateGroupCalldata';
+
+const GROUP = '0xDe6c6ECB280C6fA535000F2d5BBb8DFdF460D161' as Address;
+
+describe('encodeAffiliateGroupCall', () => {
+  it('encodes addAffiliateGroup with the right selector and a lowercased address arg', () => {
+    const data = encodeAffiliateGroupCall('addAffiliateGroup', GROUP);
+    expect(data.slice(0, 10)).toBe(ethers.id('addAffiliateGroup(address)').slice(0, 10));
+    const [decoded] = ethers.AbiCoder.defaultAbiCoder().decode(['address'], '0x' + data.slice(10));
+    expect((decoded as string).toLowerCase()).toBe(GROUP.toLowerCase());
+  });
+
+  it('encodes removeAffiliateGroup with the right selector', () => {
+    const data = encodeAffiliateGroupCall('removeAffiliateGroup', GROUP);
+    expect(data.slice(0, 10)).toBe(ethers.id('removeAffiliateGroup(address)').slice(0, 10));
+  });
+
+  it('decodes the registry custom errors used for friendly messages', () => {
+    const onlyHuman = affiliateRegistryInterface.encodeErrorResult('OnlyHuman', []);
+    expect(affiliateRegistryInterface.parseError(onlyHuman)?.name).toBe('OnlyHuman');
+
+    const notExist = affiliateRegistryInterface.encodeErrorResult('AffiliateGroupNotExist', [GROUP.toLowerCase()]);
+    expect(affiliateRegistryInterface.parseError(notExist)?.name).toBe('AffiliateGroupNotExist');
+  });
+});

--- a/circles-app/src/lib/__tests__/avatarCommunities.test.ts
+++ b/circles-app/src/lib/__tests__/avatarCommunities.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import type { Sdk } from '@aboutcircles/sdk';
+import type { Address } from '@aboutcircles/sdk-types';
+import { loadAvatarCommunities } from '$lib/areas/groups/utils/getAvatarCommunities';
+import { RPC_METHOD_NOT_FOUND } from '$lib/shared/data/circles/affiliateGroupQueries';
+
+const AVATAR = '0xAAaA000000000000000000000000000000000001' as Address;
+const G1 = '0x1111111111111111111111111111111111111111';
+const G2 = '0x2222222222222222222222222222222222222222';
+const G_MIXED_UPPER = '0xABCDEF0000000000000000000000000000000001';
+const G_MIXED_LOWER = '0xabcdef0000000000000000000000000000000001';
+
+/**
+ * Stub SDK whose `rpc.client.call` dispatches by method name to the provided
+ * response (or throws, if the entry is a function that throws), recording every call.
+ */
+function mockSdk(
+  responses: Record<string, unknown | (() => unknown)>
+): { sdk: Sdk; calls: Array<{ method: string; params: unknown }> } {
+  const calls: Array<{ method: string; params: unknown }> = [];
+  const sdk = {
+    rpc: {
+      client: {
+        call: async (method: string, params: unknown) => {
+          calls.push({ method, params });
+          const r = responses[method];
+          if (typeof r === 'function') return (r as () => unknown)();
+          if (r === undefined) throw new Error(`unexpected method ${method}`);
+          return r;
+        },
+      },
+    },
+  } as unknown as Sdk;
+  return { sdk, calls };
+}
+
+describe('loadAvatarCommunities', () => {
+  it('lowercases the avatar address in both RPC calls', async () => {
+    const { sdk, calls } = mockSdk({
+      circles_getAffiliateGroupWishlist: { totalFeePercentage: 0, groups: [] },
+      circles_getAffiliateGroups: { totalFeePercentage: 0, groups: [] },
+    });
+    await loadAvatarCommunities(sdk, AVATAR);
+    expect(calls.map((c) => c.method).sort()).toEqual([
+      'circles_getAffiliateGroupWishlist',
+      'circles_getAffiliateGroups',
+    ].sort());
+    for (const c of calls) {
+      expect((c.params as string[])[0]).toBe(AVATAR.toLowerCase());
+    }
+  });
+
+  it('flags wishlist groups confirmed when present in the trusted set', async () => {
+    const { sdk } = mockSdk({
+      circles_getAffiliateGroupWishlist: {
+        totalFeePercentage: 12,
+        groups: [
+          { groupName: 'A', groupAddress: G1, membershipFee: 10, timestamp: 1 },
+          { groupName: 'B', groupAddress: G2, membershipFee: 2, timestamp: 2 },
+        ],
+      },
+      circles_getAffiliateGroups: {
+        totalFeePercentage: 10,
+        groups: [{ groupName: 'A', groupAddress: G1, membershipFee: 10, timestamp: 1 }],
+      },
+    });
+    const res = await loadAvatarCommunities(sdk, AVATAR);
+    expect(res.unavailable).toBe(false);
+    expect(res.totalFeePercentage).toBe(12);
+    expect(res.communities.map((c) => [c.groupAddress, c.confirmed])).toEqual([
+      [G1, true],
+      [G2, false],
+    ]);
+  });
+
+  it('matches confirmed status case-insensitively and preserves null fees', async () => {
+    const { sdk } = mockSdk({
+      circles_getAffiliateGroupWishlist: {
+        totalFeePercentage: 0,
+        groups: [{ groupName: null, groupAddress: G_MIXED_UPPER, membershipFee: null, timestamp: 0 }],
+      },
+      circles_getAffiliateGroups: {
+        totalFeePercentage: 0,
+        groups: [{ groupName: null, groupAddress: G_MIXED_LOWER, membershipFee: null, timestamp: 0 }],
+      },
+    });
+    const res = await loadAvatarCommunities(sdk, AVATAR);
+    expect(res.communities[0].groupAddress).toBe(G_MIXED_LOWER);
+    expect(res.communities[0].confirmed).toBe(true);
+    expect(res.communities[0].membershipFee).toBeNull();
+  });
+
+  it('returns unavailable=true when the RPC method is not found (-32601)', async () => {
+    const err = Object.assign(new Error('Method not found'), { code: RPC_METHOD_NOT_FOUND });
+    const { sdk } = mockSdk({
+      circles_getAffiliateGroupWishlist: () => {
+        throw err;
+      },
+      circles_getAffiliateGroups: { totalFeePercentage: 0, groups: [] },
+    });
+    const res = await loadAvatarCommunities(sdk, AVATAR);
+    expect(res.unavailable).toBe(true);
+    expect(res.communities).toEqual([]);
+    expect(res.totalFeePercentage).toBe(0);
+  });
+
+  it('propagates errors that are not method-not-found', async () => {
+    const { sdk } = mockSdk({
+      circles_getAffiliateGroupWishlist: () => {
+        throw new Error('boom');
+      },
+      circles_getAffiliateGroups: { totalFeePercentage: 0, groups: [] },
+    });
+    await expect(loadAvatarCommunities(sdk, AVATAR)).rejects.toThrow('boom');
+  });
+});

--- a/circles-app/src/lib/areas/groups/state/communitiesSignal.svelte.ts
+++ b/circles-app/src/lib/areas/groups/state/communitiesSignal.svelte.ts
@@ -1,0 +1,12 @@
+/**
+ * A minimal cross-component signal so a community join/leave performed outside the
+ * Communities tab (e.g. joining from the Discover list) invalidates its cached
+ * data. The tab's loader folds `token` into its cache key; bumping it forces a
+ * reload the next time the tab is viewed.
+ */
+export const communitiesRefresh = $state<{ token: number }>({ token: 0 });
+
+/** Invalidate the Communities tab's cached data, forcing a reload on next view. */
+export function invalidateCommunities(): void {
+  communitiesRefresh.token += 1;
+}

--- a/circles-app/src/lib/areas/groups/utils/affiliateGroupActions.ts
+++ b/circles-app/src/lib/areas/groups/utils/affiliateGroupActions.ts
@@ -4,15 +4,11 @@ import type { Address } from '@aboutcircles/sdk-types';
 
 import { circles } from '$lib/shared/state/circles';
 import { wallet } from '$lib/shared/state/wallet.svelte';
-import { avatarState } from '$lib/shared/state/avatar.svelte';
 import { runTask } from '$lib/shared/utils/tasks';
 import { shortenAddress } from '$lib/shared/utils/shared';
 import { sendRunnerTransactionAndWait } from '$lib/shared/utils/tx';
 import { getActiveConfig } from '$lib/shared/state/settings.svelte';
-import {
-  getAffiliateGroupFeesPercentage,
-  isMethodNotFound,
-} from '$lib/shared/data/circles/affiliateGroupQueries';
+import { getAffiliateGroupFeesPercentage } from '$lib/shared/data/circles/affiliateGroupQueries';
 import {
   affiliateRegistryInterface,
   encodeAffiliateGroupCall,
@@ -85,10 +81,25 @@ async function preflight(from: Address, to: Address, data: string): Promise<stri
   }
 }
 
-async function sendRegistryTx(
+// Advisory pre-check: is the avatar already committed to the full 100% fee cap?
+// The cap is NOT enforced on-chain (the registry never reads fees), so this is a
+// courtesy guard only. Reads the fee total for the same account that will send
+// the tx. Any read failure (method absent on this server, transient error) skips
+// the guard and lets the join proceed.
+async function isAtFeeCap(): Promise<boolean> {
+  const sdk = get(circles);
+  const me = runnerAddress();
+  if (!sdk || !me) return false;
+  try {
+    return (await getAffiliateGroupFeesPercentage(sdk.rpc, me)) >= 100;
+  } catch {
+    return false;
+  }
+}
+
+async function submitRegistryTx(
   method: 'addAffiliateGroup' | 'removeAffiliateGroup',
   group: Address,
-  taskName: string,
   label: string
 ): Promise<void> {
   const registry = affiliateRegistryAddress();
@@ -105,54 +116,35 @@ async function sendRegistryTx(
   const reason = await preflight(from, registry, data);
   if (reason) throw new Error(reason);
 
-  await runTask({
-    name: taskName,
-    promise: sendRunnerTransactionAndWait(runner, { to: registry, value: 0n, data }, { label }),
-  });
+  await sendRunnerTransactionAndWait(runner, { to: registry, value: 0n, data }, { label });
 }
 
 /**
  * Signal on-chain intent to join `group` as a community (`addAffiliateGroup`).
- * Idempotent on-chain (a no-op if already joined). Refuses early if the avatar is
- * already at the 100% fee cap — best-effort: the guard is skipped when the read
- * RPC doesn't expose the affiliate methods (e.g. the production server).
+ * Idempotent on-chain (a no-op if already joined). The whole operation runs under
+ * a single task so every failure — the cap message, a decoded preflight revert,
+ * or the broadcast — surfaces to the user once.
  */
 export async function joinCommunity(group: Address): Promise<void> {
   const target = group.toLowerCase() as Address;
-  const me = avatarState.avatar?.address?.toLowerCase() as Address | undefined;
-
-  // Best-effort cap guard: refuse if already committed to the full 100%.
-  const sdk = get(circles);
-  if (sdk && me) {
-    let committed: number | null = null;
-    try {
-      committed = await getAffiliateGroupFeesPercentage(sdk.rpc, me);
-    } catch (e) {
-      if (!isMethodNotFound(e)) throw e;
-      committed = null; // unreadable on this server → skip the guard
-    }
-    if (committed != null && committed >= 100) {
-      throw new Error(
-        'You are already committed to the 100% membership-fee cap. Leave a community before joining another.'
-      );
-    }
-  }
-
-  await sendRegistryTx(
-    'addAffiliateGroup',
-    target,
-    `Joining community ${shortenAddress(target)} …`,
-    'Join community'
-  );
+  await runTask({
+    name: `Joining community ${shortenAddress(target)} …`,
+    promise: (async () => {
+      if (await isAtFeeCap()) {
+        throw new Error(
+          'You are already committed to the 100% membership-fee cap. Leave a community before joining another.'
+        );
+      }
+      await submitRegistryTx('addAffiliateGroup', target, 'Join community');
+    })(),
+  });
 }
 
 /** Withdraw intent to join `group` (`removeAffiliateGroup`). */
 export async function leaveCommunity(group: Address): Promise<void> {
   const target = group.toLowerCase() as Address;
-  await sendRegistryTx(
-    'removeAffiliateGroup',
-    target,
-    `Leaving community ${shortenAddress(target)} …`,
-    'Leave community'
-  );
+  await runTask({
+    name: `Leaving community ${shortenAddress(target)} …`,
+    promise: submitRegistryTx('removeAffiliateGroup', target, 'Leave community'),
+  });
 }

--- a/circles-app/src/lib/areas/groups/utils/affiliateGroupActions.ts
+++ b/circles-app/src/lib/areas/groups/utils/affiliateGroupActions.ts
@@ -1,0 +1,158 @@
+import { get } from 'svelte/store';
+import { JsonRpcProvider } from 'ethers';
+import type { Address } from '@aboutcircles/sdk-types';
+
+import { circles } from '$lib/shared/state/circles';
+import { wallet } from '$lib/shared/state/wallet.svelte';
+import { avatarState } from '$lib/shared/state/avatar.svelte';
+import { runTask } from '$lib/shared/utils/tasks';
+import { shortenAddress } from '$lib/shared/utils/shared';
+import { sendRunnerTransactionAndWait } from '$lib/shared/utils/tx';
+import { getActiveConfig } from '$lib/shared/state/settings.svelte';
+import {
+  getAffiliateGroupFeesPercentage,
+  isMethodNotFound,
+} from '$lib/shared/data/circles/affiliateGroupQueries';
+import {
+  affiliateRegistryInterface,
+  encodeAffiliateGroupCall,
+} from '$lib/areas/groups/utils/affiliateGroupCalldata';
+
+/** The configured registry address (lowercased), or null when not on a supported network. */
+export function affiliateRegistryAddress(): Address | null {
+  const addr = getActiveConfig().multiAffiliateGroupRegistry;
+  return addr ? (addr.toLowerCase() as Address) : null;
+}
+
+/** Whether community join/leave is wired for the active network (Gnosis mainnet). */
+export function isAffiliateRegistryAvailable(): boolean {
+  return affiliateRegistryAddress() !== null;
+}
+
+function runnerAddress(): Address | null {
+  const r = get(wallet) as { address?: string } | null;
+  return r?.address ? (r.address.toLowerCase() as Address) : null;
+}
+
+function getRpcProvider(): JsonRpcProvider | null {
+  const config = getActiveConfig();
+  const rpcUrl = config.chainRpcUrl ?? config.circlesRpcUrl;
+  return rpcUrl ? new JsonRpcProvider(rpcUrl) : null;
+}
+
+// Translate a registry revert into a user-facing message, decoding the custom
+// errors where possible. Returns null when the data doesn't decode as one of them.
+function describeRegistryRevert(error: unknown): string | null {
+  const candidates: unknown[] = [
+    (error as { data?: unknown })?.data,
+    (error as { info?: { error?: { data?: unknown } } })?.info?.error?.data,
+    (error as { error?: { data?: unknown } })?.error?.data,
+    (error as { cause?: { data?: unknown } })?.cause?.data,
+    (error as { cause?: { info?: { error?: { data?: unknown } } } })?.cause?.info?.error?.data,
+  ];
+  for (const c of candidates) {
+    if (typeof c === 'string' && /^0x[0-9a-fA-F]{8,}$/.test(c)) {
+      try {
+        const parsed = affiliateRegistryInterface.parseError(c);
+        if (parsed?.name === 'OnlyHuman') {
+          return 'Only human avatars can join communities. Switch to a person avatar and try again.';
+        }
+        if (parsed?.name === 'AffiliateGroupNotExist') {
+          return 'That address is not a registered Circles group (or is not in your communities).';
+        }
+        if (parsed) return parsed.name;
+      } catch {
+        // not a registry error — fall through to the next candidate
+      }
+    }
+  }
+  return null;
+}
+
+// Best-effort preflight so we surface a clear reason instead of an opaque
+// execTransaction revert. Skipped silently if no provider is configured.
+async function preflight(from: Address, to: Address, data: string): Promise<string | null> {
+  const provider = getRpcProvider();
+  if (!provider) return null;
+  try {
+    await provider.call({ from, to, data });
+    return null;
+  } catch (error) {
+    return (
+      describeRegistryRevert(error) ??
+      (error instanceof Error ? error.message : 'execution reverted')
+    );
+  }
+}
+
+async function sendRegistryTx(
+  method: 'addAffiliateGroup' | 'removeAffiliateGroup',
+  group: Address,
+  taskName: string,
+  label: string
+): Promise<void> {
+  const registry = affiliateRegistryAddress();
+  if (!registry) throw new Error('Communities are not available on this network.');
+
+  const runner = get(wallet);
+  if (!runner?.sendTransaction) throw new Error('Wallet not connected.');
+
+  const from = runnerAddress();
+  if (!from) throw new Error('Wallet runner has no address — reconnect and try again.');
+
+  const data = encodeAffiliateGroupCall(method, group);
+
+  const reason = await preflight(from, registry, data);
+  if (reason) throw new Error(reason);
+
+  await runTask({
+    name: taskName,
+    promise: sendRunnerTransactionAndWait(runner, { to: registry, value: 0n, data }, { label }),
+  });
+}
+
+/**
+ * Signal on-chain intent to join `group` as a community (`addAffiliateGroup`).
+ * Idempotent on-chain (a no-op if already joined). Refuses early if the avatar is
+ * already at the 100% fee cap — best-effort: the guard is skipped when the read
+ * RPC doesn't expose the affiliate methods (e.g. the production server).
+ */
+export async function joinCommunity(group: Address): Promise<void> {
+  const target = group.toLowerCase() as Address;
+  const me = avatarState.avatar?.address?.toLowerCase() as Address | undefined;
+
+  // Best-effort cap guard: refuse if already committed to the full 100%.
+  const sdk = get(circles);
+  if (sdk && me) {
+    let committed: number | null = null;
+    try {
+      committed = await getAffiliateGroupFeesPercentage(sdk.rpc, me);
+    } catch (e) {
+      if (!isMethodNotFound(e)) throw e;
+      committed = null; // unreadable on this server → skip the guard
+    }
+    if (committed != null && committed >= 100) {
+      throw new Error(
+        'You are already committed to the 100% membership-fee cap. Leave a community before joining another.'
+      );
+    }
+  }
+
+  await sendRegistryTx(
+    'addAffiliateGroup',
+    target,
+    `Joining community ${shortenAddress(target)} …`,
+    'Join community'
+  );
+}
+
+/** Withdraw intent to join `group` (`removeAffiliateGroup`). */
+export async function leaveCommunity(group: Address): Promise<void> {
+  const target = group.toLowerCase() as Address;
+  await sendRegistryTx(
+    'removeAffiliateGroup',
+    target,
+    `Leaving community ${shortenAddress(target)} …`,
+    'Leave community'
+  );
+}

--- a/circles-app/src/lib/areas/groups/utils/affiliateGroupCalldata.ts
+++ b/circles-app/src/lib/areas/groups/utils/affiliateGroupCalldata.ts
@@ -1,0 +1,23 @@
+import { ethers } from 'ethers';
+import type { Address } from '@aboutcircles/sdk-types';
+
+/**
+ * MultiAffiliateGroupRegistry write ABI plus its decodable custom errors. Kept in
+ * a store-free module so the calldata encoding is unit-testable without pulling in
+ * the wallet/SDK state modules.
+ */
+export const affiliateRegistryInterface = new ethers.Interface([
+  'function addAffiliateGroup(address affiliateGroupToAdd) external',
+  'function removeAffiliateGroup(address affiliateGroupToRemove) external',
+  'error OnlyHuman()',
+  'error AffiliateGroupNotExist(address affiliateGroup)',
+  'error SenderNotDeployer()',
+]);
+
+/** ABI-encode an `addAffiliateGroup`/`removeAffiliateGroup` call for `group`. */
+export function encodeAffiliateGroupCall(
+  method: 'addAffiliateGroup' | 'removeAffiliateGroup',
+  group: Address
+): string {
+  return affiliateRegistryInterface.encodeFunctionData(method, [group.toLowerCase()]);
+}

--- a/circles-app/src/lib/areas/groups/utils/getAvatarCommunities.ts
+++ b/circles-app/src/lib/areas/groups/utils/getAvatarCommunities.ts
@@ -1,0 +1,71 @@
+import type { Sdk } from '@aboutcircles/sdk';
+import type { Address } from '@aboutcircles/sdk-types';
+import {
+  getAffiliateGroupWishlist,
+  getAffiliateGroups,
+  isMethodNotFound,
+  type AffiliateGroupRow,
+} from '$lib/shared/data/circles/affiliateGroupQueries';
+
+/** A wishlist community, annotated with whether the group has confirmed the avatar. */
+export interface AvatarCommunity extends AffiliateGroupRow {
+  /** true once the group also trusts the avatar on-chain (the bilateral handshake). */
+  confirmed: boolean;
+}
+
+export interface AvatarCommunities {
+  /** Sum of `membershipFee` across the wishlist; gate joins against the 100% cap. */
+  totalFeePercentage: number;
+  communities: AvatarCommunity[];
+  /**
+   * true when the connected RPC doesn't expose the affiliate methods (e.g. the
+   * production server before promotion). The UI shows an "available on staging"
+   * hint instead of an error.
+   */
+  unavailable: boolean;
+}
+
+const EMPTY: AvatarCommunities = {
+  totalFeePercentage: 0,
+  communities: [],
+  unavailable: false,
+};
+
+/**
+ * Load the communities an avatar has signalled intent to join, each flagged with
+ * its confirmed/pending trust status, plus the running total fee percentage.
+ *
+ * Wishlist = intent (the avatar signalled on-chain). The trusted set is a subset
+ * (the group also trusts the avatar) and lags the wishlist by the trust-manager
+ * delay, so a community stays "Pending" until that trust lands.
+ */
+export async function loadAvatarCommunities(
+  sdk: Sdk,
+  avatar: Address
+): Promise<AvatarCommunities> {
+  try {
+    const [wishlist, trusted] = await Promise.all([
+      getAffiliateGroupWishlist(sdk.rpc, avatar),
+      getAffiliateGroups(sdk.rpc, avatar),
+    ]);
+
+    const confirmedSet = new Set(trusted.groups.map((g) => g.groupAddress));
+    const communities: AvatarCommunity[] = wishlist.groups.map((g) => ({
+      ...g,
+      confirmed: confirmedSet.has(g.groupAddress),
+    }));
+
+    return {
+      totalFeePercentage: wishlist.totalFeePercentage,
+      communities,
+      unavailable: false,
+    };
+  } catch (err) {
+    // The methods are deployed together; if the server lacks them, surface a
+    // "not available here" state rather than propagating the error.
+    if (isMethodNotFound(err)) {
+      return { ...EMPTY, unavailable: true };
+    }
+    throw err;
+  }
+}

--- a/circles-app/src/lib/shared/config/circles.ts
+++ b/circles-app/src/lib/shared/config/circles.ts
@@ -40,6 +40,14 @@ export type CirclesConfig = BaseCirclesConfig & {
    * profile-less sink. Undefined → no migration labeling on this network.
    */
   scoreGroupMigrationSink?: string;
+  /**
+   * MultiAffiliateGroupRegistry (GA 2.0 communities) — the per-avatar registry of
+   * community (affiliate group) join intents, read by the Communities tab and
+   * written by its join/leave actions. Same address on every Gnosis-mainnet
+   * deployment (staging and production read the same chain). Undefined → community
+   * join/leave is unavailable on this network.
+   */
+  multiAffiliateGroupRegistry?: string;
 };
 
 export const chiadoConfig: { production: CirclesConfig; rings: CirclesConfig } =
@@ -143,6 +151,10 @@ export const gnosisConfig: { production: CirclesConfig; rings: CirclesConfig } =
       scoreGroupsBackendUrl: 'https://rpc.aboutcircles.com/score-groups',
       scoreGatedGroupAddress: '0x93eD5A96347927ff6fF6b790F8Cf5258240c321f',
       scoreGroupMigrationSink: '0xD4cF9afd3aE777C24454b70dd28E32d1bd516F05',
+      // MultiAffiliateGroupRegistry (GA 2.0 communities) — Gnosis mainnet. Reads
+      // need the staging indexer until the RPC methods are promoted to prod; the
+      // on-chain join/leave writes work against this address on either server.
+      multiAffiliateGroupRegistry: '0x4a25a7cf216351963f1637ad965d77b3ae277ef3',
     },
     rings: {
       circlesRpcUrl:

--- a/circles-app/src/lib/shared/data/circles/affiliateGroupQueries.ts
+++ b/circles-app/src/lib/shared/data/circles/affiliateGroupQueries.ts
@@ -1,0 +1,80 @@
+import type { CirclesRpc } from '@aboutcircles/sdk-rpc';
+import type { Address } from '@aboutcircles/sdk-types';
+
+/**
+ * A single community (affiliate group) an avatar has a relationship with, as
+ * returned by the `circles_getAffiliateGroup*` RPC methods. `membershipFee` is a
+ * percent in [0,100] of the avatar's daily gCRC mint, or `null` when the group's
+ * profile declares no fee.
+ */
+export interface AffiliateGroupRow {
+  groupName: string | null;
+  groupAddress: Address;
+  membershipFee: number | null;
+  timestamp: number;
+}
+
+/** Response shape shared by the wishlist (intent) and trusted (confirmed) methods. */
+export interface AffiliateGroupListResponse {
+  /** Sum of `membershipFee` over `groups`; a `null` fee contributes 0. */
+  totalFeePercentage: number;
+  groups: AffiliateGroupRow[];
+}
+
+/** JSON-RPC "method not found" error code (JSON-RPC 2.0 spec). */
+export const RPC_METHOD_NOT_FOUND = -32601;
+
+/**
+ * The five `circles_getAffiliateGroup*` methods are currently deployed on the
+ * staging indexer only. On a production-server RPC the call rejects with
+ * `-32601`; callers treat that as "feature unavailable on this server" rather
+ * than a hard error, so the Communities tab can show a hint instead of failing.
+ */
+export function isMethodNotFound(err: unknown): boolean {
+  const code = (err as { code?: number } | null)?.code;
+  if (code === RPC_METHOD_NOT_FOUND) return true;
+  const msg = err instanceof Error ? err.message : String(err ?? '');
+  return /method not found|not supported|does not exist|unknown method/i.test(msg);
+}
+
+function normalizeListResponse(
+  res: AffiliateGroupListResponse | null
+): AffiliateGroupListResponse {
+  return {
+    totalFeePercentage: Number(res?.totalFeePercentage ?? 0),
+    groups: (res?.groups ?? []).map((g) => ({
+      groupName: g.groupName ?? null,
+      groupAddress: String(g.groupAddress).toLowerCase() as Address,
+      membershipFee: g.membershipFee == null ? null : Number(g.membershipFee),
+      timestamp: Number(g.timestamp ?? 0),
+    })),
+  };
+}
+
+/** Communities an avatar has signalled on-chain intent to join (the wishlist). */
+export async function getAffiliateGroupWishlist(
+  circlesRpc: CirclesRpc,
+  avatar: Address
+): Promise<AffiliateGroupListResponse> {
+  const res: AffiliateGroupListResponse = await circlesRpc.client.call(
+    'circles_getAffiliateGroupWishlist',
+    [avatar.toLowerCase()]
+  );
+  return normalizeListResponse(res);
+}
+
+/**
+ * The confirmed-membership subset: groups that currently trust the avatar
+ * on-chain (the bilateral handshake). Always a subset of the wishlist, and lags
+ * it by the trust-manager delay.
+ */
+export async function getAffiliateGroups(
+  circlesRpc: CirclesRpc,
+  avatar: Address
+): Promise<AffiliateGroupListResponse> {
+  const res: AffiliateGroupListResponse = await circlesRpc.client.call(
+    'circles_getAffiliateGroups',
+    [avatar.toLowerCase()]
+  );
+  return normalizeListResponse(res);
+}

--- a/circles-app/src/lib/shared/data/circles/affiliateGroupQueries.ts
+++ b/circles-app/src/lib/shared/data/circles/affiliateGroupQueries.ts
@@ -78,3 +78,18 @@ export async function getAffiliateGroups(
   );
   return normalizeListResponse(res);
 }
+
+/**
+ * The avatar's total committed membership-fee percentage across its wishlist —
+ * the number to check against the 100% cap before signalling a new join.
+ */
+export async function getAffiliateGroupFeesPercentage(
+  circlesRpc: CirclesRpc,
+  avatar: Address
+): Promise<number> {
+  const res: { totalFeePercentage?: number } | null = await circlesRpc.client.call(
+    'circles_getAffiliateGroupFeesPercentage',
+    [avatar.toLowerCase()]
+  );
+  return Number(res?.totalFeePercentage ?? 0);
+}

--- a/circles-app/src/lib/shared/data/circles/affiliateGroupQueries.ts
+++ b/circles-app/src/lib/shared/data/circles/affiliateGroupQueries.ts
@@ -33,8 +33,12 @@ export const RPC_METHOD_NOT_FOUND = -32601;
 export function isMethodNotFound(err: unknown): boolean {
   const code = (err as { code?: number } | null)?.code;
   if (code === RPC_METHOD_NOT_FOUND) return true;
+  // Message fallback only for servers that don't set the JSON-RPC code. Kept
+  // narrow to the canonical "method not found" phrasing — generic substrings like
+  // "not supported" / "does not exist" would misclassify real failures (bad
+  // address, node errors) as "feature unavailable" and hide them.
   const msg = err instanceof Error ? err.message : String(err ?? '');
-  return /method not found|not supported|does not exist|unknown method/i.test(msg);
+  return /method not found|unknown method/i.test(msg);
 }
 
 function normalizeListResponse(

--- a/circles-app/src/routes/groups/+page.svelte
+++ b/circles-app/src/routes/groups/+page.svelte
@@ -10,11 +10,13 @@
     import { openFlowPopup } from '$lib/shared/state/popup';
     import CreateGroup from '$lib/areas/groups/flows/createGroup/1_CreateGroup.svelte';
     import GroupCard from './GroupCard.svelte';
+    import CommunityCard from './CommunityCard.svelte';
     import { resetCreateGroupContext } from '$lib/areas/groups/flows/createGroup/context';
     import { circles } from '$lib/shared/state/circles';
     import { CirclesStorage } from '$lib/shared/utils/storage';
     import { getBaseAndCmgGroupsByOwnerBatch } from '$lib/shared/utils/getGroupsByOwnerBatch';
     import { getGroupsByMember, streamGroupsByMember } from '$lib/areas/groups/utils/getGroupsByMemberBatch';
+    import { loadAvatarCommunities, type AvatarCommunity } from '$lib/areas/groups/utils/getAvatarCommunities';
 
     import { T } from '$lib/design-system/tokens.js';
     import Icon from '$lib/design-system/Icon.svelte';
@@ -34,22 +36,34 @@
     let membershipsLoading: boolean = $state(false);
     let membershipsError: string | null = $state(null);
 
+    // Communities = the multi-affiliate registry: groups the avatar has signalled
+    // on-chain intent to join, each flagged confirmed (group also trusts the
+    // avatar) or pending. Loaded lazily when the tab opens, since the backing
+    // RPC methods are staging-only until promotion.
+    let communities: AvatarCommunity[] = $state([]);
+    let communitiesTotalFee: number = $state(0);
+    let communitiesLoading: boolean = $state(false);
+    let communitiesError: string | null = $state(null);
+    let communitiesUnavailable: boolean = $state(false);
+
     let ownedGroupsLoadedForAvatar: string | null = $state(null);
     let membershipsLoadedForAvatar: string | null = $state(null);
     let allGroupsLoadedForAvatar: string | null = $state(null);
+    let communitiesLoadedForAvatar: string | null = $state(null);
 
     // Generation counter used to cancel stale streamGroupsByMember callbacks
     // when the user switches avatars (or otherwise triggers a refetch)
     // before the in-flight stream finishes.
     let membershipsLoadGeneration = 0;
 
-    type TabId = 'yours' | 'memberships' | 'all';
+    type TabId = 'yours' | 'memberships' | 'communities' | 'all';
     let selectedTab: TabId = $state('yours');
 
     const ownerAddress: string | undefined = $derived(
         (CirclesStorage.getInstance().avatar as string | undefined) ?? avatarState.avatar?.address
     );
     const canShowMembershipsTab: boolean = $derived(!!ownerAddress);
+    const canShowCommunitiesTab: boolean = $derived(!!ownerAddress);
     const canCreateGroup: boolean = $derived(!!$circles && !!CirclesStorage.getInstance().avatar);
 
     async function loadGroups(): Promise<void> {
@@ -133,6 +147,28 @@
         }
     }
 
+    async function loadCommunities(): Promise<void> {
+        if (!$circles || !ownerAddress) {
+            communities = []; communitiesTotalFee = 0;
+            communitiesLoading = false; communitiesError = null; communitiesUnavailable = false;
+            return;
+        }
+        const targetKey = String(ownerAddress).toLowerCase();
+        communitiesLoading = true; communitiesError = null;
+        try {
+            const result = await loadAvatarCommunities($circles, ownerAddress as Address);
+            communities = result.communities;
+            communitiesTotalFee = result.totalFeePercentage;
+            communitiesUnavailable = result.unavailable;
+            communitiesLoadedForAvatar = targetKey;
+        } catch (e) {
+            communitiesError = e instanceof Error ? e.message : String(e);
+            communities = [];
+        } finally {
+            communitiesLoading = false;
+        }
+    }
+
     $effect(() => {
         const avatar = avatarState.avatar;
         if (!avatar) { groups = undefined; allGroupsLoadedForAvatar = null; return; }
@@ -141,6 +177,20 @@
         if (allGroupsLoadedForAvatar === avatarKey && groups) return;
         allGroupsLoadedForAvatar = avatarKey;
         void loadGroups();
+    });
+
+    // Lazily load communities only when the tab is opened — keeps the staging-only
+    // affiliate RPC calls off every Groups visit, and off the production server.
+    $effect(() => {
+        if (selectedTab !== 'communities') return;
+        if (!$circles || !ownerAddress) {
+            communities = []; communitiesTotalFee = 0;
+            communitiesError = null; communitiesUnavailable = false; communitiesLoadedForAvatar = null;
+            return;
+        }
+        const ownerKey = String(ownerAddress).toLowerCase();
+        if (communitiesLoadedForAvatar === ownerKey || communitiesLoading) return;
+        void loadCommunities();
     });
 
     $effect(() => {
@@ -166,6 +216,7 @@
     $effect(() => {
         const availableTabs: TabId[] = ['yours'];
         if (canShowMembershipsTab) availableTabs.push('memberships');
+        if (canShowCommunitiesTab) availableTabs.push('communities');
         availableTabs.push('all');
         if (!availableTabs.includes(selectedTab)) selectedTab = availableTabs[0];
     });
@@ -191,6 +242,7 @@
     const tabItems = $derived([
         { id: 'yours' as TabId,       label: 'My groups',   count: ownedGroups.length },
         ...(canShowMembershipsTab ? [{ id: 'memberships' as TabId, label: 'Memberships', count: memberships.length }] : []),
+        ...(canShowCommunitiesTab ? [{ id: 'communities' as TabId, label: 'Communities', count: communitiesLoadedForAvatar ? communities.length : (undefined as number | undefined) }] : []),
         { id: 'all' as TabId,         label: 'Discover',    count: undefined as number | undefined },
     ]);
 </script>
@@ -342,6 +394,53 @@
                     <div class="grid grid-cols-2 md:grid-cols-3 gap-3">
                         {#each memberships as item, i (item.group)}
                             <GroupCard {item} variant="member" gradientIndex={i} />
+                        {/each}
+                    </div>
+                {/if}
+
+            {:else if selectedTab === 'communities'}
+                {#if !ownerAddress}
+                    <div style="background:{T.surface};border-radius:18px;border:1px solid {T.hairlineSoft};padding:24px 16px;text-align:center;">
+                        <span style="font-size:13.5px;color:{T.inkMuted};">Connect an avatar to see the communities you've signalled intent to join.</span>
+                    </div>
+                {:else if communitiesLoading}
+                    <div class="grid grid-cols-2 md:grid-cols-3 gap-3">
+                        {#each Array(3) as _, i (i)}
+                            <div style="border-radius:18px;background:{T.pageDeep};height:160px;" class="animate-pulse"></div>
+                        {/each}
+                    </div>
+                {:else if communitiesError}
+                    <div style="background:{T.surface};border-radius:18px;border:1px solid rgba(196,68,48,0.2);padding:18px 16px;display:flex;flex-direction:column;gap:10px;align-items:flex-start;">
+                        <div style="display:flex;flex-direction:column;gap:4px;">
+                            <span style="font-size:13.5px;font-weight:580;color:{T.ink};">Couldn't load communities</span>
+                            <span style="font-size:12px;color:{T.inkMuted};">{communitiesError}</span>
+                        </div>
+                        <button type="button" onclick={loadCommunities} style="height:32px;padding:0 14px;border-radius:9999px;border:1px solid {T.hairline};background:{T.surface};color:{T.ink};font-size:12.5px;font-weight:540;cursor:pointer;">Retry</button>
+                    </div>
+                {:else if communitiesUnavailable}
+                    <div style="background:{T.surface};border-radius:18px;border:1px solid {T.hairlineSoft};padding:24px 16px;text-align:center;display:flex;flex-direction:column;gap:6px;">
+                        <span style="font-size:13.5px;font-weight:580;color:{T.ink};">Communities aren't available on this server yet</span>
+                        <span style="font-size:12.5px;color:{T.inkMuted};line-height:1.45;">The multi-affiliate registry is live on the staging server. Switch the server to Staging in network settings to preview it.</span>
+                    </div>
+                {:else if communities.length === 0}
+                    <div style="background:{T.surface};border-radius:18px;border:1px solid {T.hairlineSoft};padding:24px 16px;text-align:center;">
+                        <span style="font-size:13.5px;color:{T.inkMuted};">You haven't signalled intent to join any communities yet.</span>
+                    </div>
+                {:else}
+                    <!-- Fee commitment summary: communities fees are capped at 100% of daily mint -->
+                    {@const feePct = Math.min(100, Math.max(0, communitiesTotalFee))}
+                    <div style="background:{T.surface};border-radius:18px;border:1px solid {T.hairlineSoft};padding:14px 16px;margin-bottom:12px;box-shadow:{T.shadow.xs};">
+                        <div style="display:flex;align-items:baseline;justify-content:space-between;gap:10px;">
+                            <span style="font-size:12.5px;font-weight:580;color:{T.inkBody};">Committed membership fees</span>
+                            <span style="font-size:13px;font-weight:600;font-variant-numeric:tabular-nums;color:{communitiesTotalFee >= 100 ? '#C44430' : T.ink};">{communitiesTotalFee}% <span style="color:{T.inkMuted};font-weight:540;">of 100%</span></span>
+                        </div>
+                        <div style="height:6px;border-radius:9999px;background:{T.pageDeep};margin-top:8px;overflow:hidden;">
+                            <div style="height:100%;width:{feePct}%;border-radius:9999px;background:{communitiesTotalFee >= 100 ? '#C44430' : T.primary};transition:width .2s ease-out;"></div>
+                        </div>
+                    </div>
+                    <div class="grid grid-cols-2 md:grid-cols-3 gap-3">
+                        {#each communities as item, i (item.groupAddress)}
+                            <CommunityCard {item} gradientIndex={i} />
                         {/each}
                     </div>
                 {/if}

--- a/circles-app/src/routes/groups/+page.svelte
+++ b/circles-app/src/routes/groups/+page.svelte
@@ -56,6 +56,9 @@
     // when the user switches avatars (or otherwise triggers a refetch)
     // before the in-flight stream finishes.
     let membershipsLoadGeneration = 0;
+    // Same idea for the communities load: drop a stale response if a newer load
+    // (e.g. avatar switch) started before it resolved.
+    let communitiesLoadGeneration = 0;
 
     type TabId = 'yours' | 'memberships' | 'communities' | 'all';
     let selectedTab: TabId = $state('yours');
@@ -160,21 +163,26 @@
             communitiesLoading = false; communitiesError = null; communitiesUnavailable = false;
             return;
         }
+        const generation = ++communitiesLoadGeneration;
         const cacheKey = communitiesCacheKey();
         communitiesLoading = true; communitiesError = null;
         try {
             const result = await loadAvatarCommunities($circles, ownerAddress as Address);
+            if (generation !== communitiesLoadGeneration) return; // a newer load started — drop stale result
             communities = result.communities;
             communitiesTotalFee = result.totalFeePercentage;
             communitiesUnavailable = result.unavailable;
         } catch (e) {
+            if (generation !== communitiesLoadGeneration) return;
             communitiesError = e instanceof Error ? e.message : String(e);
             communities = [];
         } finally {
-            // Mark this key attempted (success OR error) so the effect doesn't
-            // auto-retry into a loop; the user retries explicitly, which bumps the token.
-            communitiesLoadedForAvatar = cacheKey;
-            communitiesLoading = false;
+            if (generation === communitiesLoadGeneration) {
+                // Mark this key attempted (success OR error) so the effect doesn't
+                // auto-retry into a loop; the user retries explicitly, which bumps the token.
+                communitiesLoadedForAvatar = cacheKey;
+                communitiesLoading = false;
+            }
         }
     }
 

--- a/circles-app/src/routes/groups/+page.svelte
+++ b/circles-app/src/routes/groups/+page.svelte
@@ -17,6 +17,7 @@
     import { getBaseAndCmgGroupsByOwnerBatch } from '$lib/shared/utils/getGroupsByOwnerBatch';
     import { getGroupsByMember, streamGroupsByMember } from '$lib/areas/groups/utils/getGroupsByMemberBatch';
     import { loadAvatarCommunities, type AvatarCommunity } from '$lib/areas/groups/utils/getAvatarCommunities';
+    import { communitiesRefresh, invalidateCommunities } from '$lib/areas/groups/state/communitiesSignal.svelte';
 
     import { T } from '$lib/design-system/tokens.js';
     import Icon from '$lib/design-system/Icon.svelte';
@@ -147,24 +148,32 @@
         }
     }
 
+    // Cache key folds in the refresh token so a join/leave (which bumps the token)
+    // forces a reload even for the same avatar.
+    function communitiesCacheKey(): string {
+        return `${String(ownerAddress).toLowerCase()}:${communitiesRefresh.token}`;
+    }
+
     async function loadCommunities(): Promise<void> {
         if (!$circles || !ownerAddress) {
             communities = []; communitiesTotalFee = 0;
             communitiesLoading = false; communitiesError = null; communitiesUnavailable = false;
             return;
         }
-        const targetKey = String(ownerAddress).toLowerCase();
+        const cacheKey = communitiesCacheKey();
         communitiesLoading = true; communitiesError = null;
         try {
             const result = await loadAvatarCommunities($circles, ownerAddress as Address);
             communities = result.communities;
             communitiesTotalFee = result.totalFeePercentage;
             communitiesUnavailable = result.unavailable;
-            communitiesLoadedForAvatar = targetKey;
         } catch (e) {
             communitiesError = e instanceof Error ? e.message : String(e);
             communities = [];
         } finally {
+            // Mark this key attempted (success OR error) so the effect doesn't
+            // auto-retry into a loop; the user retries explicitly, which bumps the token.
+            communitiesLoadedForAvatar = cacheKey;
             communitiesLoading = false;
         }
     }
@@ -181,15 +190,17 @@
 
     // Lazily load communities only when the tab is opened — keeps the staging-only
     // affiliate RPC calls off every Groups visit, and off the production server.
+    // Reading communitiesRefresh.token makes a join/leave invalidate the cache.
     $effect(() => {
+        const token = communitiesRefresh.token;
         if (selectedTab !== 'communities') return;
         if (!$circles || !ownerAddress) {
             communities = []; communitiesTotalFee = 0;
             communitiesError = null; communitiesUnavailable = false; communitiesLoadedForAvatar = null;
             return;
         }
-        const ownerKey = String(ownerAddress).toLowerCase();
-        if (communitiesLoadedForAvatar === ownerKey || communitiesLoading) return;
+        const cacheKey = `${String(ownerAddress).toLowerCase()}:${token}`;
+        if (communitiesLoadedForAvatar === cacheKey || communitiesLoading) return;
         void loadCommunities();
     });
 
@@ -242,7 +253,7 @@
     const tabItems = $derived([
         { id: 'yours' as TabId,       label: 'My groups',   count: ownedGroups.length },
         ...(canShowMembershipsTab ? [{ id: 'memberships' as TabId, label: 'Memberships', count: memberships.length }] : []),
-        ...(canShowCommunitiesTab ? [{ id: 'communities' as TabId, label: 'Communities', count: communitiesLoadedForAvatar ? communities.length : (undefined as number | undefined) }] : []),
+        ...(canShowCommunitiesTab ? [{ id: 'communities' as TabId, label: 'Communities', count: (communitiesLoadedForAvatar && !communitiesUnavailable) ? communities.length : (undefined as number | undefined) }] : []),
         { id: 'all' as TabId,         label: 'Discover',    count: undefined as number | undefined },
     ]);
 </script>
@@ -415,7 +426,7 @@
                             <span style="font-size:13.5px;font-weight:580;color:{T.ink};">Couldn't load communities</span>
                             <span style="font-size:12px;color:{T.inkMuted};">{communitiesError}</span>
                         </div>
-                        <button type="button" onclick={loadCommunities} style="height:32px;padding:0 14px;border-radius:9999px;border:1px solid {T.hairline};background:{T.surface};color:{T.ink};font-size:12.5px;font-weight:540;cursor:pointer;">Retry</button>
+                        <button type="button" onclick={() => invalidateCommunities()} style="height:32px;padding:0 14px;border-radius:9999px;border:1px solid {T.hairline};background:{T.surface};color:{T.ink};font-size:12.5px;font-weight:540;cursor:pointer;">Retry</button>
                     </div>
                 {:else if communitiesUnavailable}
                     <div style="background:{T.surface};border-radius:18px;border:1px solid {T.hairlineSoft};padding:24px 16px;text-align:center;display:flex;flex-direction:column;gap:6px;">
@@ -423,8 +434,16 @@
                         <span style="font-size:12.5px;color:{T.inkMuted};line-height:1.45;">The multi-affiliate registry is live on the staging server. Switch the server to Staging in network settings to preview it.</span>
                     </div>
                 {:else if communities.length === 0}
-                    <div style="background:{T.surface};border-radius:18px;border:1px solid {T.hairlineSoft};padding:24px 16px;text-align:center;">
+                    <div style="background:{T.surface};border-radius:18px;border:1px solid {T.hairlineSoft};padding:24px 16px;text-align:center;display:flex;flex-direction:column;gap:12px;align-items:center;">
                         <span style="font-size:13.5px;color:{T.inkMuted};">You haven't signalled intent to join any communities yet.</span>
+                        <button
+                            type="button"
+                            onclick={() => selectedTab = 'all'}
+                            style="height:36px;padding:0 14px;border-radius:9999px;background:transparent;color:{T.ink};border:1px solid {T.hairline};cursor:pointer;display:inline-flex;align-items:center;gap:6px;font-family:{T.fontSans};font-size:13px;font-weight:540;"
+                        >
+                            Browse groups to join
+                            <Icon name="chevronRight" size={14} stroke={T.ink} />
+                        </button>
                     </div>
                 {:else}
                     <!-- Fee commitment summary: communities fees are capped at 100% of daily mint -->
@@ -440,7 +459,7 @@
                     </div>
                     <div class="grid grid-cols-2 md:grid-cols-3 gap-3">
                         {#each communities as item, i (item.groupAddress)}
-                            <CommunityCard {item} gradientIndex={i} />
+                            <CommunityCard {item} gradientIndex={i} onLeave={() => invalidateCommunities()} />
                         {/each}
                     </div>
                 {/if}

--- a/circles-app/src/routes/groups/CommunityCard.svelte
+++ b/circles-app/src/routes/groups/CommunityCard.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+    import { T } from '$lib/design-system/tokens.js';
+    import Icon from '$lib/design-system/Icon.svelte';
+    import Avatar from '$lib/shared/ui/avatar/Avatar.svelte';
+    import { openProfilePopup } from '$lib/shared/ui/profile/openProfilePopup';
+    import type { AvatarCommunity } from '$lib/areas/groups/utils/getAvatarCommunities';
+
+    interface Props {
+        item: AvatarCommunity;
+        gradientIndex?: number;
+    }
+    let { item, gradientIndex = 0 }: Props = $props();
+
+    const gradients = [
+        'linear-gradient(120deg,#FBE3D8,#F5DCE6)',
+        'linear-gradient(120deg,#EEEBFA,#FBEFCB)',
+        'linear-gradient(120deg,#DCEBDF,#FBEFCB)',
+        'linear-gradient(120deg,#EEEBFA,#FBE3D8)',
+        'linear-gradient(120deg,#FBE3D8,#FBEFCB)',
+        'linear-gradient(120deg,#DCEBDF,#EEEBFA)',
+    ];
+    const gradient = $derived(gradients[gradientIndex % gradients.length]);
+
+    // Fee shown beneath the group name. `null` means the group declares no fee.
+    const feeLabel = $derived(item.membershipFee == null ? 'No fee' : `${item.membershipFee}% fee`);
+</script>
+
+<button
+    type="button"
+    class="community-card"
+    onclick={() => openProfilePopup(item.groupAddress)}
+    aria-label={`Open community ${item.groupName ?? item.groupAddress}`}
+    style="
+        text-align:left;width:100%;padding:0;cursor:pointer;
+        background:{T.surface};
+        border:1px solid {T.hairlineSoft};border-radius:18px;
+        overflow:hidden;box-shadow:{T.shadow.xs};
+        transition:box-shadow .18s ease-out, transform .18s ease-out;
+        display:flex;flex-direction:column;
+    "
+>
+    <!-- Gradient header band with the confirmed/pending status badge -->
+    <div style="height:64px;background:{gradient};position:relative;flex-shrink:0;">
+        {#if item.confirmed}
+            <span style="position:absolute;right:12px;top:12px;display:inline-flex;align-items:center;padding:3px 9px;border-radius:9999px;background:{T.sageSoft};color:#1F5E37;font-size:10.5px;font-weight:580;letter-spacing:0.02em;">Confirmed</span>
+        {:else}
+            <span style="position:absolute;right:12px;top:12px;display:inline-flex;align-items:center;padding:3px 9px;border-radius:9999px;background:{T.butterSoft};color:#7A5B12;font-size:10.5px;font-weight:580;letter-spacing:0.02em;">Pending</span>
+        {/if}
+    </div>
+
+    <!-- Body -->
+    <div style="padding:14px 16px 16px;display:flex;flex-direction:column;gap:8px;flex:1;">
+        <Avatar
+            address={item.groupAddress}
+            view="horizontal"
+            clickable={false}
+            showTypeInfo={false}
+            bottomInfo={feeLabel}
+            placeholderAvatar={false}
+            placeholderTop={true}
+            placeholderBottom={true}
+        />
+        <div style="display:flex;align-items:center;gap:8px;margin-top:auto;padding-top:10px;border-top:1px solid {T.hairlineSoft};">
+            <span style="font-size:11px;font-weight:580;color:{T.inkMuted};letter-spacing:0.04em;text-transform:uppercase;">View</span>
+            <div style="flex:1;"></div>
+            <Icon name="chevronRight" size={14} stroke={T.inkMuted} />
+        </div>
+    </div>
+</button>
+
+<style>
+    .community-card:hover {
+        box-shadow: 0 6px 16px rgba(15,10,30,0.08), 0 1px 3px rgba(15,10,30,0.04);
+        transform: translateY(-1px);
+    }
+</style>

--- a/circles-app/src/routes/groups/CommunityCard.svelte
+++ b/circles-app/src/routes/groups/CommunityCard.svelte
@@ -4,12 +4,18 @@
     import Avatar from '$lib/shared/ui/avatar/Avatar.svelte';
     import { openProfilePopup } from '$lib/shared/ui/profile/openProfilePopup';
     import type { AvatarCommunity } from '$lib/areas/groups/utils/getAvatarCommunities';
+    import { leaveCommunity, isAffiliateRegistryAvailable } from '$lib/areas/groups/utils/affiliateGroupActions';
 
     interface Props {
         item: AvatarCommunity;
         gradientIndex?: number;
+        /** Called after a successful leave so the parent can refresh its list. */
+        onLeave?: () => void | Promise<void>;
     }
-    let { item, gradientIndex = 0 }: Props = $props();
+    let { item, gradientIndex = 0, onLeave }: Props = $props();
+
+    let leaving: boolean = $state(false);
+    const canLeave = $derived(isAffiliateRegistryAvailable());
 
     const gradients = [
         'linear-gradient(120deg,#FBE3D8,#F5DCE6)',
@@ -23,15 +29,43 @@
 
     // Fee shown beneath the group name. `null` means the group declares no fee.
     const feeLabel = $derived(item.membershipFee == null ? 'No fee' : `${item.membershipFee}% fee`);
+
+    function open() {
+        openProfilePopup(item.groupAddress);
+    }
+
+    function onKeydown(event: KeyboardEvent) {
+        if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            open();
+        }
+    }
+
+    async function handleLeave(event: MouseEvent) {
+        event.stopPropagation();
+        if (leaving) return;
+        leaving = true;
+        try {
+            await leaveCommunity(item.groupAddress);
+            await onLeave?.();
+        } catch (e) {
+            // The task runner surfaces the failure; keep the card interactive.
+            console.error('Failed to leave community', e);
+        } finally {
+            leaving = false;
+        }
+    }
 </script>
 
-<button
-    type="button"
+<div
+    role="button"
+    tabindex={0}
     class="community-card"
-    onclick={() => openProfilePopup(item.groupAddress)}
+    onclick={open}
+    onkeydown={onKeydown}
     aria-label={`Open community ${item.groupName ?? item.groupAddress}`}
     style="
-        text-align:left;width:100%;padding:0;cursor:pointer;
+        text-align:left;width:100%;cursor:pointer;
         background:{T.surface};
         border:1px solid {T.hairlineSoft};border-radius:18px;
         overflow:hidden;box-shadow:{T.shadow.xs};
@@ -63,10 +97,27 @@
         <div style="display:flex;align-items:center;gap:8px;margin-top:auto;padding-top:10px;border-top:1px solid {T.hairlineSoft};">
             <span style="font-size:11px;font-weight:580;color:{T.inkMuted};letter-spacing:0.04em;text-transform:uppercase;">View</span>
             <div style="flex:1;"></div>
-            <Icon name="chevronRight" size={14} stroke={T.inkMuted} />
+            {#if canLeave}
+                <button
+                    type="button"
+                    onclick={handleLeave}
+                    disabled={leaving}
+                    aria-label={`Leave community ${item.groupName ?? item.groupAddress}`}
+                    style="
+                        height:28px;padding:0 12px;border-radius:9999px;cursor:pointer;
+                        background:transparent;color:#C44430;border:1px solid rgba(196,68,48,0.3);
+                        font-family:{T.fontSans};font-size:11.5px;font-weight:560;
+                        opacity:{leaving ? 0.6 : 1};
+                    "
+                >
+                    {leaving ? 'Leaving…' : 'Leave'}
+                </button>
+            {:else}
+                <Icon name="chevronRight" size={14} stroke={T.inkMuted} />
+            {/if}
         </div>
     </div>
-</button>
+</div>
 
 <style>
     .community-card:hover {

--- a/circles-app/src/routes/groups/GroupRowView.svelte
+++ b/circles-app/src/routes/groups/GroupRowView.svelte
@@ -8,6 +8,9 @@
     import { openFlowPopup } from '$lib/shared/state/popup';
     import LeaveGroup from '$lib/areas/groups/ui/pages/LeaveGroup.svelte';
     import { T } from '$lib/design-system/tokens.js';
+    import { avatarState } from '$lib/shared/state/avatar.svelte';
+    import { joinCommunity, isAffiliateRegistryAvailable } from '$lib/areas/groups/utils/affiliateGroupActions';
+    import { invalidateCommunities } from '$lib/areas/groups/state/communitiesSignal.svelte';
 
     interface Props {
         item: GroupRow;
@@ -17,6 +20,26 @@
     let { item, showOptOut = false, onLeft }: Props = $props();
 
     let optOutSupported: boolean = $state(false);
+
+    // "Join as community" = signal on-chain intent in the multi-affiliate registry.
+    // Only humans can signal, and only where the registry is configured (Gnosis).
+    let joining: boolean = $state(false);
+    const canJoin = $derived(isAffiliateRegistryAvailable() && avatarState.isHuman === true);
+
+    async function handleJoin(event: MouseEvent): Promise<void> {
+        event.stopPropagation();
+        if (joining) return;
+        joining = true;
+        try {
+            await joinCommunity(item.group);
+            invalidateCommunities();
+        } catch (e) {
+            // The task runner surfaces the failure; keep the row interactive.
+            console.error('Failed to join community', e);
+        } finally {
+            joining = false;
+        }
+    }
 
     $effect(() => {
         if (!showOptOut) return;
@@ -93,6 +116,17 @@
             bottomInfo={`${item.memberCount} member${item.memberCount === 1 ? '' : 's'}`}
         />
     </div>
+    {#if canJoin}
+        <button
+            type="button"
+            class="btn btn-xs btn-outline"
+            onclick={handleJoin}
+            disabled={joining}
+            aria-label={`Join community ${item.group}`}
+        >
+            {joining ? 'Joining…' : 'Join'}
+        </button>
+    {/if}
     {#if showOptOut && optOutSupported}
         <button
             type="button"


### PR DESCRIPTION
## Summary

Surfaces GA 2.0 **communities** (multi-affiliate groups) in the wallet: see the communities the connected avatar has signalled intent to join, and signal/withdraw that intent on-chain. Sourced from the `circles_getAffiliateGroup*` RPC methods; writes go to the `MultiAffiliateGroupRegistry`.

### View (read)
- A **Communities** tab on the Groups page, gated on a connected avatar, loaded lazily when opened.
- Merges the wishlist (intent) with the trusted subset, badging each community **Confirmed** (the group also trusts the avatar) or **Pending**.
- Shows the running committed-fee percentage against the 100% cap.
- Degrades gracefully when the RPC server lacks the methods (JSON-RPC `-32601`): shows an "available on staging" hint, so it lights up automatically once the methods are promoted to production. The existing Production/Staging server toggle exposes the staging deployment where they are already live.

### Join / leave (write)
- **Join** action on the Discover (all-groups) rows — signals intent (`addAffiliateGroup`), idempotent on-chain. Gated to human avatars on registry-configured networks.
- **Leave** action on a community card (`removeAffiliateGroup`).
- Sent via the avatar's Safe (ethers `Interface` + `sendRunnerTransactionAndWait`), with a preflight that decodes `OnlyHuman` / `AffiliateGroupNotExist` into readable messages, and a best-effort 100% fee-cap guard.
- After a write, a small refresh signal invalidates the Communities tab cache.

## Changes

- `lib/shared/config/circles.ts` — register the registry address (Gnosis mainnet).
- `lib/shared/data/circles/affiliateGroupQueries.ts` — typed read wrappers (wishlist, trusted, fee %) + method-not-found detection.
- `lib/areas/groups/utils/getAvatarCommunities.ts` — merge wishlist + trusted into the annotated model.
- `lib/areas/groups/utils/affiliateGroupCalldata.ts` — store-free ABI encode (unit-tested).
- `lib/areas/groups/utils/affiliateGroupActions.ts` — join/leave via the Safe, preflight, cap guard.
- `lib/areas/groups/state/communitiesSignal.svelte.ts` — cross-tab cache invalidation signal.
- `routes/groups/CommunityCard.svelte` — community card with Leave.
- `routes/groups/GroupRowView.svelte` — gated Join on Discover rows.
- `routes/groups/+page.svelte` — the tab, fee-cap meter, lazy load + cache wiring.
- `lib/__tests__/avatarCommunities.test.ts`, `lib/__tests__/affiliateGroupCalldata.test.ts` — unit tests.

## Notes

- The read methods are staging-indexer-only until promotion; the on-chain writes work on either server (same chain). No feature flag — visibility is config/availability-driven.
- The existing `groupMetrics.svelte.ts` `countCurrentAffiliateMembers()` queries the **legacy** single-affiliate `AffiliateGroupChanged` registry; reconciling it with the new multi-affiliate model is a separate follow-up.
- Write-side helpers are not in the SDK (`@aboutcircles/sdk@0.1.47`); calldata is built directly here. A typed SDK wrapper can replace it later without UI changes.

## Test plan

- [ ] \`npm run test:run\` — \`avatarCommunities\` + \`affiliateGroupCalldata\` pass.
- [ ] \`npm run check\` — no new svelte-check errors.
- [ ] Server = Staging, human avatar: Groups → Discover → **Join** a group → toast → Groups → Communities shows it as **Pending** with its fee; the committed-fee meter updates.
- [ ] Communities → **Leave** a community → it disappears after refresh.
- [ ] Join is hidden for non-human (group/org) avatars and on non-Gnosis networks.
- [ ] Server = Production: Communities shows the "available on staging" hint (no error).
- [ ] Cap guard: an avatar already at 100% committed fee is blocked from joining with a clear message.