### PR TITLE
feat(shell): always-visible Production/Staging server switcher

### DIFF
--- a/circles-app/src/lib/shared/ui/shell/AppSidebar.svelte
+++ b/circles-app/src/lib/shared/ui/shell/AppSidebar.svelte
@@ -21,6 +21,7 @@
   import { settings } from '$lib/shared/state/settings.svelte';
   import Tooltip from '$lib/shared/ui/primitives/Tooltip.svelte';
   import EnvironmentInfoPopup from '$lib/shared/ui/shell/EnvironmentInfoPopup.svelte';
+  import ServerSwitcher from '$lib/shared/ui/shell/ServerSwitcher.svelte';
 
   // "Invite" is only meaningful for human v2 avatars. While the avatar is still
   // restoring (`avatar` undefined) we OPTIMISTICALLY reserve its slot — the common
@@ -209,8 +210,9 @@
     </div>
   {/if}
 
-  <!-- Footer: network + live realtime status; opens an environment-details popup on click. -->
-  <div style="margin-top:auto;padding:8px 8px 0;border-top:1px solid {T.hairlineSoft};">
+  <!-- Footer: server switch + network/live realtime status (opens an environment-details popup). -->
+  <div style="margin-top:auto;padding:10px 8px 0;border-top:1px solid {T.hairlineSoft};display:flex;flex-direction:column;gap:4px;">
+    <ServerSwitcher direction="up" />
     <Tooltip content={`${realtimeLabel} · click for details`} class="block w-full">
       <button
         type="button"

