### PR TITLE
fix(ui): tone DaisyUI select radius + match invites page width

### DIFF
--- a/circles-app/src/app.css
+++ b/circles-app/src/app.css
@@ -160,6 +160,10 @@ input:not([type="checkbox"]):not([type="radio"]):not([type="range"]), textarea, 
    which turns multi-line inputs into capsules. Element-qualified selector
    (specificity 0,1,1) pins textareas to a sane radius regardless of source order. */
 textarea.textarea { border-radius: 12px; }
+/* Same issue for DaisyUI's .select: it inherits --rounded-btn (9999px) and renders
+   dropdowns as full pills. The global `select` rule above (0,0,1) loses to `.select`
+   (0,1,0); the element-qualified selector (0,1,1) wins and restores a sane radius. */
+select.select { border-radius: 12px; }
 
 /* Row tokens */
 :root {

--- a/circles-app/src/lib/areas/invites/ui/pages/InviteLinks.svelte
+++ b/circles-app/src/lib/areas/invites/ui/pages/InviteLinks.svelte
@@ -124,7 +124,7 @@
 </script>
 
 <div style="background:{T.page};min-height:100%;width:100%;font-family:{T.fontSans};color:{T.inkBody};">
-  <div style="padding:8px 18px 24px;" class="md:!p-9 md:max-w-[860px] md:mx-auto">
+  <div style="padding:8px 18px 24px;" class="md:!p-9 md:max-w-[1280px] md:mx-auto">
 
     <!-- Page title + primary action -->
     <div style="display:flex;align-items:center;justify-content:space-between;padding:8px 0 14px;gap:12px;">


### PR DESCRIPTION
## Summary
Two small cosmetic fixes.

1. **Select dropdown radius.** DaisyUI's `.select` inherits the theme's `--rounded-btn` (9999px, intended for pill buttons), so every `<select class="select ...">` renders as a full capsule. Added `select.select { border-radius: 12px; }` — an element-qualified rule (specificity 0,1,1) that beats `.select` (0,1,0), exactly mirroring the existing `textarea.textarea` rule directly above it. Single-line `.input` controls are unaffected (the global `input:not(...)` rule already pins them to 8px).
2. **Invites page width.** `InviteLinks` container was `md:max-w-[860px]`; the dashboard/groups/contacts/settings pages all use `md:max-w-[1280px]`. Aligned it so the invites page matches.

## Test plan
- [ ] Open a page with a `<select>` (e.g. Settings → Payment, group backing asset, market offer pricing): dropdown has a ~12px radius, not a full pill.
- [ ] Multi-line textarea (Add trust → bulk paste) still ~12px (unchanged).
- [ ] Single-line inputs unchanged (~8px).
- [ ] `/invites` on desktop uses the same content width as `/dashboard` and `/groups`.
- [ ] `npm run check` clean; unit suite passes.