### PR TITLE
feat(groups): operator view of a group's affiliate join requests (advanced mode)

### DIFF
--- a/circles-app/src/lib/__tests__/groupAffiliateMembers.test.ts
+++ b/circles-app/src/lib/__tests__/groupAffiliateMembers.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest';
+import type { Sdk } from '@aboutcircles/sdk';
+import type { Address } from '@aboutcircles/sdk-types';
+import { loadGroupAffiliateMembers } from '$lib/areas/groups/utils/getGroupAffiliateMembers';
+import { RPC_METHOD_NOT_FOUND } from '$lib/shared/data/circles/affiliateGroupQueries';
+
+const GROUP = '0xAaAa000000000000000000000000000000000010' as Address;
+const M1 = '0x1111111111111111111111111111111111111111';
+const M2 = '0x2222222222222222222222222222222222222222';
+const M3 = '0x3333333333333333333333333333333333333333';
+const M_UPPER = '0xABCDEF0000000000000000000000000000000002';
+const M_LOWER = '0xabcdef0000000000000000000000000000000002';
+
+const WISHLIST = 'circles_getAffiliateGroupMembersWishlist';
+const MEMBERS = 'circles_getAffiliateGroupMembers';
+
+/** A single member row in the indexer's wire shape. */
+function row(avatarAddress: string, timestamp: number, avatarName: string | null = null) {
+  return { avatarName, avatarAddress, timestamp };
+}
+
+/** A one-page (no-cursor) response wrapping `rows`. */
+function page(rows: ReturnType<typeof row>[]) {
+  return { results: rows, hasMore: false, nextCursor: null };
+}
+
+/**
+ * Stub SDK whose `rpc.client.call` dispatches by method name to the provided
+ * response (a value, or a function of params for cursor-aware paging), recording
+ * every call.
+ */
+function mockSdk(
+  responses: Record<string, unknown | ((params: unknown[]) => unknown)>
+): { sdk: Sdk; calls: Array<{ method: string; params: unknown[] }> } {
+  const calls: Array<{ method: string; params: unknown[] }> = [];
+  const sdk = {
+    rpc: {
+      client: {
+        call: async (method: string, params: unknown[]) => {
+          calls.push({ method, params });
+          const r = responses[method];
+          if (typeof r === 'function') return (r as (p: unknown[]) => unknown)(params);
+          if (r === undefined) throw new Error(`unexpected method ${method}`);
+          return r;
+        },
+      },
+    },
+  } as unknown as Sdk;
+  return { sdk, calls };
+}
+
+describe('loadGroupAffiliateMembers', () => {
+  it('lowercases the group address in both RPC calls', async () => {
+    const { sdk, calls } = mockSdk({ [WISHLIST]: page([]), [MEMBERS]: page([]) });
+    await loadGroupAffiliateMembers(sdk, GROUP);
+    expect(calls.map((c) => c.method).sort()).toEqual([MEMBERS, WISHLIST].sort());
+    for (const c of calls) {
+      expect(c.params[0]).toBe(GROUP.toLowerCase());
+    }
+  });
+
+  it('flags confirmed members and sorts pending-first, newest-first within each', async () => {
+    const { sdk } = mockSdk({
+      [WISHLIST]: page([row(M1, 1), row(M2, 2), row(M3, 3)]),
+      [MEMBERS]: page([row(M2, 2)]),
+    });
+    const res = await loadGroupAffiliateMembers(sdk, GROUP);
+    expect(res.unavailable).toBe(false);
+    expect(res.confirmedCount).toBe(1);
+    expect(res.pendingCount).toBe(2);
+    // pending (M3 then M1, newest first) before confirmed (M2)
+    expect(res.members.map((m) => [m.avatarAddress, m.confirmed])).toEqual([
+      [M3, false],
+      [M1, false],
+      [M2, true],
+    ]);
+  });
+
+  it('matches confirmed status case-insensitively and lowercases addresses', async () => {
+    const { sdk } = mockSdk({
+      [WISHLIST]: page([row(M_UPPER, 5)]),
+      [MEMBERS]: page([row(M_LOWER, 5)]),
+    });
+    const res = await loadGroupAffiliateMembers(sdk, GROUP);
+    expect(res.members[0].avatarAddress).toBe(M_LOWER);
+    expect(res.members[0].confirmed).toBe(true);
+  });
+
+  it('drains cursor-paginated wishlist pages', async () => {
+    const { sdk, calls } = mockSdk({
+      [WISHLIST]: (params: unknown[]) => {
+        const cursor = params[2];
+        if (cursor == null) return { results: [row(M1, 1)], hasMore: true, nextCursor: 'c1' };
+        if (cursor === 'c1') return { results: [row(M2, 2)], hasMore: false, nextCursor: null };
+        return page([]);
+      },
+      [MEMBERS]: page([]),
+    });
+    const res = await loadGroupAffiliateMembers(sdk, GROUP);
+    expect(res.members.map((m) => m.avatarAddress).sort()).toEqual([M1, M2].sort());
+    const wishlistCursors = calls.filter((c) => c.method === WISHLIST).map((c) => c.params[2]);
+    expect(wishlistCursors).toEqual([null, 'c1']);
+  });
+
+  it('caps the drain at MAX_PAGES (20) and flags truncated when the cursor never terminates', async () => {
+    let n = 0;
+    const { sdk } = mockSdk({
+      // Always claims another page — the loader must stop itself at the cap.
+      [WISHLIST]: () => {
+        n += 1;
+        const addr = `0x${n.toString(16).padStart(40, '0')}`;
+        return { results: [row(addr, n)], hasMore: true, nextCursor: `c${n}` };
+      },
+      [MEMBERS]: page([]),
+    });
+    const res = await loadGroupAffiliateMembers(sdk, GROUP);
+    expect(res.truncated).toBe(true);
+    expect(res.members.length).toBe(20);
+  });
+
+  it('returns unavailable=true when the RPC method is not found (-32601)', async () => {
+    const err = Object.assign(new Error('Method not found'), { code: RPC_METHOD_NOT_FOUND });
+    const { sdk } = mockSdk({
+      [WISHLIST]: () => {
+        throw err;
+      },
+      [MEMBERS]: page([]),
+    });
+    const res = await loadGroupAffiliateMembers(sdk, GROUP);
+    expect(res.unavailable).toBe(true);
+    expect(res.members).toEqual([]);
+  });
+
+  it('propagates errors that are not method-not-found', async () => {
+    const { sdk } = mockSdk({
+      [WISHLIST]: () => {
+        throw new Error('boom');
+      },
+      [MEMBERS]: page([]),
+    });
+    await expect(loadGroupAffiliateMembers(sdk, GROUP)).rejects.toThrow('boom');
+  });
+});