--- a/circles-app/src/lib/shared/ui/shell/ServerSwitcher.svelte
+++ b/circles-app/src/lib/shared/ui/shell/ServerSwitcher.svelte
@@ -1,0 +1,143 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { T } from '$lib/design-system/tokens.js';
+  import { settings, updateSettings } from '$lib/shared/state/settings.svelte';
+
+  type Server = 'production' | 'staging';
+
+  // Which way the menu opens — 'up' for the desktop sidebar footer (anchored at the
+  // bottom of the viewport), 'down' for the mobile header.
+  let { direction = 'down' }: { direction?: 'up' | 'down' } = $props();
+
+  // The server toggle only maps to a real alternate backend on Gnosis mainnet (staging
+  // indexes the same chain); on other networks there's nothing to switch, so hide it.
+  const isSwitchable = $derived(settings.network === 'gnosis');
+
+  const options: { id: Server; label: string }[] = [
+    { id: 'production', label: 'Production' },
+    { id: 'staging', label: 'Staging' },
+  ];
+  const active = $derived(settings.server === 'staging' ? 'staging' : 'production');
+  const isStaging = $derived(active === 'staging');
+
+  let detailsEl: HTMLDetailsElement | null = $state(null);
+  function close(): void {
+    if (detailsEl?.open) detailsEl.open = false;
+  }
+  function choose(target: Server): void {
+    close();
+    if (target === active) return;
+    // The SDK and its realtime websocket are built once at wallet init, so the switch
+    // can't take effect live — persist the choice and reload to rebuild against the new
+    // backend (same contract as the Environment popup's toggle).
+    updateSettings({ server: target });
+    if (typeof window !== 'undefined') window.location.reload();
+  }
+
+  function onDocClick(e: MouseEvent): void {
+    const t = e.target as Node | null;
+    if (detailsEl?.open && t && !detailsEl.contains(t)) close();
+  }
+  function onKeydown(e: KeyboardEvent): void {
+    if (e.key === 'Escape') close();
+  }
+  onMount(() => {
+    document.addEventListener('click', onDocClick);
+    document.addEventListener('keydown', onKeydown);
+    return () => {
+      document.removeEventListener('click', onDocClick);
+      document.removeEventListener('keydown', onKeydown);
+    };
+  });
+</script>
+
+{#if isSwitchable}
+  <details bind:this={detailsEl} class="serverswitch">
+    <summary
+      class="serverswitch-chip"
+      aria-haspopup="menu"
+      title={isStaging
+        ? 'Data source: Staging backend — click to switch'
+        : 'Data source: Production backend — click to switch'}
+      style="
+        display:inline-flex;align-items:center;gap:5px;cursor:pointer;
+        font-family:{T.fontSans};font-size:11.5px;font-weight:560;line-height:1;
+        padding:4px 8px;border-radius:9999px;white-space:nowrap;
+        background:{isStaging ? 'rgba(217,119,6,0.12)' : 'transparent'};
+        color:{isStaging ? '#B45309' : T.inkMuted};
+        border:1px solid {isStaging ? 'rgba(217,119,6,0.30)' : T.hairline};
+      "
+    >
+      <span
+        style="width:6px;height:6px;border-radius:9999px;flex-shrink:0;background:{isStaging ? '#D97706' : T.inkFaint};"
+        aria-hidden="true"
+      ></span>
+      {options.find((o) => o.id === active)?.label}
+      <svg viewBox="0 0 12 12" aria-hidden="true" style="width:9px;height:9px;opacity:0.55;">
+        <path d="M3 4.5 6 7.5 9 4.5" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" />
+      </svg>
+    </summary>
+
+    <div
+      role="menu"
+      class="serverswitch-menu"
+      style="
+        position:absolute;{direction === 'up' ? 'bottom:calc(100% + 6px);' : 'top:calc(100% + 6px);'}left:0;z-index:30;
+        min-width:196px;background:{T.surface};border:1px solid {T.hairline};border-radius:12px;
+        box-shadow:0 8px 28px rgba(15,10,30,0.14);padding:6px;
+      "
+    >
+      <div
+        style="font-size:10px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:{T.inkFaint};padding:5px 8px 4px;"
+      >
+        Data source
+      </div>
+      {#each options as opt}
+        {@const on = opt.id === active}
+        <button
+          type="button"
+          role="menuitemradio"
+          aria-checked={on}
+          onclick={() => choose(opt.id)}
+          class="serverswitch-item"
+          style="
+            display:flex;align-items:center;gap:8px;width:100%;text-align:left;cursor:pointer;
+            background:{on ? T.surfaceAlt : 'transparent'};border:0;border-radius:8px;
+            padding:7px 8px;font-family:{T.fontSans};font-size:12.5px;color:{T.inkBody};
+          "
+        >
+          <span
+            style="width:7px;height:7px;border-radius:9999px;flex-shrink:0;background:{opt.id === 'staging' ? '#D97706' : T.inkFaint};"
+            aria-hidden="true"
+          ></span>
+          <span style="flex:1;font-weight:{on ? 580 : 480};">{opt.label}</span>
+          {#if on}
+            <svg viewBox="0 0 16 16" aria-hidden="true" style="width:13px;height:13px;color:{T.primary};">
+              <path d="M3.5 8.5 6.5 11.5 12.5 5" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" />
+            </svg>
+          {/if}
+        </button>
+      {/each}
+      <div style="font-size:10.5px;color:{T.inkFaint};padding:5px 8px 3px;line-height:1.4;">
+        Switching reloads the app.
+      </div>
+    </div>
+  </details>
+{/if}
+
+<style>
+  /* Self-contained dropdown; the menu is absolutely positioned against this anchor. */
+  .serverswitch {
+    position: relative;
+  }
+  /* Hide the native <details> disclosure triangle. */
+  .serverswitch summary {
+    list-style: none;
+  }
+  .serverswitch summary::-webkit-details-marker {
+    display: none;
+  }
+  .serverswitch-item:hover {
+    background: rgba(0, 0, 0, 0.04) !important;
+  }
+</style>

--- a/circles-app/src/routes/DefaultHeader.svelte
+++ b/circles-app/src/routes/DefaultHeader.svelte
@@ -15,6 +15,7 @@
   import { canCreateInviteLinks } from '$lib/areas/invites/data/canCreateInviteLinks';
   import GlobalAvatarSearchPopup from '$lib/shared/ui/avatar-search/GlobalAvatarSearchPopup.svelte';
   import EnvironmentInfoPopup from '$lib/shared/ui/shell/EnvironmentInfoPopup.svelte';
+  import ServerSwitcher from '$lib/shared/ui/shell/ServerSwitcher.svelte';
   import {
     basketCount,
     ensureBasketCountSubscription,
@@ -116,6 +117,9 @@
     <span class="text-[10px] px-1.5 py-0.5 rounded-full font-[580] tracking-wider lowercase"
       style="background:#EFEDE7;color:rgba(15,10,30,0.40);">beta</span>
   </a>
+
+  <!-- Backend (Production/Staging) switch — always visible so the active data source is obvious. -->
+  <ServerSwitcher direction="down" />
 
   <!-- Cart (market page or has items) -->
   {#if isMarketPage || $basketCount > 0}


### PR DESCRIPTION
## Summary

Surface the active data-source backend (Production vs Staging) as a compact, always-visible chip and let users switch it directly from the desktop sidebar footer and the mobile header — previously this was only reachable from inside the Environment popup.

## Changes

- New `ServerSwitcher.svelte` — a compact chip (active backend + caret) with a dropdown menu. Gated to Gnosis (the only network with an alternate backend). Switching persists `settings.server` and reloads, since the SDK and its realtime websocket are constructed once at wallet init. Staging is amber-accented so it is obvious when the app is pointed at the staging backend.
- Mounted in `AppSidebar` (opens upward, above the existing environment/realtime row) and `DefaultHeader` (opens downward).

## Test plan

- [x] `npm run check` — no new errors/warnings.
- [x] Full build passes.
- [ ] Desktop: sidebar footer shows the chip; dropdown switches Production/Staging and reloads.
- [ ] Mobile: header shows the chip; dropdown opens downward and switches.
- [ ] Non-Gnosis (Chiado): chip is hidden.