### PR TITLE
fix(wallet): hide generic injected connector when EIP-6963 wallets are present

### DIFF
--- a/circles-app/src/lib/areas/wallet/ui/onboarding/SelectWallet.svelte
+++ b/circles-app/src/lib/areas/wallet/ui/onboarding/SelectWallet.svelte
@@ -12,7 +12,24 @@
   import { T } from '$lib/design-system/tokens.js';
   import Icon from '$lib/design-system/Icon.svelte';
 
-  const connectors = getConnectors(config);
+  // Hide the generic `injected()` connector ("Injected") from the picker whenever a
+  // real wallet is surfaced by EIP-6963 discovery. The generic connector targets the
+  // legacy global `window.ethereum`, which is contested when several wallets are
+  // installed — in Brave it resolves to the built-in Brave Wallet rather than, say, an
+  // unlocked Rabby, so `connect()` fires `eth_requestAccounts` at the wrong (locked)
+  // provider, no approval popup appears, and the picker spinner hangs forever. The
+  // named EIP-6963 connectors (id = the provider's rdns, e.g. `io.rabby`) talk to their
+  // provider directly and don't have this problem. The generic connector is KEPT in the
+  // wagmi config (restoreSession() falls back to `id === 'injected'` — see
+  // wallet.svelte.ts) and is only dropped from this list; if nothing is discovered (a
+  // lone legacy wallet with no EIP-6963 support) it stays visible as the only way in.
+  const allConnectors = getConnectors(config);
+  const hasDiscoveredWallet = allConnectors.some(
+    (c) => c.type === 'injected' && c.id !== 'injected',
+  );
+  const connectors = hasDiscoveredWallet
+    ? allConnectors.filter((c) => c.id !== 'injected')
+    : allConnectors;
   let connectingId: string | null = $state(null);
   let connectError: string | null = $state(null);
 


### PR DESCRIPTION
## Summary

The wallet picker (`SelectWallet.svelte`) rendered every wagmi connector, including the generic `injected()` fallback shown as **"Injected"**. That connector targets the legacy global `window.ethereum`, which is contested when multiple wallets are installed. In Brave, `window.ethereum` defaults to the built-in Brave Wallet rather than another unlocked extension, so `connect()` dispatches `eth_requestAccounts` at the wrong (locked) provider — no approval prompt appears and the picker spinner hangs indefinitely.

## What changed

- Filter the generic connector (`id === 'injected'`) out of the **displayed** list whenever at least one EIP-6963-discovered wallet is present. Discovered wallets are created by wagmi as `injected({ target: { id: info.rdns } })`, so they have `type === 'injected'` and `id === <rdns>` (e.g. `io.rabby`, `com.brave.wallet`); the predicate `type === 'injected' && id !== 'injected'` identifies them.
- The generic connector is **kept in the wagmi config** — `restoreSession()` still falls back to `id === 'injected'` (`wallet.svelte.ts`), so only the picker UI changes.
- Fails safe: with no EIP-6963 wallet discovered (a lone legacy injected wallet), the generic "Injected" entry stays visible as the only connect option.

## Test plan

- [x] `npm run check` — 0 errors
- [x] Live picker connector ids confirmed: `injected` (generic) + `io.rabby` + `com.brave.wallet` (discovered) → filter removes only the generic entry
- [ ] After deploy: with a named wallet extension installed, the picker shows the named wallet(s) + Circles.garden, no generic "Injected" row; connecting via the named wallet succeeds
- [ ] Restore still works (reload a connected session)