--- a/circles-app/src/lib/areas/groups/ui/components/GroupCommunityMembers.svelte
+++ b/circles-app/src/lib/areas/groups/ui/components/GroupCommunityMembers.svelte
@@ -1,0 +1,146 @@
+<script lang="ts">
+    import type { Address } from '@aboutcircles/sdk-types';
+    import { circles } from '$lib/shared/state/circles';
+    import { T } from '$lib/design-system/tokens.js';
+    import Avatar from '$lib/shared/ui/avatar/Avatar.svelte';
+    import { openProfilePopup } from '$lib/shared/ui/profile/openProfilePopup';
+    import { getTimeAgo } from '$lib/shared/utils/shared';
+    import {
+        loadGroupAffiliateMembers,
+        type GroupAffiliateMember,
+    } from '$lib/areas/groups/utils/getGroupAffiliateMembers';
+
+    interface Props {
+        group: Address;
+    }
+    let { group }: Props = $props();
+
+    let members: GroupAffiliateMember[] = $state([]);
+    let confirmedCount: number = $state(0);
+    let pendingCount: number = $state(0);
+    let truncated: boolean = $state(false);
+    let unavailable: boolean = $state(false);
+    let loading: boolean = $state(false);
+    let error: string | null = $state(null);
+
+    // Generation counter: drop a stale response if the group/SDK changed before it resolved.
+    let loadGeneration = 0;
+
+    async function load(): Promise<void> {
+        const sdk = $circles;
+        if (!sdk || !group) {
+            members = []; confirmedCount = 0; pendingCount = 0;
+            truncated = false; unavailable = false; error = null;
+            return;
+        }
+        const generation = ++loadGeneration;
+        loading = true;
+        error = null;
+        try {
+            const res = await loadGroupAffiliateMembers(sdk, group);
+            if (generation !== loadGeneration) return;
+            members = res.members;
+            confirmedCount = res.confirmedCount;
+            pendingCount = res.pendingCount;
+            truncated = res.truncated;
+            unavailable = res.unavailable;
+        } catch (e) {
+            if (generation !== loadGeneration) return;
+            error = e instanceof Error ? e.message : String(e);
+            members = [];
+        } finally {
+            if (generation === loadGeneration) loading = false;
+        }
+    }
+
+    $effect(() => {
+        // Re-run whenever the group or the SDK instance changes.
+        void group;
+        void $circles;
+        void load();
+    });
+</script>
+
+<!-- Hidden entirely when the server lacks the affiliate methods (e.g. production),
+     so the members page stays clean unless the feature is actually available. -->
+{#if !unavailable}
+    <section style="background:#FFFFFF;border:1px solid rgba(31,17,70,0.05);border-radius:12px;padding:16px;width:100%;">
+        <!-- Header -->
+        <div style="display:flex;align-items:flex-start;justify-content:space-between;gap:12px;margin-bottom:12px;">
+            <div style="display:flex;flex-direction:column;gap:3px;">
+                <span style="font-size:14px;font-weight:600;color:{T.ink};">Community join requests</span>
+                <span style="font-size:12px;color:{T.inkMuted};line-height:1.4;">
+                    Avatars that signalled intent to join this group as a community. Confirmed once the group trusts them back.
+                </span>
+            </div>
+            {#if !loading && !error && members.length > 0}
+                <span style="flex:0 0 auto;font-size:11.5px;font-weight:560;color:{T.inkMuted};font-variant-numeric:tabular-nums;white-space:nowrap;">
+                    {confirmedCount} confirmed · {pendingCount} pending
+                </span>
+            {/if}
+        </div>
+
+        {#if loading}
+            <div style="display:flex;flex-direction:column;gap:8px;">
+                {#each Array(3) as _, i (i)}
+                    <div style="height:48px;border-radius:10px;background:{T.pageDeep};" class="animate-pulse"></div>
+                {/each}
+            </div>
+        {:else if error}
+            <div style="display:flex;flex-direction:column;gap:10px;align-items:flex-start;">
+                <span style="font-size:12.5px;color:{T.inkMuted};">Couldn't load community join requests. {error}</span>
+                <button
+                    type="button"
+                    onclick={load}
+                    style="height:30px;padding:0 12px;border-radius:9999px;border:1px solid {T.hairline};background:{T.surface};color:{T.ink};font-size:12px;font-weight:540;cursor:pointer;"
+                >Retry</button>
+            </div>
+        {:else if members.length === 0}
+            <div style="font-size:13px;color:{T.inkMuted};padding:6px 0;">
+                No one has signalled to join this community yet.
+            </div>
+        {:else}
+            <div style="display:flex;flex-direction:column;gap:2px;">
+                {#each members as m (m.avatarAddress)}
+                    <div
+                        role="button"
+                        tabindex={0}
+                        onclick={() => openProfilePopup(m.avatarAddress)}
+                        onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openProfilePopup(m.avatarAddress); } }}
+                        style="
+                            display:flex;align-items:center;gap:10px;padding:8px 6px;border-radius:10px;cursor:pointer;
+                            transition:background .14s ease-out;
+                        "
+                        class="member-row"
+                    >
+                        <div style="flex:1;min-width:0;">
+                            <Avatar
+                                address={m.avatarAddress}
+                                view="small"
+                                clickable={false}
+                                showTypeInfo={false}
+                                bottomInfo={getTimeAgo(m.timestamp)}
+                            />
+                        </div>
+                        {#if m.confirmed}
+                            <span style="flex:0 0 auto;display:inline-flex;align-items:center;padding:3px 9px;border-radius:9999px;background:{T.sageSoft};color:#1F5E37;font-size:10.5px;font-weight:580;letter-spacing:0.02em;">Confirmed</span>
+                        {:else}
+                            <span style="flex:0 0 auto;display:inline-flex;align-items:center;padding:3px 9px;border-radius:9999px;background:{T.butterSoft};color:#7A5B12;font-size:10.5px;font-weight:580;letter-spacing:0.02em;">Pending</span>
+                        {/if}
+                    </div>
+                {/each}
+            </div>
+            {#if truncated}
+                <div style="font-size:11.5px;color:{T.inkMuted};margin-top:10px;">
+                    Showing the first {members.length} requests.
+                </div>
+            {/if}
+        {/if}
+    </section>
+{/if}
+
+<style>
+    .member-row:hover {
+        background: rgba(31, 17, 70, 0.03);
+    }
+</style>

--- a/circles-app/src/lib/areas/groups/utils/getGroupAffiliateMembers.ts
+++ b/circles-app/src/lib/areas/groups/utils/getGroupAffiliateMembers.ts
@@ -1,0 +1,110 @@
+import type { Sdk } from '@aboutcircles/sdk';
+import type { Address } from '@aboutcircles/sdk-types';
+import {
+  getAffiliateGroupMembersWishlist,
+  getAffiliateGroupMembers,
+  isMethodNotFound,
+  type AffiliateGroupMemberRow,
+} from '$lib/shared/data/circles/affiliateGroupQueries';
+
+/** A wishlist member, annotated with whether the group has trusted them back. */
+export interface GroupAffiliateMember extends AffiliateGroupMemberRow {
+  /** true once the group also trusts the avatar on-chain (the bilateral handshake). */
+  confirmed: boolean;
+}
+
+export interface GroupAffiliateMembers {
+  /** Wishlist members (intent), pending first then confirmed, newest first within each. */
+  members: GroupAffiliateMember[];
+  confirmedCount: number;
+  pendingCount: number;
+  /**
+   * true when the safety page cap was hit, so the lists may be incomplete (and a
+   * confirmed member beyond the cap could surface as "pending"). Beta wishlists are
+   * far below the cap; the UI surfaces this as a "showing first N" note when set.
+   */
+  truncated: boolean;
+  /**
+   * true when the connected RPC doesn't expose the affiliate methods (e.g. the
+   * production server before promotion). The UI hides the section rather than error.
+   */
+  unavailable: boolean;
+}
+
+const PAGE_SIZE = 100;
+/** Hard cap (PAGE_SIZE × MAX_PAGES = 2000 rows) so a runaway cursor can't loop forever. */
+const MAX_PAGES = 20;
+
+const EMPTY: GroupAffiliateMembers = {
+  members: [],
+  confirmedCount: 0,
+  pendingCount: 0,
+  truncated: false,
+  unavailable: false,
+};
+
+/** Drain a cursor-paginated reader up to the safety cap, flagging if it was hit. */
+async function loadAllPages(
+  fetchPage: (cursor: string | null) => Promise<{
+    results: AffiliateGroupMemberRow[];
+    hasMore: boolean;
+    nextCursor: string | null;
+  }>
+): Promise<{ rows: AffiliateGroupMemberRow[]; truncated: boolean }> {
+  const rows: AffiliateGroupMemberRow[] = [];
+  let cursor: string | null = null;
+  for (let i = 0; i < MAX_PAGES; i++) {
+    const page = await fetchPage(cursor);
+    rows.push(...page.results);
+    if (!page.hasMore || !page.nextCursor) return { rows, truncated: false };
+    cursor = page.nextCursor;
+  }
+  return { rows, truncated: true };
+}
+
+/**
+ * Load a group's affiliate wishlist — the avatars that signalled intent to join it
+ * as a community — each flagged confirmed (the group also trusts them) or pending.
+ *
+ * Wishlist = inbound intent. The confirmed set is a subset (the group trusts the
+ * avatar back) and lags the wishlist by the trust-manager delay, so a member stays
+ * "Pending" until that trust lands. Pending rows are exactly the avatars a group
+ * operator (or its TMS) would trust to confirm.
+ */
+export async function loadGroupAffiliateMembers(
+  sdk: Sdk,
+  group: Address
+): Promise<GroupAffiliateMembers> {
+  try {
+    const [wishlist, confirmed] = await Promise.all([
+      loadAllPages((cursor) => getAffiliateGroupMembersWishlist(sdk.rpc, group, PAGE_SIZE, cursor)),
+      loadAllPages((cursor) => getAffiliateGroupMembers(sdk.rpc, group, PAGE_SIZE, cursor)),
+    ]);
+
+    const confirmedSet = new Set(confirmed.rows.map((m) => m.avatarAddress));
+    const members: GroupAffiliateMember[] = wishlist.rows.map((m) => ({
+      ...m,
+      confirmed: confirmedSet.has(m.avatarAddress),
+    }));
+
+    // Pending first (the operator's action queue), then confirmed; newest first within each.
+    members.sort(
+      (a, b) => Number(a.confirmed) - Number(b.confirmed) || b.timestamp - a.timestamp
+    );
+
+    return {
+      members,
+      confirmedCount: members.filter((m) => m.confirmed).length,
+      pendingCount: members.filter((m) => !m.confirmed).length,
+      truncated: wishlist.truncated || confirmed.truncated,
+      unavailable: false,
+    };
+  } catch (err) {
+    // The methods are deployed together; if the server lacks them, surface a
+    // "not available here" state rather than propagating the error.
+    if (isMethodNotFound(err)) {
+      return { ...EMPTY, unavailable: true };
+    }
+    throw err;
+  }
+}

--- a/circles-app/src/lib/shared/data/circles/affiliateGroupQueries.ts
+++ b/circles-app/src/lib/shared/data/circles/affiliateGroupQueries.ts
@@ -21,6 +21,27 @@ export interface AffiliateGroupListResponse {
   groups: AffiliateGroupRow[];
 }
 
+/**
+ * One member avatar in a group's affiliate wishlist (signalled intent to join) or
+ * confirmed-members list, as returned by the `circles_getAffiliateGroupMembers*`
+ * RPC methods. The group-centric counterpart to {@link AffiliateGroupRow}.
+ */
+export interface AffiliateGroupMemberRow {
+  /** Member avatar's profile name, or `null` when it has no profile/name. */
+  avatarName: string | null;
+  /** The member avatar's address (lowercased by {@link normalizeMembersResponse}). */
+  avatarAddress: Address;
+  /** Unix seconds of the winning `AffiliateGroupAdded` event. */
+  timestamp: number;
+}
+
+/** A page of {@link AffiliateGroupMemberRow}s plus the indexer's pagination cursor. */
+export interface PagedAffiliateMembers {
+  results: AffiliateGroupMemberRow[];
+  hasMore: boolean;
+  nextCursor: string | null;
+}
+
 /** JSON-RPC "method not found" error code (JSON-RPC 2.0 spec). */
 export const RPC_METHOD_NOT_FOUND = -32601;
 
@@ -96,4 +117,55 @@ export async function getAffiliateGroupFeesPercentage(
     [avatar.toLowerCase()]
   );
   return Number(res?.totalFeePercentage ?? 0);
+}
+
+/** Lowercase every member row's address so confirmed/pending set comparisons are case-stable. */
+function normalizeMembersResponse(
+  res: Partial<PagedAffiliateMembers> | null
+): PagedAffiliateMembers {
+  return {
+    results: (res?.results ?? []).map((m) => ({
+      avatarName: m.avatarName ?? null,
+      avatarAddress: String(m.avatarAddress).toLowerCase() as Address,
+      timestamp: Number(m.timestamp ?? 0),
+    })),
+    hasMore: Boolean(res?.hasMore),
+    nextCursor: res?.nextCursor ?? null,
+  };
+}
+
+/**
+ * One page of a group's affiliate **wishlist** — avatars that signalled on-chain
+ * intent to join `group` as a community. A superset of the confirmed members:
+ * an entry stays "pending" until the group also trusts the avatar back.
+ */
+export async function getAffiliateGroupMembersWishlist(
+  circlesRpc: CirclesRpc,
+  group: Address,
+  limit = 100,
+  cursor: string | null = null
+): Promise<PagedAffiliateMembers> {
+  const res: Partial<PagedAffiliateMembers> | null = await circlesRpc.client.call(
+    'circles_getAffiliateGroupMembersWishlist',
+    [group.toLowerCase(), limit, cursor]
+  );
+  return normalizeMembersResponse(res);
+}
+
+/**
+ * One page of a group's **confirmed** affiliate members — the wishlist subset the
+ * group currently trusts back (the bilateral handshake). Lags the wishlist by the
+ * trust-manager delay.
+ */
+export async function getAffiliateGroupMembers(
+  circlesRpc: CirclesRpc,
+  group: Address,
+  limit = 100,
+  cursor: string | null = null
+): Promise<PagedAffiliateMembers> {
+  const res: Partial<PagedAffiliateMembers> | null = await circlesRpc.client.call(
+    'circles_getAffiliateGroupMembers',
+    [group.toLowerCase(), limit, cursor]
+  );
+  return normalizeMembersResponse(res);
 }

--- a/circles-app/src/routes/groups/+page.svelte
+++ b/circles-app/src/routes/groups/+page.svelte
@@ -13,6 +13,7 @@
     import CommunityCard from './CommunityCard.svelte';
     import { resetCreateGroupContext } from '$lib/areas/groups/flows/createGroup/context';
     import { circles } from '$lib/shared/state/circles';
+    import { settings } from '$lib/shared/state/settings.svelte';
     import { CirclesStorage } from '$lib/shared/utils/storage';
     import { getBaseAndCmgGroupsByOwnerBatch } from '$lib/shared/utils/getGroupsByOwnerBatch';
     import { getGroupsByMember, streamGroupsByMember } from '$lib/areas/groups/utils/getGroupsByMemberBatch';
@@ -67,7 +68,9 @@
         (CirclesStorage.getInstance().avatar as string | undefined) ?? avatarState.avatar?.address
     );
     const canShowMembershipsTab: boolean = $derived(!!ownerAddress);
-    const canShowCommunitiesTab: boolean = $derived(!!ownerAddress);
+    // Communities is a beta surface (multi-affiliate registry, staging-only RPC) —
+    // hidden unless the user has opted into advanced mode.
+    const canShowCommunitiesTab: boolean = $derived(!!ownerAddress && !!settings.advancedMode);
     const canCreateGroup: boolean = $derived(!!$circles && !!CirclesStorage.getInstance().avatar);
 
     async function loadGroups(): Promise<void> {

--- a/circles-app/src/routes/groups/members/[group]/+page.svelte
+++ b/circles-app/src/routes/groups/members/[group]/+page.svelte
@@ -9,7 +9,9 @@
   import type { Action } from '$lib/shared/ui/shell/actions';
   import { getProfileDisplayName } from '$lib/areas/groups/ui/utils/profileDisplayName';
   import GroupMembersManager from '$lib/areas/groups/ui/components/GroupMembersManager.svelte';
+  import GroupCommunityMembers from '$lib/areas/groups/ui/components/GroupCommunityMembers.svelte';
   import AddressView from '$lib/shared/ui/primitives/Address.svelte';
+  import { settings } from '$lib/shared/state/settings.svelte';
 
   const group = $derived(($page.params.group ?? '').toLowerCase() as Address | '');
   const shortAddr = (a?: string) => (a ? `${a.slice(0, 6)}…${a.slice(-4)}` : '');
@@ -112,6 +114,10 @@
     <section style="background:#FFFFFF;border:1px solid rgba(31,17,70,0.05);border-radius:12px;padding:16px;width:100%;">
       <GroupMembersManager group={group} />
     </section>
+    {#if settings.advancedMode}
+      <div style="height:14px;"></div>
+      <GroupCommunityMembers {group} />
+    {/if}
   {:else}
     <section style="background:#FFFFFF;border:1px solid rgba(31,17,70,0.05);border-radius:12px;padding:16px;width:100%;">
       <div style="font-size:14px;opacity:0.7;">Invalid group route.</div>


### PR DESCRIPTION
Supersedes #267, which GitHub auto-closed when its stacked base branch was deleted on the #262 squash-merge. Same commit, now rebased directly onto `dev`.

## Summary
Adds a read-only **Community join requests** section to the group members page (`/groups/members/[group]`) listing the avatars that have signalled on-chain intent to join the group as a community via the multi-affiliate registry — the group-centric counterpart to the avatar-centric Communities tab (#262). Each entry is flagged **Confirmed** (the group trusts the avatar back — the bilateral handshake) or **Pending**.

Both the operator section and the Communities tab are gated behind advanced mode (`settings.advancedMode`, default off), since the multi-affiliate registry is a beta surface served only by the staging indexer.

## What changed
- `shared/data/circles/affiliateGroupQueries.ts`: add paginated `getAffiliateGroupMembersWishlist` / `getAffiliateGroupMembers` readers (group-centric counterpart to the avatar-centric reads), normalising row addresses to lowercase.
- `areas/groups/utils/getGroupAffiliateMembers.ts`: drain both cursor-paginated lists (capped at 2000 rows), merge, label each wishlist member confirmed/pending, sort pending-first then newest-first.
- `areas/groups/ui/components/GroupCommunityMembers.svelte`: section UI with loading/error/empty states and a generation-counter stale-load guard. Hides itself when the RPC lacks the methods (JSON-RPC `-32601`, e.g. the production server).
- mount on `/groups/members/[group]` behind `settings.advancedMode` (so the RPC isn't fired when advanced mode is off).
- gate the Communities tab (groups overview) behind `settings.advancedMode`.
- unit tests: address lowercasing, confirmed-flag + sort, case-insensitive match, cursor pagination drain, page-cap truncation, `-32601` unavailable, error propagation.

## Notes
- Reads use raw `circlesRpc.client.call` to match #262 (no dependency on the typed SDK affiliate wrapper). When that SDK surface publishes, both #262 and this PR can adopt it together.
- The methods are staging-indexer-only today; on a production RPC the section self-hides via `-32601`.

## Test plan
- [x] `npm run check` — no new errors
- [x] `npm run test:run` — affiliate suites pass
- [x] Advanced mode ON + Staging server: open a group you operate → members page shows "Community join requests" with Confirmed/Pending badges
- [x] Advanced mode OFF: the section and the Communities tab are hidden
- [x] Production server: the section self-hides (no error)