### PR TITLE
fix(wallet,ui): curate wallet connectors and fix form-control styling

### DIFF
--- a/circles-app/src/app.css
+++ b/circles-app/src/app.css
@@ -156,6 +156,10 @@ a:focus-visible,
 
 /* Ensure native inputs have a sensible border-radius */
 input:not([type="checkbox"]):not([type="radio"]):not([type="range"]), textarea, select { border-radius: 8px; }
+/* DaisyUI's .textarea pulls --rounded-btn (9999px, intended for pill buttons),
+   which turns multi-line inputs into capsules. Element-qualified selector
+   (specificity 0,1,1) pins textareas to a sane radius regardless of source order. */
+textarea.textarea { border-radius: 12px; }
 
 /* Row tokens */
 :root {

--- a/circles-app/src/config.ts
+++ b/circles-app/src/config.ts
@@ -1,6 +1,6 @@
 import { http, createConfig } from '@wagmi/core';
 import { gnosis } from '@wagmi/core/chains';
-import { injected, coinbaseWallet, safe } from '@wagmi/connectors';
+import { injected } from '@wagmi/connectors';
 import { gnosisConfig } from '$lib/shared/config/circles';
 
 // Single source of truth: all chain RPC URLs come from circles.ts
@@ -8,10 +8,14 @@ const chainRpcUrl = gnosisConfig.production.chainRpcUrl ?? gnosisConfig.producti
 
 export const config = createConfig({
   chains: [gnosis],
+  // Only the generic injected connector is configured explicitly. Real wallets
+  // (MetaMask, Rabby, …) are surfaced via wagmi's default EIP-6963 discovery, and
+  // Safe accounts use the native SafeBrowserRunner flow (the wagmi `safe()` connector
+  // is deliberately not used — see wallet.svelte.ts). `coinbaseWallet()` was dropped:
+  // its SDK rendered an option unconditionally even without the extension, and
+  // Coinbase Smart Wallet doesn't support Gnosis (chainId 100).
   connectors: [
     injected(),
-    coinbaseWallet({ appName: 'Circles' }),
-    safe(),
   ],
   transports: {
     [gnosis.id]: http(chainRpcUrl),

--- a/circles-app/src/lib/shared/ui/forms/AddressInput.svelte
+++ b/circles-app/src/lib/shared/ui/forms/AddressInput.svelte
@@ -86,7 +86,7 @@
   <input
     bind:this={input}
     type="text"
-    class="input input-bordered bg-gray-100 flex-1"
+    class="input input-bordered bg-base-200 flex-1"
     placeholder="Enter or scan Ethereum address"
     oninput={handleInput}
     onpaste={handleInput}
@@ -99,7 +99,7 @@
 </div>
 
 {#if isScanning}
-  <div class="fixed top-0 left-0 w-screen h-screen z-100">
+  <div class="fixed top-0 left-0 w-screen h-screen z-[1000]">
     <div id="qr-scanner" class="w-[300px] my-5 mx-auto"></div>
   </div>
 {/if}

--- a/circles-app/src/routes/market/+page.svelte
+++ b/circles-app/src/routes/market/+page.svelte
@@ -376,9 +376,11 @@
                     <button
                         onclick={loadNextPage}
                         disabled={loading}
+                        aria-busy={loading}
                         style="
                             height:38px;padding:0 18px;border-radius:9999px;
-                            background:{T.surface};color:{T.inkBody};border:1px solid {T.hairline};cursor:pointer;
+                            background:{T.surface};color:{T.inkBody};border:1px solid {T.hairline};
+                            cursor:{loading ? 'not-allowed' : 'pointer'};
                             font-family:{T.fontSans};font-size:13px;font-weight:540;
                             opacity:{loading ? 0.5 : 1};
                         "


### PR DESCRIPTION
## Summary
Curate the wallet connection options and fix three form-control / overlay styling bugs.

## Changes
- **Wallet picker:** remove the `coinbaseWallet` and `safe` wagmi connectors; keep `injected`. Installed wallets (MetaMask, Rabby, Brave, …) continue to surface via wagmi's EIP-6963 discovery, and Safe accounts use the existing native SafeBrowserRunner flow. The `coinbaseWallet` connector rendered an option unconditionally (its SDK needs no extension) and Coinbase Smart Wallet does not support Gnosis (chainId 100), so the entry was a dead end. Wallet restore degrades gracefully — a previously persisted `coinbaseWallet`/`safe` connector id falls back to `injected`.
- **Textarea radius:** DaisyUI's `.textarea` inherits `--rounded-btn` (9999px, used for pill buttons), rendering multi-line inputs as capsules. Pin `textarea.textarea` to 12px (element-qualified selector wins on specificity; does not affect single-line `.input`/`.select`).
- **QR scanner overlay:** `z-100` is not a Tailwind utility (compiles to `z-index:auto`), so the mobile QR overlay could render behind popups/toasts. Use `z-[1000]`.
- **AddressInput:** use the `bg-base-200` theme token instead of hardcoded `bg-gray-100`.
- **Marketplace "Load more":** add `aria-busy` and a `not-allowed` cursor while loading.

## Test plan
- [x] `npm run check` — clean (0 errors)
- [ ] Connect-wallet popup lists installed wallets + Injected + Circles.garden; no Coinbase/Safe entries
- [ ] Wallet restore still works for an existing injected session
- [ ] Add-trust bulk textarea renders with a normal radius (not a capsule)
- [ ] Mobile QR scan overlay appears above the popup