### PR TITLE
feat(settings): advanced/standard UI mode toggle

### DIFF
--- a/circles-app/src/lib/areas/market/ui/product/ProductViewerDetail.svelte
+++ b/circles-app/src/lib/areas/market/ui/product/ProductViewerDetail.svelte
@@ -11,6 +11,7 @@
   import { ipfsGatewayUrl } from '$lib/shared/utils/ipfs';
   import { sanitizeUrl } from '$lib/shared/ui/content/markdown/ast';
   import JumpLink from '$lib/shared/ui/content/jump/JumpLink.svelte';
+  import { settings } from '$lib/shared/state/settings.svelte';
 
   interface Meta {
     publishedAt?: number;
@@ -189,12 +190,12 @@
       <JumpLink className="link link-primary" url={productUrlSafe}>Product URL</JumpLink>
     {/if}
 
-    {#if ipfsUrlSafe}
+    {#if settings.advancedMode && ipfsUrlSafe}
       <JumpLink className="link link-primary" url={ipfsUrlSafe}>IPFS</JumpLink>
     {/if}
   </div>
 
-  {#if showMeta && meta}
+  {#if settings.advancedMode && showMeta && meta}
     <div class="text-xs opacity-60 flex items-center gap-3">
       {#if publishedDateText}
         <div>Published: {publishedDateText}</div>

--- a/circles-app/src/lib/areas/settings/ui/sections/PersonalSection.svelte
+++ b/circles-app/src/lib/areas/settings/ui/sections/PersonalSection.svelte
@@ -4,6 +4,7 @@ import ProfileExplorer from '$lib/areas/profile/ui/ProfileExplorer.svelte';
   import GroupSetting from '$lib/areas/settings/ui/editors/GroupSetting.svelte';
   import GroupProfileExtras from '$lib/areas/groups/ui/GroupProfileExtras.svelte';
   import { ipfsGatewayUrl } from '$lib/shared/utils/ipfs';
+  import { settings } from '$lib/shared/state/settings.svelte';
 
   type Props = {
     avatarAddress: Address | '';
@@ -27,27 +28,30 @@ import ProfileExplorer from '$lib/areas/profile/ui/ProfileExplorer.svelte';
   }: Props = $props();
 </script>
 
-<section class="bg-base-100 border border-base-300 rounded-xl p-4 w-full">
-  <div>
-    <h3 class="text-sm font-semibold m-0">Profile</h3>
-    <div class="text-xs text-base-content/70 flex flex-wrap items-center gap-2">
-      {#if profileCidLoading}
-        <span>loading…</span>
-      {:else if profileCid}
-        <span class="font-mono select-all break-all">{profileCid}</span>
-        <button class="btn btn-ghost btn-xs" onclick={copyProfileCid}>Copy</button>
-        <a class="link link-primary text-xs" href={ipfsGatewayUrl(profileCid)} target="_blank" rel="noopener noreferrer">
-          Open
-        </a>
-      {:else}
-        <span class="opacity-70">none yet</span>
-      {/if}
-      {#if profileCidError}
-        <span class="text-error">{profileCidError}</span>
-      {/if}
+<!-- Raw profile CID is a power-user detail; standard mode shows only the profile editor below. -->
+{#if settings.advancedMode}
+  <section class="bg-base-100 border border-base-300 rounded-xl p-4 w-full">
+    <div>
+      <h3 class="text-sm font-semibold m-0">Profile</h3>
+      <div class="text-xs text-base-content/70 flex flex-wrap items-center gap-2">
+        {#if profileCidLoading}
+          <span>loading…</span>
+        {:else if profileCid}
+          <span class="font-mono select-all break-all">{profileCid}</span>
+          <button class="btn btn-ghost btn-xs" onclick={copyProfileCid}>Copy</button>
+          <a class="link link-primary text-xs" href={ipfsGatewayUrl(profileCid)} target="_blank" rel="noopener noreferrer">
+            Open
+          </a>
+        {:else}
+          <span class="opacity-70">none yet</span>
+        {/if}
+        {#if profileCidError}
+          <span class="text-error">{profileCidError}</span>
+        {/if}
+      </div>
     </div>
-  </div>
-</section>
+  </section>
+{/if}
 
 {#if avatarAddress}
   <section class="bg-base-100 border border-base-300 rounded-xl p-4 w-full">
@@ -65,7 +69,7 @@ import ProfileExplorer from '$lib/areas/profile/ui/ProfileExplorer.svelte';
   </section>
 {/if}
 
-{#if avatarState?.isGroup}
+{#if settings.advancedMode && avatarState?.isGroup}
   <section class="bg-base-100 border border-base-300 rounded-xl p-4 w-full">
     <div>
       <h3 class="text-sm font-semibold m-0">Advanced group settings</h3>

--- a/circles-app/src/lib/shared/state/settings.svelte.ts
+++ b/circles-app/src/lib/shared/state/settings.svelte.ts
@@ -41,6 +41,12 @@ export interface NetworkSettings {
   customPathfinderUrl?: string;
   /** Use legacy EOA mode (no Safe) */
   legacy?: boolean;
+  /**
+   * Show advanced / power-user features (extra Settings tabs, raw profile CID,
+   * product IPFS/CID/SKU, …). When false (the default) the app runs in a
+   * simplified "standard" view that hides these. Toggled via the "beta" label.
+   */
+  advancedMode?: boolean;
 }
 
 /**
@@ -49,6 +55,8 @@ export interface NetworkSettings {
 const defaultSettings: NetworkSettings = {
   ring: false,
   network: 'gnosis',
+  // Default to the simplified standard view; power users opt in via the "beta" label.
+  advancedMode: false,
 };
 
 /**
@@ -97,6 +105,14 @@ export const settings = $state<NetworkSettings>(loadSettings());
 export function updateSettings(updates: Partial<NetworkSettings>): void {
   Object.assign(settings, updates);
   saveSettings(settings);
+}
+
+/**
+ * Toggle the advanced / standard UI mode. Exposed as a shared helper so the "beta"
+ * label in the desktop sidebar and the mobile header drive the exact same write path.
+ */
+export function toggleAdvancedMode(): void {
+  updateSettings({ advancedMode: !settings.advancedMode });
 }
 
 /**
@@ -151,6 +167,9 @@ export function getActiveConfig(): CirclesConfig {
  * Reset settings to defaults
  */
 export function resetSettings(): void {
-  Object.assign(settings, defaultSettings);
+  // advancedMode is a per-device UI preference, not network config — preserve it across a
+  // network-settings reset so clearing RPC overrides doesn't silently flip the UI mode.
+  const { advancedMode } = settings;
+  Object.assign(settings, defaultSettings, { advancedMode });
   saveSettings(settings);
 }

--- a/circles-app/src/lib/shared/ui/shell/AppSidebar.svelte
+++ b/circles-app/src/lib/shared/ui/shell/AppSidebar.svelte
@@ -18,7 +18,7 @@
   import { canCreateInviteLinks } from '$lib/areas/invites/data/canCreateInviteLinks';
   import { T } from '$lib/design-system/tokens.js';
   import { isWebsocketConnected } from '$lib/shared/state/realtimeSync';
-  import { settings } from '$lib/shared/state/settings.svelte';
+  import { settings, toggleAdvancedMode } from '$lib/shared/state/settings.svelte';
   import Tooltip from '$lib/shared/ui/primitives/Tooltip.svelte';
   import EnvironmentInfoPopup from '$lib/shared/ui/shell/EnvironmentInfoPopup.svelte';
   import ServerSwitcher from '$lib/shared/ui/shell/ServerSwitcher.svelte';
@@ -106,7 +106,16 @@
   <!-- Logo row -->
   <div style="padding:4px 10px 0;display:flex;align-items:center;gap:8px;">
     <img src="/logo.svg" alt="Circles" class="w-[26px] h-[26px]" />
-    <span style="font-family:{T.fontSans};font-size:11px;color:{T.inkFaint};padding:2px 7px;border-radius:9999px;background:{T.pageDeep};font-weight:580;letter-spacing:0.04em;text-transform:lowercase;">beta</span>
+    <!-- The "beta" label doubles as the Advanced-mode toggle: click to reveal power-user
+         features (extra Settings tabs, raw profile CID, product IPFS/CID, …). -->
+    <span
+      role="button"
+      tabindex="0"
+      aria-pressed={settings.advancedMode}
+      onclick={toggleAdvancedMode}
+      onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleAdvancedMode(); } }}
+      title={settings.advancedMode ? 'Advanced mode on — click to switch to standard' : 'Toggle advanced mode'}
+      style="font-family:{T.fontSans};font-size:11px;color:{settings.advancedMode ? T.primary : T.inkFaint};padding:2px 7px;border-radius:9999px;background:{settings.advancedMode ? T.primaryFaint : T.pageDeep};font-weight:580;letter-spacing:0.04em;text-transform:lowercase;cursor:pointer;">beta</span>
   </div>
 
   <!-- Account picker -->

--- a/circles-app/src/routes/DefaultHeader.svelte
+++ b/circles-app/src/routes/DefaultHeader.svelte
@@ -16,6 +16,7 @@
   import GlobalAvatarSearchPopup from '$lib/shared/ui/avatar-search/GlobalAvatarSearchPopup.svelte';
   import EnvironmentInfoPopup from '$lib/shared/ui/shell/EnvironmentInfoPopup.svelte';
   import ServerSwitcher from '$lib/shared/ui/shell/ServerSwitcher.svelte';
+  import { settings, toggleAdvancedMode } from '$lib/shared/state/settings.svelte';
   import {
     basketCount,
     ensureBasketCountSubscription,
@@ -114,8 +115,17 @@
   <a href={homeLink} class="flex items-center gap-2 flex-1 no-underline">
     <img src="/logo.svg" alt="Circles" class="w-[22px] h-[22px]" />
     <span class="font-semibold text-[15px] tracking-tight" style="color:#0F0A1E;">Circles</span>
-    <span class="text-[10px] px-1.5 py-0.5 rounded-full font-[580] tracking-wider lowercase"
-      style="background:#EFEDE7;color:rgba(15,10,30,0.40);">beta</span>
+    <!-- "beta" doubles as the Advanced-mode toggle (mirrors the desktop sidebar). It sits
+         inside the home link, so the handler stops propagation to avoid navigating home. -->
+    <span
+      role="button"
+      tabindex="0"
+      aria-pressed={settings.advancedMode}
+      onclick={(e) => { e.preventDefault(); e.stopPropagation(); toggleAdvancedMode(); }}
+      onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); e.stopPropagation(); toggleAdvancedMode(); } }}
+      title={settings.advancedMode ? 'Advanced mode on — click to switch to standard' : 'Toggle advanced mode'}
+      class="text-[10px] px-1.5 py-0.5 rounded-full font-[580] tracking-wider lowercase"
+      style="cursor:pointer;background:{settings.advancedMode ? 'rgba(88,73,212,0.12)' : '#EFEDE7'};color:{settings.advancedMode ? '#5849D4' : 'rgba(15,10,30,0.40)'};">beta</span>
   </a>
 
   <!-- Backend (Production/Staging) switch — always visible so the active data source is obvious. -->
@@ -176,8 +186,10 @@
       <li class="defaultheader-label" role="presentation">Account</li>
       <li><a class="defaultheader-link" href="/settings?tab=personal">Profile</a></li>
       <li><a class="defaultheader-link" href="/settings">Settings</a></li>
-      <li><a class="defaultheader-link" href="/settings?tab=bookmarks">Bookmarks</a></li>
-      <li><a class="defaultheader-link" href="/settings?tab=keys">Signing keys</a></li>
+      {#if settings.advancedMode}
+        <li><a class="defaultheader-link" href="/settings?tab=bookmarks">Bookmarks</a></li>
+        <li><a class="defaultheader-link" href="/settings?tab=keys">Signing keys</a></li>
+      {/if}
 
       <li class="defaultheader-sep" role="separator" aria-hidden="true"></li>
       <li class="defaultheader-label" role="presentation">Marketplace</li>
@@ -185,7 +197,9 @@
       <li><a class="defaultheader-link" href="/settings?tab=sales">Sales</a></li>
       <li><a class="defaultheader-link" href="/settings?tab=offers">Offers</a></li>
       <li><a class="defaultheader-link" href="/settings?tab=payment">Payment gateways</a></li>
-      <li><a class="defaultheader-link" href="/settings?tab=namespaces">Namespaces</a></li>
+      {#if settings.advancedMode}
+        <li><a class="defaultheader-link" href="/settings?tab=namespaces">Namespaces</a></li>
+      {/if}
 
       <li class="defaultheader-sep" role="separator" aria-hidden="true"></li>
       {#if avatarState.avatar}

--- a/circles-app/src/routes/settings/+layout.svelte
+++ b/circles-app/src/routes/settings/+layout.svelte
@@ -68,6 +68,7 @@
   import type { PaginatedReadable } from '$lib/shared/state/paginatedList';
   import CreateGatewayProfile from '$lib/areas/settings/flows/gateway/CreateGatewayProfile.svelte';
   import { coerceTabId, type TabIdOf } from '$lib/shared/ui/primitives/tabs/tabId';
+  import { settings } from '$lib/shared/state/settings.svelte';
 
   const TAB_IDS = ['personal', 'bookmarks', 'orders', 'sales', 'keys', 'namespaces', 'offers', 'payment'] as const;
   type TabId = TabIdOf<typeof TAB_IDS>;
@@ -93,6 +94,17 @@
   ];
 
   let selectedTab = $state<TabId>('personal');
+
+  // Advanced-only tabs are dropped from the strip in standard mode. The currently-selected
+  // tab is always kept visible, so deep-links (?tab=keys) still resolve, and toggling advanced
+  // mode off while viewing one doesn't yank it out from under you — it just won't reappear in
+  // the strip once you navigate to a standard tab.
+  const ADVANCED_TABS = new Set<TabId>(['bookmarks', 'namespaces', 'keys']);
+  const visibleTabs = $derived(
+    settings.advancedMode
+      ? TAB_ORDER
+      : TAB_ORDER.filter((id) => !ADVANCED_TABS.has(id) || id === selectedTab),
+  );
 
   // URL → tab: read ?tab= on load/navigation
   $effect(() => {
@@ -614,7 +626,7 @@
 
     <!-- Pill tabs -->
     <div style="display:flex;align-items:center;gap:6px;margin-bottom:18px;overflow-x:auto;padding-bottom:4px;scrollbar-width:none;">
-      {#each TAB_ORDER as id}
+      {#each visibleTabs as id}
         {@const active = selectedTab === id}
         <button
           type="button"


### PR DESCRIPTION
## Summary
Adds a global advanced/standard UI mode. The app defaults to a simplified **standard** view that hides power-user surfaces; clicking the **beta** label switches to **advanced** mode (and back). The choice persists per device.

## What changed
- `settings.svelte.ts`: new `advancedMode` flag on the settings store (default `false`); shared `toggleAdvancedMode()` helper; `resetSettings()` preserves the flag so a network-settings reset doesn't flip the UI mode.
- `AppSidebar.svelte` / `DefaultHeader.svelte`: the "beta" label becomes a keyboard-accessible toggle (`role=button`, `tabindex`, `aria-pressed`). The mobile variant `stopPropagation`s so it doesn't trigger the wrapping home link.
- `settings/+layout.svelte`: advanced-only tabs (Bookmarks, Applications, Signing keys) drop out of the tab strip in standard mode. Deep-links still resolve, and the currently-selected tab is always kept visible.
- `PersonalSection.svelte`: raw Profile CID + advanced group settings hidden in standard mode.
- `ProductViewerDetail.svelte`: product IPFS link + technical metadata hidden in standard mode.
- `DefaultHeader.svelte`: mobile-menu links to the hidden tabs are gated.

## Test plan
- [ ] Standard mode (default): Settings shows only Profile/Orders/Sales/Offers/Payment; Bookmarks/Applications/Signing keys hidden; Profile CID + product IPFS/meta hidden.
- [ ] Click "beta" (desktop sidebar): advanced on — hidden tabs/sections appear, label highlights; click again returns to standard.
- [ ] Click "beta" (mobile header): toggles without navigating home.
- [ ] Toggle persists across reload.
- [ ] Deep-link `/settings?tab=keys` in standard mode still resolves (tab visible + content shown).
- [ ] `npm run check` clean; unit suite passes.